### PR TITLE
Phase 6: BYOK + admin role + vendor-agnostic provider registry

### DIFF
--- a/.github/workflows/ai.yml
+++ b/.github/workflows/ai.yml
@@ -4,13 +4,13 @@ on:
   push:
     branches: [main, develop]
     paths:
-      - 'services/ai/**'
-      - 'shared/**'
+      - "services/ai/**"
+      - "shared/**"
   pull_request:
     branches: [main, develop]
     paths:
-      - 'services/ai/**'
-      - 'shared/**'
+      - "services/ai/**"
+      - "shared/**"
 
 jobs:
   ai-test:
@@ -21,6 +21,14 @@ jobs:
       PYTHONPATH: ${{ github.workspace }}/services/ai:${{ github.workspace }}
     steps:
       - uses: actions/checkout@v4
+
+      - name: Lint
+        working-directory: ./services/ai
+        run: |
+          pip install black mypy flake8
+          black --check ./app
+          mypy ./app
+          flake8 ./app
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -35,11 +43,3 @@ jobs:
       - name: Run tests
         working-directory: ./services/ai
         run: python -m pytest tests/ -v
-
-      - name: Lint
-        working-directory: ./services/ai
-        run: |
-          pip install black mypy flake8
-          black --check ./app
-          mypy ./app
-          flake8 ./app

--- a/.github/workflows/ai.yml
+++ b/.github/workflows/ai.yml
@@ -22,14 +22,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Lint
-        working-directory: ./services/ai
-        run: |
-          pip install black mypy flake8
-          black --check ./app
-          mypy ./app
-          flake8 ./app
-
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -39,6 +31,14 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r services/ai/requirements.txt
+
+      - name: Lint
+        working-directory: ./services/ai
+        run: |
+          pip install black mypy flake8
+          black --check ./app
+          mypy ./app
+          flake8 ./app
 
       - name: Run tests
         working-directory: ./services/ai

--- a/.github/workflows/budget.yml
+++ b/.github/workflows/budget.yml
@@ -29,14 +29,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Lint
-        working-directory: ./services/budget
-        run: |
-          pip install black mypy flake8
-          black --check ./app
-          mypy ./app
-          flake8 ./app
-
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -46,6 +38,14 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r services/budget/requirements.txt
+
+      - name: Lint
+        working-directory: ./services/budget
+        run: |
+          pip install black mypy flake8
+          black --check ./app
+          mypy ./app
+          flake8 ./app
 
       - name: Run tests
         working-directory: ./services/budget

--- a/.github/workflows/budget.yml
+++ b/.github/workflows/budget.yml
@@ -4,13 +4,13 @@ on:
   push:
     branches: [main, develop]
     paths:
-      - 'services/budget/**'
-      - 'shared/**'
+      - "services/budget/**"
+      - "shared/**"
   pull_request:
     branches: [main, develop]
     paths:
-      - 'services/budget/**'
-      - 'shared/**'
+      - "services/budget/**"
+      - "shared/**"
 
 jobs:
   budget-test:
@@ -29,6 +29,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Lint
+        working-directory: ./services/budget
+        run: |
+          pip install black mypy flake8
+          black --check ./app
+          mypy ./app
+          flake8 ./app
+
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -42,11 +50,3 @@ jobs:
       - name: Run tests
         working-directory: ./services/budget
         run: python -m pytest tests/test_budget_with_lines.py -v
-
-      - name: Lint
-        working-directory: ./services/budget
-        run: |
-          pip install black mypy flake8
-          black --check ./app
-          mypy ./app
-          flake8 ./app

--- a/.github/workflows/users.yml
+++ b/.github/workflows/users.yml
@@ -22,14 +22,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Lint
-        working-directory: ./services/users
-        run: |
-          pip install black mypy flake8
-          black --check ./app
-          mypy ./app
-          flake8 ./app
-
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -39,6 +31,14 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r services/users/requirements.txt
+
+      - name: Lint
+        working-directory: ./services/users
+        run: |
+          pip install black mypy flake8
+          black --check ./app
+          mypy ./app
+          flake8 ./app
 
       - name: Run tests
         working-directory: ./services/users

--- a/.github/workflows/users.yml
+++ b/.github/workflows/users.yml
@@ -4,13 +4,13 @@ on:
   push:
     branches: [main, develop]
     paths:
-      - 'services/users/**'
-      - 'shared/**'
+      - "services/users/**"
+      - "shared/**"
   pull_request:
     branches: [main, develop]
     paths:
-      - 'services/users/**'
-      - 'shared/**'
+      - "services/users/**"
+      - "shared/**"
 
 jobs:
   users-test:
@@ -21,6 +21,14 @@ jobs:
       PYTHONPATH: ${{ github.workspace }}/services/users:${{ github.workspace }}
     steps:
       - uses: actions/checkout@v4
+
+      - name: Lint
+        working-directory: ./services/users
+        run: |
+          pip install black mypy flake8
+          black --check ./app
+          mypy ./app
+          flake8 ./app
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -35,11 +43,3 @@ jobs:
       - name: Run tests
         working-directory: ./services/users
         run: echo "Skipping tests for now"
-
-      - name: Lint
-        working-directory: ./services/users
-        run: |
-          pip install black mypy flake8
-          black --check ./app
-          mypy ./app
-          flake8 ./app

--- a/frontend-typescript/src/App.tsx
+++ b/frontend-typescript/src/App.tsx
@@ -9,6 +9,7 @@ import Onboarding from "./pages/OnBoarding";
 import BudgetsPage from "./pages/Budgets/budgets";
 import { SingleBudgetViewContainer } from "./pages/Budgets/SingleBudgetView";
 import DashboardLayout from "./pages/Dashboard/DashboardLayout";
+import SettingsPage from "./pages/Settings/Settings";
 
 function PrivateRoute({ children }: { children: JSX.Element }) {
   const { isAuthenticated, loading } = useAuth();
@@ -51,6 +52,7 @@ export default function App() {
               <Route path="/dashboard" element={<Dashboard />} />
               <Route path="/budgets" element={<BudgetsPage />} />
               <Route path="/budgets/:id" element={<SingleBudgetViewContainer />} />
+              <Route path="/settings" element={<SettingsPage />} />
             </Route>
             <Route path="*" element={<Navigate to="/dashboard" replace />} />
           </Routes>

--- a/frontend-typescript/src/api/aiSettingsApi.ts
+++ b/frontend-typescript/src/api/aiSettingsApi.ts
@@ -1,0 +1,39 @@
+import gatewayApi from "@/api/gatewayApi";
+
+export interface ProviderStatus {
+  name: string;
+  display_name: string;
+  requires_key: boolean;
+  has_key: boolean;
+  model: string | null;
+  base_url: string | null;
+}
+
+export interface AiSettings {
+  providers: ProviderStatus[];
+}
+
+export const getAiSettings = async (): Promise<AiSettings> => {
+  const { data } = await gatewayApi.get("/users/me/ai-settings");
+  return data;
+};
+
+export const saveAiKey = async (
+  provider: string,
+  key: string | null,
+  model: string,
+  base_url?: string | null,
+): Promise<AiSettings> => {
+  const { data } = await gatewayApi.put("/users/me/ai-settings", {
+    provider,
+    key,
+    model,
+    base_url: base_url ?? null,
+  });
+  return data;
+};
+
+export const clearAiKey = async (provider: string): Promise<AiSettings> => {
+  const { data } = await gatewayApi.delete(`/users/me/ai-settings/${provider}/key`);
+  return data;
+};

--- a/frontend-typescript/src/pages/Dashboard/DashboardLayout.tsx
+++ b/frontend-typescript/src/pages/Dashboard/DashboardLayout.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { Menu, X, Home, FileText, BarChart3, Sparkles } from "lucide-react";
+import { Menu, X, Home, FileText, BarChart3, Sparkles, Settings } from "lucide-react";
 import Button from "../../components/ui/Button";
 import { AIChatPanel } from "@/pages/Budgets/components/AIChatPanel";
 import { useAiChat } from "@/context/AiChatContext";
@@ -66,6 +66,17 @@ export default function DashboardLayout({ children }: DashboardLayoutProps) {
             </li>
           </ul>
         </nav>
+
+        {/* Settings link pinned above AI Mode */}
+        <div className="px-3 pb-1">
+          <a
+            href="/settings"
+            className="flex items-center gap-3 px-3 py-2.5 rounded-lg hover:bg-slate-700 text-slate-300 hover:text-white transition-colors"
+          >
+            <Settings size={20} className="flex-shrink-0" />
+            {isOpen && <span className="text-sm font-medium">Settings</span>}
+          </a>
+        </div>
 
         {/* AI Mode button pinned to bottom of sidebar */}
         <div className="p-3 border-t border-slate-700">

--- a/frontend-typescript/src/pages/Settings/Settings.tsx
+++ b/frontend-typescript/src/pages/Settings/Settings.tsx
@@ -1,0 +1,204 @@
+import { useState } from "react";
+import { Eye, EyeOff, ExternalLink } from "lucide-react";
+import { getAiSettings, saveAiKey, clearAiKey, ProviderStatus } from "@/api/aiSettingsApi";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+
+// Mirrors AIModelName enum from the backend — models the platform officially supports
+const SUPPORTED_MODELS = [
+  { value: "claude-sonnet-4-6", label: "Claude Sonnet 4.6" },
+  { value: "llama3.2", label: "Llama 3.2 (Ollama)" },
+];
+
+const PROVIDER_HELP: Record<string, { description: string; link: string; linkLabel: string }> = {
+  anthropic: {
+    description:
+      "Used for AI-powered budget creation. Your key is encrypted at rest and never exposed.",
+    link: "https://console.anthropic.com/settings/keys",
+    linkLabel: "Get an Anthropic API key",
+  },
+};
+
+function ProviderCard({ provider }: { provider: ProviderStatus }) {
+  const queryClient = useQueryClient();
+  const [keyInput, setKeyInput] = useState("");
+  const [showKey, setShowKey] = useState(false);
+  const [selectedModel, setSelectedModel] = useState(
+    provider.model ?? SUPPORTED_MODELS[0].value
+  );
+  const [urlInput, setUrlInput] = useState(provider.base_url ?? "");
+  const [confirmClear, setConfirmClear] = useState(false);
+
+  const saveMutation = useMutation({
+    mutationFn: () =>
+      saveAiKey(
+        provider.name,
+        provider.requires_key ? keyInput : null,
+        selectedModel,
+        provider.base_url !== undefined ? urlInput || null : null,
+      ),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["ai-settings"] });
+      setKeyInput("");
+    },
+  });
+
+  const clearMutation = useMutation({
+    mutationFn: () => clearAiKey(provider.name),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["ai-settings"] });
+      setConfirmClear(false);
+    },
+  });
+
+  const canSave = provider.requires_key ? keyInput.trim().length > 0 : true;
+  const help = PROVIDER_HELP[provider.name];
+
+  return (
+    <section className="bg-white rounded-xl border border-gray-200 p-6">
+      <div className="flex items-start justify-between mb-1">
+        <h2 className="text-base font-semibold text-gray-900">{provider.display_name}</h2>
+        <span
+          className={`text-xs font-medium px-2.5 py-1 rounded-full ${
+            provider.has_key ? "bg-green-100 text-green-700" : "bg-gray-100 text-gray-500"
+          }`}
+        >
+          {provider.has_key ? "Configured" : "Not configured"}
+        </span>
+      </div>
+
+      {help && (
+        <p className="text-sm text-gray-500 mb-5">
+          {help.description}{" "}
+          <a
+            href={help.link}
+            target="_blank"
+            rel="noreferrer"
+            className="inline-flex items-center gap-1 text-blue-600 hover:underline"
+          >
+            {help.linkLabel} <ExternalLink size={12} />
+          </a>
+        </p>
+      )}
+
+      <div className="flex flex-col gap-3 mb-3">
+        {/* Model selector */}
+        <div>
+          <label className="block text-xs font-medium text-gray-500 mb-1">Model</label>
+          <select
+            value={selectedModel}
+            onChange={(e) => setSelectedModel(e.target.value)}
+            className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+          >
+            {SUPPORTED_MODELS.map((m) => (
+              <option key={m.value} value={m.value}>
+                {m.label}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        {/* API key input (key-based providers only) */}
+        {provider.requires_key && (
+          <div>
+            <label className="block text-xs font-medium text-gray-500 mb-1">API Key</label>
+            <div className="relative">
+              <input
+                type={showKey ? "text" : "password"}
+                value={keyInput}
+                onChange={(e) => setKeyInput(e.target.value)}
+                placeholder={provider.has_key ? "Enter new key to replace existing" : "sk-ant-..."}
+                className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm pr-10 focus:outline-none focus:ring-2 focus:ring-blue-500"
+              />
+              <button
+                type="button"
+                onClick={() => setShowKey((v) => !v)}
+                className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600"
+              >
+                {showKey ? <EyeOff size={16} /> : <Eye size={16} />}
+              </button>
+            </div>
+          </div>
+        )}
+
+        {/* Base URL input (URL-based providers like Ollama) */}
+        {!provider.requires_key && (
+          <div>
+            <label className="block text-xs font-medium text-gray-500 mb-1">Base URL</label>
+            <input
+              type="text"
+              value={urlInput}
+              onChange={(e) => setUrlInput(e.target.value)}
+              placeholder="http://localhost:11434"
+              className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+            />
+          </div>
+        )}
+      </div>
+
+      <div className="flex items-center gap-3">
+        <button
+          onClick={() => saveMutation.mutate()}
+          disabled={!canSave || saveMutation.isPending}
+          className="px-4 py-2 text-sm font-medium bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          {saveMutation.isPending ? "Saving…" : "Save"}
+        </button>
+
+        {provider.has_key && !confirmClear && (
+          <button
+            onClick={() => setConfirmClear(true)}
+            className="text-sm text-red-500 hover:text-red-700"
+          >
+            Remove
+          </button>
+        )}
+
+        {confirmClear && (
+          <>
+            <span className="text-sm text-gray-600">Remove configuration?</span>
+            <button
+              onClick={() => clearMutation.mutate()}
+              disabled={clearMutation.isPending}
+              className="text-sm font-medium text-red-600 hover:text-red-800 disabled:opacity-50"
+            >
+              {clearMutation.isPending ? "Removing…" : "Yes, remove"}
+            </button>
+            <button
+              onClick={() => setConfirmClear(false)}
+              className="text-sm text-gray-500 hover:text-gray-700"
+            >
+              Cancel
+            </button>
+          </>
+        )}
+      </div>
+
+      {saveMutation.isError && (
+        <p className="text-sm text-red-600 mt-3">
+          {(saveMutation.error as any)?.response?.data?.detail ?? "Failed to save"}
+        </p>
+      )}
+    </section>
+  );
+}
+
+export default function SettingsPage() {
+  const { data, isLoading } = useQuery({
+    queryKey: ["ai-settings"],
+    queryFn: getAiSettings,
+  });
+
+  return (
+    <div className="max-w-2xl">
+      <h1 className="text-2xl font-semibold text-gray-900 mb-8">Settings</h1>
+
+      {isLoading && <p className="text-sm text-gray-400">Loading…</p>}
+
+      <div className="flex flex-col gap-4">
+        {data?.providers.map((p) => (
+          <ProviderCard key={p.name} provider={p} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/nginx/nginx-dev.conf
+++ b/nginx/nginx-dev.conf
@@ -87,6 +87,15 @@ http {
             proxy_set_header X-Forwarded-Proto $scheme;
         }
 
+        # ---- AI SETTINGS (proxied through users service) ----
+        location /api/v1/users/me/ai-settings {
+            proxy_pass http://users/api/users/me/ai-settings;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
         # ---- AI SERVICE ----
         location /api/v1/ai/ {
             proxy_pass http://ai/api/v1/ai/;

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -79,6 +79,16 @@ http {
             proxy_set_header X-Forwarded-Proto $scheme;
         }
 
+        # ---- AI SETTINGS (proxied through users service) ----
+        location /api/v1/users/me/ai-settings {
+            set $users_service "http://users:8000";
+            proxy_pass $users_service/api/users/me/ai-settings;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
         # ---- AI SERVICE ----
         location /api/v1/ai/ {
             set $ai_service "http://ai:8000";

--- a/services/ai/.env.ai.private.dev
+++ b/services/ai/.env.ai.private.dev
@@ -7,6 +7,8 @@ POSTGRES_HOST=localhost
 POSTGRES_PORT=5432
 AI_DATABASE_URL=postgresql://postgres:postgres@localhost:5432/grandflow_ai
 ANTHROPIC_API_KEY=
+# Generate with: python -c "import secrets,base64; print(base64.b64encode(secrets.token_bytes(32)).decode())"
+ENCRYPTION_KEY=
 OLLAMA_URL=http://localhost:11434
 OLLAMA_MODEL=llama3.2
 AI_RATE_LIMIT_PER_HOUR=100

--- a/services/ai/.env.ai.private.local
+++ b/services/ai/.env.ai.private.local
@@ -8,6 +8,8 @@ POSTGRES_PORT=5432
 POSTGRES_DB_NAME=grandflow_ai
 AI_DATABASE_URL=postgresql://postgres:postgres@grandflow-db:5432/grandflow_ai
 ANTHROPIC_API_KEY=
+# Generate with: python -c "import secrets,base64; print(base64.b64encode(secrets.token_bytes(32)).decode())"
+ENCRYPTION_KEY=
 OLLAMA_URL=http://localhost:11434
 OLLAMA_MODEL=llama3.2
 AI_RATE_LIMIT_PER_HOUR=100

--- a/services/ai/.env.ai.prod
+++ b/services/ai/.env.ai.prod
@@ -8,6 +8,8 @@ POSTGRES_PORT=5432
 POSTGRES_DB_NAME=grandflow_ai
 AI_DATABASE_URL=
 ANTHROPIC_API_KEY=
+# Generate with: python -c "import secrets,base64; print(base64.b64encode(secrets.token_bytes(32)).decode())"
+ENCRYPTION_KEY=
 OLLAMA_MODEL=llama3.2
 AI_RATE_LIMIT_PER_HOUR=100
 REDIS_URL=redis://redis:6379

--- a/services/ai/app/api/parse_routes.py
+++ b/services/ai/app/api/parse_routes.py
@@ -1,6 +1,8 @@
 from fastapi import APIRouter, Depends, HTTPException
 from fastapi.responses import StreamingResponse
 
+from app.crud.user_provider_key import get_active_key
+from app.db.session import AsyncSessionLocal
 from app.services.parse_service import build_parse_stream
 from app.services.provider import NullProvider, resolve_provider
 from app.services.rate_limiter import check_and_increment
@@ -13,6 +15,9 @@ _SSE_HEADERS = {
     "X-Accel-Buffering": "no",
     "X-RateLimit-Limit": str(settings.AI_RATE_LIMIT_PER_HOUR),
 }
+
+# Alias used in tests to mock DB lookup without hitting a real DB
+get_settings = get_active_key
 
 
 @router.get("/parse-budget/stream")
@@ -34,7 +39,11 @@ async def stream_parse_budget(
             },
         )
 
-    provider = resolve_provider(settings.env)
+    user_key = None
+    async with AsyncSessionLocal() as db:
+        user_key = await get_settings(user_id, db)
+
+    provider = resolve_provider(user_key=user_key)
 
     if isinstance(provider, NullProvider):
 

--- a/services/ai/app/api/settings_routes.py
+++ b/services/ai/app/api/settings_routes.py
@@ -1,0 +1,135 @@
+import anthropic as anthropic_sdk
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.config import settings
+from app.crud.ai_provider import get_by_name, list_active
+from app.crud.user_provider_key import delete_key, get_key, upsert_key
+from app.db.session import AsyncSessionLocal
+from app.models.ai_provider import AIModelName
+from app.utils.encryption import encrypt
+from app.utils.security import get_validated_user
+
+router = APIRouter(prefix="/ai/settings", tags=["AI Settings"])
+
+_ALLOWED_ROLES = {"superuser", "admin"}
+
+
+async def get_db():
+    async with AsyncSessionLocal() as db:
+        yield db
+
+
+def _require_admin(valid_user: dict) -> None:
+    if valid_user.get("role") not in _ALLOWED_ROLES:
+        raise HTTPException(status_code=403, detail="Admin or superuser role required")
+
+
+class ProviderStatus(BaseModel):
+    name: str
+    display_name: str
+    requires_key: bool
+    has_key: bool
+    model: str | None
+    base_url: str | None
+
+
+class SettingsResponse(BaseModel):
+    providers: list[ProviderStatus]
+
+
+class SaveKeyRequest(BaseModel):
+    provider: str
+    key: str | None = None
+    model: AIModelName
+    base_url: str | None = None
+
+
+async def _validate_key_with_provider(
+    provider_name: str, key_prefix: str | None, key: str | None
+) -> None:
+    if key_prefix and not key:
+        raise HTTPException(status_code=422, detail=f"{provider_name} requires an API key")
+    if key_prefix and key and not key.startswith(key_prefix):
+        raise HTTPException(
+            status_code=422,
+            detail=f"Invalid key format for {provider_name} (expected prefix: {key_prefix})",
+        )
+    if provider_name == "anthropic" and key:
+        try:
+            client = anthropic_sdk.AsyncAnthropic(api_key=key)
+            await client.messages.create(
+                model="claude-haiku-4-5-20251001",
+                max_tokens=1,
+                messages=[{"role": "user", "content": "hi"}],
+            )
+        except anthropic_sdk.AuthenticationError:
+            raise HTTPException(status_code=422, detail="Anthropic key is invalid or inactive")
+        except Exception:
+            raise HTTPException(
+                status_code=502, detail="Could not reach Anthropic to validate key"
+            )
+
+
+@router.get("", response_model=SettingsResponse)
+async def get_ai_settings(
+    valid_user: dict = Depends(get_validated_user),
+    db: AsyncSession = Depends(get_db),
+):
+    _require_admin(valid_user)
+    user_id = str(valid_user["user_id"])
+    providers = await list_active(db)
+    statuses: list[ProviderStatus] = []
+    for p in providers:
+        row = await get_key(user_id, str(p.id), db)
+        statuses.append(
+            ProviderStatus(
+                name=p.name,
+                display_name=p.display_name,
+                requires_key=p.key_prefix is not None,
+                has_key=bool(row and row.encrypted_key),
+                model=row.model_name if row else None,
+                base_url=row.base_url if row else None,
+            )
+        )
+    return SettingsResponse(providers=statuses)
+
+
+@router.put("", response_model=SettingsResponse)
+async def save_ai_settings(
+    body: SaveKeyRequest,
+    valid_user: dict = Depends(get_validated_user),
+    db: AsyncSession = Depends(get_db),
+):
+    _require_admin(valid_user)
+    provider = await get_by_name(body.provider, db)
+    if not provider:
+        raise HTTPException(status_code=404, detail=f"Provider '{body.provider}' not found")
+    await _validate_key_with_provider(provider.name, provider.key_prefix, body.key)
+    encrypted = encrypt(body.key, settings.ENCRYPTION_KEY) if body.key else None
+    user_id = str(valid_user["user_id"])
+    await upsert_key(
+        user_id=user_id,
+        provider_id=str(provider.id),
+        encrypted_key=encrypted,
+        model_name=body.model.value,
+        base_url=body.base_url,
+        db=db,
+    )
+    return await get_ai_settings(valid_user=valid_user, db=db)
+
+
+@router.delete("/{provider}/key", response_model=SettingsResponse)
+async def clear_ai_key(
+    provider: str,
+    valid_user: dict = Depends(get_validated_user),
+    db: AsyncSession = Depends(get_db),
+):
+    _require_admin(valid_user)
+    provider_row = await get_by_name(provider, db)
+    if not provider_row:
+        raise HTTPException(status_code=404, detail=f"Provider '{provider}' not found")
+    user_id = str(valid_user["user_id"])
+    await delete_key(user_id, str(provider_row.id), db)
+    return await get_ai_settings(valid_user=valid_user, db=db)

--- a/services/ai/app/api/settings_routes.py
+++ b/services/ai/app/api/settings_routes.py
@@ -67,9 +67,7 @@ async def _validate_key_with_provider(
         except anthropic_sdk.AuthenticationError:
             raise HTTPException(status_code=422, detail="Anthropic key is invalid or inactive")
         except Exception:
-            raise HTTPException(
-                status_code=502, detail="Could not reach Anthropic to validate key"
-            )
+            raise HTTPException(status_code=502, detail="Could not reach Anthropic to validate key")
 
 
 @router.get("", response_model=SettingsResponse)

--- a/services/ai/app/core/config.py
+++ b/services/ai/app/core/config.py
@@ -20,6 +20,7 @@ class Settings(BaseSettings):
     ai_database_url: str
     REDIS_URL: str = "redis://localhost:6379"
     ANTHROPIC_API_KEY: str | None = None
+    ENCRYPTION_KEY: str  # 32-byte base64-encoded secret for AES-256-GCM
     OLLAMA_URL: str | None = None
     OLLAMA_MODEL: str = "llama3.2"
     AI_RATE_LIMIT_PER_HOUR: int = 100

--- a/services/ai/app/crud/ai_provider.py
+++ b/services/ai/app/crud/ai_provider.py
@@ -1,0 +1,18 @@
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.ai_provider import AIProvider
+
+
+async def get_by_name(name: str, db: AsyncSession) -> AIProvider | None:
+    result = await db.execute(
+        select(AIProvider).where(AIProvider.name == name, AIProvider.is_active.is_(True))
+    )
+    return result.scalar_one_or_none()
+
+
+async def list_active(db: AsyncSession) -> list[AIProvider]:
+    result = await db.execute(
+        select(AIProvider).where(AIProvider.is_active.is_(True)).order_by(AIProvider.name)
+    )
+    return list(result.scalars().all())

--- a/services/ai/app/crud/user_provider_key.py
+++ b/services/ai/app/crud/user_provider_key.py
@@ -1,0 +1,68 @@
+from datetime import datetime, timezone
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.user_provider_key import UserProviderKey
+
+
+async def get_key(user_id: str, provider_id: str, db: AsyncSession) -> UserProviderKey | None:
+    result = await db.execute(
+        select(UserProviderKey).where(
+            UserProviderKey.user_id == user_id,
+            UserProviderKey.provider_id == provider_id,
+        )
+    )
+    return result.scalar_one_or_none()
+
+
+async def get_active_key(user_id: str, db: AsyncSession) -> UserProviderKey | None:
+    """Return the first active BYOK key for this user (provider joined)."""
+    result = await db.execute(
+        select(UserProviderKey).where(
+            UserProviderKey.user_id == user_id,
+            UserProviderKey.encrypted_key.isnot(None),
+        )
+    )
+    return result.scalar_one_or_none()
+
+
+async def upsert_key(
+    user_id: str,
+    provider_id: str,
+    encrypted_key: str | None,
+    model_name: str | None,
+    base_url: str | None,
+    db: AsyncSession,
+) -> UserProviderKey:
+    now = datetime.now(timezone.utc)
+    existing = await get_key(user_id, provider_id, db)
+    if existing:
+        existing.encrypted_key = encrypted_key
+        existing.model_name = model_name
+        existing.base_url = base_url
+        existing.updated_at = now
+        await db.commit()
+        await db.refresh(existing)
+        return existing
+    row = UserProviderKey(
+        user_id=user_id,
+        provider_id=provider_id,
+        encrypted_key=encrypted_key,
+        model_name=model_name,
+        base_url=base_url,
+        created_at=now,
+        updated_at=now,
+    )
+    db.add(row)
+    await db.commit()
+    await db.refresh(row)
+    return row
+
+
+async def delete_key(user_id: str, provider_id: str, db: AsyncSession) -> None:
+    existing = await get_key(user_id, provider_id, db)
+    if existing:
+        existing.encrypted_key = None
+        existing.updated_at = datetime.now(timezone.utc)
+        await db.commit()

--- a/services/ai/app/models/__init__.py
+++ b/services/ai/app/models/__init__.py
@@ -1,4 +1,6 @@
 from app.models.audit_log import AIAuditLog  # noqa: F401
 from app.models.prompt import AIPrompt  # noqa: F401
+from app.models.ai_provider import AIProvider  # noqa: F401
+from app.models.user_provider_key import UserProviderKey  # noqa: F401
 
-__all__ = ["AIAuditLog", "AIPrompt"]
+__all__ = ["AIAuditLog", "AIPrompt", "AIProvider", "UserProviderKey"]

--- a/services/ai/app/models/ai_provider.py
+++ b/services/ai/app/models/ai_provider.py
@@ -1,0 +1,25 @@
+import uuid
+from enum import Enum
+
+from sqlalchemy import Boolean, String
+from sqlalchemy.orm import mapped_column, Mapped
+
+from app.models.base import Base
+import shared.db.type_decorators as t
+
+
+class AIModelName(str, Enum):
+    claude_sonnet_4_6 = "claude-sonnet-4-6"
+    llama3_2 = "llama3.2"
+
+
+class AIProvider(Base):
+    __tablename__ = "ai_providers"
+
+    id: Mapped[t.GUID] = mapped_column(
+        t.GUID(), primary_key=True, default=lambda: str(uuid.uuid4())
+    )
+    name: Mapped[str] = mapped_column(String, nullable=False, unique=True, index=True)
+    display_name: Mapped[str] = mapped_column(String, nullable=False)
+    key_prefix: Mapped[str | None] = mapped_column(String, nullable=True)
+    is_active: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)

--- a/services/ai/app/models/user_provider_key.py
+++ b/services/ai/app/models/user_provider_key.py
@@ -1,0 +1,48 @@
+import uuid
+from datetime import datetime
+
+from sqlalchemy import DateTime, ForeignKey, String, Text, UniqueConstraint
+from sqlalchemy.orm import mapped_column, Mapped, relationship
+
+from app.models.base import Base
+from app.models.ai_provider import AIModelName
+import shared.db.type_decorators as t
+
+
+class UserProviderKey(Base):
+    __tablename__ = "user_provider_keys"
+    __table_args__ = (
+        UniqueConstraint("user_id", "provider_id", name="uq_user_provider_keys_user_provider"),
+    )
+
+    id: Mapped[t.GUID] = mapped_column(
+        t.GUID(), primary_key=True, default=lambda: str(uuid.uuid4())
+    )
+    user_id: Mapped[t.GUID] = mapped_column(t.GUID(), nullable=False, index=True)
+    provider_id: Mapped[t.GUID] = mapped_column(
+        t.GUID(), ForeignKey("ai_providers.id"), nullable=False
+    )
+    encrypted_key: Mapped[str | None] = mapped_column(Text, nullable=True)
+    model_name: Mapped[str | None] = mapped_column(String, nullable=True)
+    base_url: Mapped[str | None] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+
+    provider: Mapped["AIProvider"] = relationship(  # type: ignore[name-defined]  # noqa: F821
+        "AIProvider", lazy="joined"
+    )
+
+    @property
+    def resolved_model(self) -> str:
+        """Return configured model or the enum default for the provider."""
+        if self.model_name:
+            return self.model_name
+        from app.core.config import settings
+
+        return settings.OLLAMA_MODEL
+
+    @property
+    def model(self) -> AIModelName | None:
+        if self.model_name:
+            return AIModelName(self.model_name)
+        return None

--- a/services/ai/app/services/provider.py
+++ b/services/ai/app/services/provider.py
@@ -1,6 +1,7 @@
 from abc import ABC, abstractmethod
 from typing import AsyncIterator, cast
 
+import anthropic as anthropic_sdk
 from openai import AsyncOpenAI, AsyncStream
 from openai.types.chat import ChatCompletionChunk, ChatCompletionMessageParam
 
@@ -103,9 +104,66 @@ class OllamaProvider(BaseProvider):
             raise
 
 
-def resolve_provider(env: str) -> BaseProvider:
-    from app.core.config import settings
+class AnthropicProvider(BaseProvider):
+    """Anthropic Claude via the official SDK. Used for BYOK and cloud mode."""
 
-    if env == "development" and settings.OLLAMA_URL:
-        return OllamaProvider(base_url=settings.OLLAMA_URL, model=settings.OLLAMA_MODEL)
+    def __init__(self, api_key: str, model: str = "claude-sonnet-4-6") -> None:
+        self._model = model
+        self._client = anthropic_sdk.AsyncAnthropic(api_key=api_key)
+
+    @property
+    def model_name(self) -> str:
+        return self._model
+
+    @property
+    def provider_name(self) -> str:
+        return "anthropic"
+
+    async def stream(self, prompt: str, system_prompt: str = "") -> AsyncIterator[str]:
+        async def _gen():
+            try:
+                async with self._client.messages.stream(
+                    model=self._model,
+                    max_tokens=2048,
+                    system=system_prompt or anthropic_sdk.NOT_GIVEN,
+                    messages=[{"role": "user", "content": prompt}],
+                ) as stream:
+                    async for text in stream.text_stream:
+                        yield text
+            except Exception as exc:
+                logger.error("anthropic_stream_error", error=str(exc))
+                raise
+
+        return _gen()
+
+    async def complete(self, prompt: str, system_prompt: str = "") -> str:
+        try:
+            response = await self._client.messages.create(
+                model=self._model,
+                max_tokens=2048,
+                system=system_prompt or anthropic_sdk.NOT_GIVEN,
+                messages=[{"role": "user", "content": prompt}],
+            )
+            return response.content[0].text if response.content else ""
+        except Exception as exc:
+            logger.error("anthropic_complete_error", error=str(exc))
+            raise
+
+
+def resolve_provider(
+    user_key=None,  # UserProviderKey | None — avoid circular import
+) -> BaseProvider:
+    from app.core.config import settings
+    from app.utils.encryption import decrypt
+
+    if user_key and user_key.provider:
+        provider_name = user_key.provider.name
+        model = user_key.model_name
+        if provider_name == "anthropic" and user_key.encrypted_key:
+            api_key = decrypt(user_key.encrypted_key, settings.ENCRYPTION_KEY)
+            return AnthropicProvider(api_key=api_key, model=model)
+        if provider_name == "ollama":
+            base_url = user_key.base_url or settings.OLLAMA_URL
+            if base_url:
+                return OllamaProvider(base_url=base_url, model=model)
     return NullProvider()

--- a/services/ai/app/services/provider.py
+++ b/services/ai/app/services/provider.py
@@ -122,12 +122,13 @@ class AnthropicProvider(BaseProvider):
     async def stream(self, prompt: str, system_prompt: str = "") -> AsyncIterator[str]:
         async def _gen():
             try:
-                async with self._client.messages.stream(
+                ctx = self._client.messages.stream(
                     model=self._model,
                     max_tokens=2048,
-                    system=system_prompt or anthropic_sdk.NOT_GIVEN,
+                    system=system_prompt if system_prompt else anthropic_sdk.NOT_GIVEN,  # type: ignore[arg-type]  # noqa: E501
                     messages=[{"role": "user", "content": prompt}],
-                ) as stream:
+                )
+                async with ctx as stream:
                     async for text in stream.text_stream:
                         yield text
             except Exception as exc:
@@ -138,13 +139,19 @@ class AnthropicProvider(BaseProvider):
 
     async def complete(self, prompt: str, system_prompt: str = "") -> str:
         try:
+            _system = (  # type: ignore[assignment]
+                system_prompt if system_prompt else anthropic_sdk.NOT_GIVEN
+            )
             response = await self._client.messages.create(
                 model=self._model,
                 max_tokens=2048,
-                system=system_prompt or anthropic_sdk.NOT_GIVEN,
+                system=_system,  # type: ignore[arg-type]
                 messages=[{"role": "user", "content": prompt}],
             )
-            return response.content[0].text if response.content else ""
+            return next(
+                (b.text for b in response.content if isinstance(b, anthropic_sdk.types.TextBlock)),
+                "",
+            )
         except Exception as exc:
             logger.error("anthropic_complete_error", error=str(exc))
             raise

--- a/services/ai/app/utils/encryption.py
+++ b/services/ai/app/utils/encryption.py
@@ -1,0 +1,20 @@
+import base64
+import os
+
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+
+_NONCE_SIZE = 12
+
+
+def encrypt(plaintext: str, key_b64: str) -> str:
+    key = base64.b64decode(key_b64)
+    nonce = os.urandom(_NONCE_SIZE)
+    ciphertext = AESGCM(key).encrypt(nonce, plaintext.encode(), None)
+    return base64.b64encode(nonce + ciphertext).decode()
+
+
+def decrypt(ciphertext_b64: str, key_b64: str) -> str:
+    key = base64.b64decode(key_b64)
+    data = base64.b64decode(ciphertext_b64)
+    nonce, ciphertext = data[:_NONCE_SIZE], data[_NONCE_SIZE:]
+    return AESGCM(key).decrypt(nonce, ciphertext, None).decode()

--- a/services/ai/main.py
+++ b/services/ai/main.py
@@ -8,7 +8,7 @@ from opentelemetry.instrumentation.redis import RedisInstrumentor
 from opentelemetry.instrumentation.sqlalchemy import SQLAlchemyInstrumentor
 from opentelemetry.sdk.trace import TracerProvider as SDKTracerProvider
 
-from app.api import parse_routes
+from app.api import parse_routes, settings_routes
 from app.core.config import settings
 from app.core.logging import setup_logging, get_logger
 from app.db.session import engine
@@ -49,6 +49,7 @@ app = FastAPI(title="AI Service", lifespan=lifespan)
 instrument_fastapi(app)
 
 app.include_router(parse_routes.router, prefix="/api/v1")
+app.include_router(settings_routes.router, prefix="/api/v1")
 app.add_route("/metrics", metrics_endpoint, methods=["GET"])
 
 

--- a/services/ai/migrations/versions/003_create_user_ai_settings.py
+++ b/services/ai/migrations/versions/003_create_user_ai_settings.py
@@ -1,0 +1,74 @@
+"""Create ai_providers and user_provider_keys tables
+
+Revision ID: 003_create_user_ai_settings
+Revises: 002_create_ai_prompts
+Create Date: 2026-06-25 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+import uuid
+
+from alembic import op
+import sqlalchemy as sa
+import shared
+
+revision: str = "003_create_user_ai_settings"
+down_revision: Union[str, Sequence[str], None] = "002_create_ai_prompts"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "ai_providers",
+        sa.Column("id", shared.db.type_decorators.GUID(), nullable=False),
+        sa.Column("name", sa.String(), nullable=False),
+        sa.Column("display_name", sa.String(), nullable=False),
+        sa.Column("key_prefix", sa.String(), nullable=True),
+        sa.Column("is_active", sa.Boolean(), nullable=False, server_default="true"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("name", name="uq_ai_providers_name"),
+    )
+    op.create_index("ix_ai_providers_name", "ai_providers", ["name"], unique=True)
+
+    op.create_table(
+        "user_provider_keys",
+        sa.Column("id", shared.db.type_decorators.GUID(), nullable=False),
+        sa.Column("user_id", shared.db.type_decorators.GUID(), nullable=False),
+        sa.Column("provider_id", shared.db.type_decorators.GUID(), nullable=False),
+        sa.Column("encrypted_key", sa.Text(), nullable=True),
+        sa.Column("model_name", sa.String(), nullable=True),
+        sa.Column("base_url", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(["provider_id"], ["ai_providers.id"]),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "user_id", "provider_id", name="uq_user_provider_keys_user_provider"
+        ),
+    )
+    op.create_index(
+        "ix_user_provider_keys_user_id", "user_provider_keys", ["user_id"], unique=False
+    )
+
+    op.execute(
+        sa.text(
+            """
+            INSERT INTO ai_providers (id, name, display_name, key_prefix, is_active)
+            VALUES
+                (:anthropic_id, 'anthropic', 'Anthropic', 'sk-ant-', TRUE),
+                (:ollama_id,    'ollama',    'Ollama (Local)', NULL,   TRUE)
+            """
+        ).bindparams(
+            anthropic_id=str(uuid.uuid4()),
+            ollama_id=str(uuid.uuid4()),
+        )
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_user_provider_keys_user_id", table_name="user_provider_keys")
+    op.drop_table("user_provider_keys")
+    op.drop_index("ix_ai_providers_name", table_name="ai_providers")
+    op.drop_table("ai_providers")

--- a/services/ai/requirements.txt
+++ b/services/ai/requirements.txt
@@ -1,4 +1,6 @@
 alembic==1.16.4
+anthropic==0.111.0
+cryptography==44.0.3
 Jinja2==3.1.6
 openai==1.84.0
 anyio==4.9.0

--- a/services/ai/tests/test_encryption.py
+++ b/services/ai/tests/test_encryption.py
@@ -1,0 +1,38 @@
+import base64
+import pytest
+from cryptography.exceptions import InvalidTag
+
+from app.utils.encryption import encrypt, decrypt
+
+
+def _make_key() -> str:
+    import secrets
+    return base64.b64encode(secrets.token_bytes(32)).decode()
+
+
+class TestEncryption:
+    def test_round_trip(self):
+        key = _make_key()
+        plaintext = "sk-ant-api03-supersecretkey"
+        assert decrypt(encrypt(plaintext, key), key) == plaintext
+
+    def test_different_ciphertexts_for_same_plaintext(self):
+        key = _make_key()
+        plaintext = "same-input"
+        assert encrypt(plaintext, key) != encrypt(plaintext, key)
+
+    def test_wrong_key_raises(self):
+        key1 = _make_key()
+        key2 = _make_key()
+        ciphertext = encrypt("secret", key1)
+        with pytest.raises((InvalidTag, Exception)):
+            decrypt(ciphertext, key2)
+
+    def test_tampered_ciphertext_raises(self):
+        key = _make_key()
+        ciphertext_b64 = encrypt("secret", key)
+        raw = bytearray(base64.b64decode(ciphertext_b64))
+        raw[-1] ^= 0xFF
+        tampered = base64.b64encode(bytes(raw)).decode()
+        with pytest.raises((InvalidTag, Exception)):
+            decrypt(tampered, key)

--- a/services/ai/tests/test_parse_route.py
+++ b/services/ai/tests/test_parse_route.py
@@ -1,6 +1,6 @@
 import redis
 from uuid import uuid4
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 from fastapi.testclient import TestClient
 
 from app.core.config import settings
@@ -8,6 +8,8 @@ from app.services.provider import NullProvider
 from main import app
 from app.api.parse_routes import get_validated_user
 from tests.factories.user import make_valid_user
+
+_GET_SETTINGS = "app.api.parse_routes.get_settings"
 
 client = TestClient(app)
 
@@ -54,14 +56,18 @@ class TestParseBudgetStream:
             pass
 
     def test_null_provider_stream_returns_unavailable_event(self):
-        with patch("app.api.parse_routes.resolve_provider", return_value=NullProvider()):
+        with (
+            patch("app.api.parse_routes.resolve_provider", return_value=NullProvider()),
+            patch(_GET_SETTINGS, new=AsyncMock(return_value=None)),
+        ):
             response = client.get("/api/v1/ai/parse-budget/stream?text=test")
         assert response.status_code == 200
         assert "text/event-stream" in response.headers["content-type"]
         assert "event: unavailable" in response.text
 
     def test_rate_limit_header_present_in_response(self):
-        response = client.get("/api/v1/ai/parse-budget/stream?text=test")
+        with patch(_GET_SETTINGS, new=AsyncMock(return_value=None)):
+            response = client.get("/api/v1/ai/parse-budget/stream?text=test")
         assert response.status_code == 200
         assert "x-ratelimit-limit" in response.headers
 

--- a/services/ai/tests/test_provider.py
+++ b/services/ai/tests/test_provider.py
@@ -1,5 +1,6 @@
 import anyio
-from app.services.provider import NullProvider
+from unittest.mock import MagicMock, patch
+from app.services.provider import NullProvider, AnthropicProvider, resolve_provider
 
 
 class TestNullProvider:
@@ -21,3 +22,35 @@ class TestNullProvider:
 
         result = anyio.run(_run)
         assert result == ""
+
+
+class TestResolveProvider:
+    def _make_user_key(self, provider_name="anthropic", model_name=None, encrypted_key="enc"):
+        user_key = MagicMock()
+        user_key.provider.name = provider_name
+        user_key.model_name = model_name
+        user_key.encrypted_key = encrypted_key
+        user_key.base_url = None
+        return user_key
+
+    def test_user_key_returns_anthropic_provider(self):
+        user_key = self._make_user_key()
+        with patch("app.utils.encryption.decrypt", return_value="sk-ant-api03-testkey"):
+            provider = resolve_provider(user_key=user_key)
+        assert isinstance(provider, AnthropicProvider)
+        assert provider.provider_name == "anthropic"
+
+    def test_user_key_uses_model_name(self):
+        user_key = self._make_user_key(model_name="claude-haiku-4-5-20251001")
+        with patch("app.utils.encryption.decrypt", return_value="sk-ant-api03-testkey"):
+            provider = resolve_provider(user_key=user_key)
+        assert isinstance(provider, AnthropicProvider)
+        assert provider.model_name == "claude-haiku-4-5-20251001"
+
+    def test_no_key_returns_null(self):
+        provider = resolve_provider(user_key=None)
+        assert isinstance(provider, NullProvider)
+
+    def test_no_user_key_returns_null(self):
+        provider = resolve_provider()
+        assert isinstance(provider, NullProvider)

--- a/services/ai/tests/test_settings_routes.py
+++ b/services/ai/tests/test_settings_routes.py
@@ -1,0 +1,202 @@
+from unittest.mock import AsyncMock, MagicMock, patch
+from fastapi.testclient import TestClient
+
+from main import app
+from app.api.settings_routes import get_db, get_validated_user
+from tests.factories.user import make_valid_user
+
+client = TestClient(app)
+
+_ENCRYPTED_KEY = "dGVzdC1lbmNyeXB0ZWQ="  # fake base64 blob
+
+_LIST_ACTIVE = "app.api.settings_routes.list_active"
+_GET_KEY = "app.api.settings_routes.get_key"
+_GET_BY_NAME = "app.api.settings_routes.get_by_name"
+_VALIDATE = "app.api.settings_routes._validate_key_with_provider"
+_ENCRYPT = "app.api.settings_routes.encrypt"
+_UPSERT = "app.api.settings_routes.upsert_key"
+_DELETE = "app.api.settings_routes.delete_key"
+
+
+def _make_admin_user():
+    return make_valid_user(role="superuser")
+
+
+def _make_regular_user():
+    return make_valid_user(role="user")
+
+
+def _make_provider(name="anthropic", has_key_prefix=True):
+    p = MagicMock()
+    p.id = "bbbbbbbb-0000-0000-0000-000000000002"
+    p.name = name
+    p.display_name = "Anthropic" if name == "anthropic" else "Ollama (Local)"
+    p.key_prefix = "sk-ant-" if has_key_prefix else None
+    p.is_active = True
+    return p
+
+
+def _make_key_row(has_key: bool):
+    if not has_key:
+        return None
+    row = MagicMock()
+    row.encrypted_key = _ENCRYPTED_KEY
+    row.model_name = "claude-sonnet-4-6"
+    row.base_url = None
+    return row
+
+
+def _mock_db():
+    async def _override():
+        yield AsyncMock()
+
+    return _override
+
+
+class TestGetAiSettings:
+    def setup_method(self):
+        app.dependency_overrides[get_validated_user] = _make_admin_user
+        app.dependency_overrides[get_db] = _mock_db()
+
+    def teardown_method(self):
+        app.dependency_overrides.pop(get_validated_user, None)
+        app.dependency_overrides.pop(get_db, None)
+
+    def test_returns_providers_list_with_has_key_true(self):
+        with (
+            patch(_LIST_ACTIVE, new=AsyncMock(return_value=[_make_provider()])),
+            patch(_GET_KEY, new=AsyncMock(return_value=_make_key_row(has_key=True))),
+        ):
+            response = client.get("/api/v1/ai/settings")
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data["providers"]) == 1
+        p = data["providers"][0]
+        assert p["name"] == "anthropic"
+        assert p["has_key"] is True
+        assert p["requires_key"] is True
+        assert p["model"] == "claude-sonnet-4-6"
+
+    def test_returns_has_key_false_when_no_key(self):
+        with (
+            patch(_LIST_ACTIVE, new=AsyncMock(return_value=[_make_provider()])),
+            patch(_GET_KEY, new=AsyncMock(return_value=None)),
+        ):
+            response = client.get("/api/v1/ai/settings")
+        assert response.status_code == 200
+        assert response.json()["providers"][0]["has_key"] is False
+
+    def test_ollama_provider_requires_no_key(self):
+        with (
+            patch(
+                _LIST_ACTIVE,
+                new=AsyncMock(
+                    return_value=[_make_provider("ollama", has_key_prefix=False)]
+                ),
+            ),
+            patch(_GET_KEY, new=AsyncMock(return_value=None)),
+        ):
+            response = client.get("/api/v1/ai/settings")
+        p = response.json()["providers"][0]
+        assert p["requires_key"] is False
+
+    def test_user_role_forbidden(self):
+        app.dependency_overrides[get_validated_user] = _make_regular_user
+        response = client.get("/api/v1/ai/settings")
+        assert response.status_code == 403
+
+
+class TestSaveAiSettings:
+    def setup_method(self):
+        app.dependency_overrides[get_validated_user] = _make_admin_user
+        app.dependency_overrides[get_db] = _mock_db()
+
+    def teardown_method(self):
+        app.dependency_overrides.pop(get_validated_user, None)
+        app.dependency_overrides.pop(get_db, None)
+
+    def test_unknown_provider_returns_404(self):
+        with patch(_GET_BY_NAME, new=AsyncMock(return_value=None)):
+            response = client.put(
+                "/api/v1/ai/settings",
+                json={"provider": "unknown", "key": "any", "model": "claude-sonnet-4-6"},
+            )
+        assert response.status_code == 404
+
+    def test_invalid_key_format_rejected(self):
+        with patch(_GET_BY_NAME, new=AsyncMock(return_value=_make_provider())):
+            response = client.put(
+                "/api/v1/ai/settings",
+                json={
+                    "provider": "anthropic",
+                    "key": "not-a-valid-key",
+                    "model": "claude-sonnet-4-6",
+                },
+            )
+        assert response.status_code == 422
+
+    def test_unsupported_model_rejected(self):
+        response = client.put(
+            "/api/v1/ai/settings",
+            json={"provider": "anthropic", "key": "sk-ant-x", "model": "gpt-5-turbo"},
+        )
+        assert response.status_code == 422
+
+    def test_valid_key_saved_returns_providers(self):
+        with (
+            patch(_GET_BY_NAME, new=AsyncMock(return_value=_make_provider())),
+            patch(_VALIDATE, new=AsyncMock()),
+            patch(_ENCRYPT, return_value=_ENCRYPTED_KEY),
+            patch(_UPSERT, new=AsyncMock()),
+            patch(_LIST_ACTIVE, new=AsyncMock(return_value=[_make_provider()])),
+            patch(_GET_KEY, new=AsyncMock(return_value=_make_key_row(has_key=True))),
+        ):
+            response = client.put(
+                "/api/v1/ai/settings",
+                json={
+                    "provider": "anthropic",
+                    "key": "sk-ant-api03-x",
+                    "model": "claude-sonnet-4-6",
+                },
+            )
+        assert response.status_code == 200
+        assert response.json()["providers"][0]["has_key"] is True
+
+    def test_user_role_forbidden(self):
+        app.dependency_overrides[get_validated_user] = _make_regular_user
+        response = client.put(
+            "/api/v1/ai/settings",
+            json={"provider": "anthropic", "key": "sk-ant-api03-x", "model": "claude-sonnet-4-6"},
+        )
+        assert response.status_code == 403
+
+
+class TestClearAiKey:
+    def setup_method(self):
+        app.dependency_overrides[get_validated_user] = _make_admin_user
+        app.dependency_overrides[get_db] = _mock_db()
+
+    def teardown_method(self):
+        app.dependency_overrides.pop(get_validated_user, None)
+        app.dependency_overrides.pop(get_db, None)
+
+    def test_unknown_provider_returns_404(self):
+        with patch(_GET_BY_NAME, new=AsyncMock(return_value=None)):
+            response = client.delete("/api/v1/ai/settings/unknown/key")
+        assert response.status_code == 404
+
+    def test_clears_key_returns_has_key_false(self):
+        with (
+            patch(_GET_BY_NAME, new=AsyncMock(return_value=_make_provider())),
+            patch(_DELETE, new=AsyncMock()),
+            patch(_LIST_ACTIVE, new=AsyncMock(return_value=[_make_provider()])),
+            patch(_GET_KEY, new=AsyncMock(return_value=None)),
+        ):
+            response = client.delete("/api/v1/ai/settings/anthropic/key")
+        assert response.status_code == 200
+        assert response.json()["providers"][0]["has_key"] is False
+
+    def test_user_role_forbidden(self):
+        app.dependency_overrides[get_validated_user] = _make_regular_user
+        response = client.delete("/api/v1/ai/settings/anthropic/key")
+        assert response.status_code == 403

--- a/services/ai/tests/test_sse_endpoint.py
+++ b/services/ai/tests/test_sse_endpoint.py
@@ -37,6 +37,7 @@ _LOAD_PROMPT = "app.services.parse_service.load_prompt"
 _AUDIT = "app.services.parse_service.write_audit_log"
 _RATE = "app.api.parse_routes.check_and_increment"
 _RESOLVE = "app.api.parse_routes.resolve_provider"
+_GET_SETTINGS = "app.api.parse_routes.get_settings"
 
 
 def _setup(customer_id="sse-test-customer"):
@@ -80,6 +81,7 @@ class TestSSEEndpoint:
             patch(_RESOLVE, return_value=_mock_provider([VALID_JSON_RESPONSE])),
             patch(_AUDIT, new=AsyncMock()),
             patch(_RATE, new=AsyncMock(return_value=(True, 0))),
+            patch(_GET_SETTINGS, new=AsyncMock(return_value=None)),
         ):
             response = self.client.get("/api/v1/ai/parse-budget/stream?text=test")
 
@@ -92,6 +94,7 @@ class TestSSEEndpoint:
             patch(_RESOLVE, return_value=_mock_provider([VALID_JSON_RESPONSE])),
             patch(_AUDIT, new=AsyncMock()),
             patch(_RATE, new=AsyncMock(return_value=(True, 0))),
+            patch(_GET_SETTINGS, new=AsyncMock(return_value=None)),
         ):
             response = self.client.get("/api/v1/ai/parse-budget/stream?text=test")
 
@@ -107,6 +110,7 @@ class TestSSEEndpoint:
             patch(_RESOLVE, return_value=_mock_provider([VALID_JSON_RESPONSE])),
             patch(_AUDIT, new=AsyncMock()),
             patch(_RATE, new=AsyncMock(return_value=(True, 0))),
+            patch(_GET_SETTINGS, new=AsyncMock(return_value=None)),
         ):
             response = self.client.get("/api/v1/ai/parse-budget/stream?text=test")
 
@@ -124,6 +128,7 @@ class TestSSEEndpoint:
             patch(_RESOLVE, return_value=_mock_provider(["not valid json at all"])),
             patch(_AUDIT, new=AsyncMock()),
             patch(_RATE, new=AsyncMock(return_value=(True, 0))),
+            patch(_GET_SETTINGS, new=AsyncMock(return_value=None)),
         ):
             response = self.client.get("/api/v1/ai/parse-budget/stream?text=test")
 
@@ -135,6 +140,7 @@ class TestSSEEndpoint:
             patch(_LOAD_PROMPT, new=AsyncMock(side_effect=ValueError("no prompt"))),
             patch(_RESOLVE, return_value=_mock_provider([])),
             patch(_RATE, new=AsyncMock(return_value=(True, 0))),
+            patch(_GET_SETTINGS, new=AsyncMock(return_value=None)),
         ):
             response = self.client.get("/api/v1/ai/parse-budget/stream?text=test")
 
@@ -148,6 +154,7 @@ class TestSSEEndpoint:
             patch(_RESOLVE, return_value=_mock_provider([VALID_JSON_RESPONSE])),
             patch(_AUDIT, mock_audit),
             patch(_RATE, new=AsyncMock(return_value=(True, 0))),
+            patch(_GET_SETTINGS, new=AsyncMock(return_value=None)),
         ):
             self.client.get("/api/v1/ai/parse-budget/stream?text=test")
 

--- a/services/ai/tests/test_user_provider_key.py
+++ b/services/ai/tests/test_user_provider_key.py
@@ -1,0 +1,108 @@
+import anyio
+from unittest.mock import AsyncMock, MagicMock
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.crud.user_provider_key import delete_key, get_active_key, get_key, upsert_key
+from app.models.user_provider_key import UserProviderKey
+
+USER_ID = "aaaaaaaa-0000-0000-0000-000000000001"
+PROVIDER_ID = "bbbbbbbb-0000-0000-0000-000000000002"
+
+
+def _make_mock_db():
+    return AsyncMock(spec=AsyncSession)
+
+
+def _scalar_result(value):
+    result = MagicMock()
+    result.scalar_one_or_none.return_value = value
+    return result
+
+
+def _scalars_result(values):
+    result = MagicMock()
+    result.scalars.return_value.all.return_value = values
+    return result
+
+
+class TestGetKey:
+    def test_returns_none_when_no_row(self):
+        db = _make_mock_db()
+        db.execute = AsyncMock(return_value=_scalar_result(None))
+        result = anyio.run(get_key, USER_ID, PROVIDER_ID, db)
+        assert result is None
+
+    def test_returns_row_when_found(self):
+        db = _make_mock_db()
+        row = UserProviderKey()
+        row.user_id = USER_ID
+        row.provider_id = PROVIDER_ID
+        row.encrypted_key = "enc_value"
+        db.execute = AsyncMock(return_value=_scalar_result(row))
+        result = anyio.run(get_key, USER_ID, PROVIDER_ID, db)
+        assert result is row
+
+
+class TestGetActiveKey:
+    def test_returns_none_when_no_key(self):
+        db = _make_mock_db()
+        db.execute = AsyncMock(return_value=_scalar_result(None))
+        result = anyio.run(get_active_key, USER_ID, db)
+        assert result is None
+
+    def test_returns_row_with_encrypted_key(self):
+        db = _make_mock_db()
+        row = UserProviderKey()
+        row.user_id = USER_ID
+        row.encrypted_key = "enc_value"
+        db.execute = AsyncMock(return_value=_scalar_result(row))
+        result = anyio.run(get_active_key, USER_ID, db)
+        assert result is row
+
+
+class TestUpsertKey:
+    def test_inserts_when_no_existing_row(self):
+        db = _make_mock_db()
+        db.execute = AsyncMock(return_value=_scalar_result(None))
+        db.add = MagicMock()
+        db.commit = AsyncMock()
+        db.refresh = AsyncMock()
+
+        anyio.run(upsert_key, USER_ID, PROVIDER_ID, "enc_key", "claude-sonnet-4-6", None, db)
+        db.add.assert_called_once()
+        db.commit.assert_awaited_once()
+
+    def test_updates_when_row_exists(self):
+        db = _make_mock_db()
+        existing = UserProviderKey()
+        existing.encrypted_key = "old_key"
+        existing.model_name = "llama3.2"
+        db.execute = AsyncMock(return_value=_scalar_result(existing))
+        db.commit = AsyncMock()
+        db.refresh = AsyncMock()
+
+        anyio.run(upsert_key, USER_ID, PROVIDER_ID, "new_key", "claude-sonnet-4-6", None, db)
+        assert existing.encrypted_key == "new_key"
+        assert existing.model_name == "claude-sonnet-4-6"
+        db.commit.assert_awaited_once()
+
+
+class TestDeleteKey:
+    def test_sets_encrypted_key_to_none(self):
+        db = _make_mock_db()
+        existing = UserProviderKey()
+        existing.encrypted_key = "some_key"
+        db.execute = AsyncMock(return_value=_scalar_result(existing))
+        db.commit = AsyncMock()
+
+        anyio.run(delete_key, USER_ID, PROVIDER_ID, db)
+        assert existing.encrypted_key is None
+        db.commit.assert_awaited_once()
+
+    def test_no_op_when_no_row(self):
+        db = _make_mock_db()
+        db.execute = AsyncMock(return_value=_scalar_result(None))
+        db.commit = AsyncMock()
+
+        anyio.run(delete_key, USER_ID, PROVIDER_ID, db)
+        db.commit.assert_not_awaited()

--- a/services/budget/tests/test_budget_services.py
+++ b/services/budget/tests/test_budget_services.py
@@ -6,6 +6,7 @@ P2: populate_budget_with_user_details graceful degradation — when inter-servic
     with partial nulls instead of propagating a 500.
 P3: create_budget_with_lines_service — asserts created budget gets status=ai_draft.
 """
+
 import pytest
 from unittest.mock import patch, AsyncMock
 from fastapi.testclient import TestClient
@@ -222,12 +223,8 @@ class TestAiDraftBudgetStatus:
         line = BudgetLineFactory.build(budget_id=budget.id, created_by=USER_ID)
 
         with (
-            patch(
-                "app.services.budget_services.create_budget", return_value=budget
-            ) as mock_create,
-            patch(
-                "app.services.budget_line_services.get_budget", return_value=budget
-            ),
+            patch("app.services.budget_services.create_budget", return_value=budget) as mock_create,
+            patch("app.services.budget_line_services.get_budget", return_value=budget),
             patch(
                 _CATEGORY_LOOKUP,
                 return_value=line.category,
@@ -259,9 +256,7 @@ class TestAiDraftBudgetStatus:
         )
 
         with (
-            patch(
-                "app.services.budget_services.create_budget", return_value=budget
-            ) as mock_create,
+            patch("app.services.budget_services.create_budget", return_value=budget) as mock_create,
             patch(
                 "app.services.budget_services.get_users_by_ids_cached",
                 new_callable=AsyncMock,

--- a/services/users/.env.users.local
+++ b/services/users/.env.users.local
@@ -10,3 +10,4 @@ REDIS_URL=redis://redis:6379/0
 RABBITMQ_URL=amqp://guest:guest@rabbitmq:5672/
 RABBITMQ_EXCHANGE=grandflow.events
 LOG_LEVEL=INFO
+AI_SERVICE_URL=http://ai:8002/api/v1

--- a/services/users/app/api/ai_settings_routes.py
+++ b/services/users/app/api/ai_settings_routes.py
@@ -1,0 +1,52 @@
+import httpx
+from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi.responses import JSONResponse
+
+from app.core.config import settings
+from app.utils.security import get_current_user
+
+router = APIRouter(prefix="/users/me")
+
+
+def _ai_headers(token: str) -> dict:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _forward_error(response: httpx.Response) -> None:
+    if response.status_code >= 400:
+        raise HTTPException(status_code=response.status_code, detail=response.json())
+
+
+@router.get("/ai-settings")
+async def get_ai_settings(current_user: dict = Depends(get_current_user)):
+    async with httpx.AsyncClient() as client:
+        response = await client.get(
+            f"{settings.AI_SERVICE_URL}/ai/settings",
+            headers=_ai_headers(current_user["token"]),
+        )
+    _forward_error(response)
+    return JSONResponse(content=response.json(), status_code=response.status_code)
+
+
+@router.put("/ai-settings")
+async def save_ai_settings(request: Request, current_user: dict = Depends(get_current_user)):
+    body = await request.json()
+    async with httpx.AsyncClient() as client:
+        response = await client.put(
+            f"{settings.AI_SERVICE_URL}/ai/settings",
+            json=body,
+            headers=_ai_headers(current_user["token"]),
+        )
+    _forward_error(response)
+    return JSONResponse(content=response.json(), status_code=response.status_code)
+
+
+@router.delete("/ai-settings/{provider}/key")
+async def clear_ai_key(provider: str, current_user: dict = Depends(get_current_user)):
+    async with httpx.AsyncClient() as client:
+        response = await client.delete(
+            f"{settings.AI_SERVICE_URL}/ai/settings/{provider}/key",
+            headers=_ai_headers(current_user["token"]),
+        )
+    _forward_error(response)
+    return JSONResponse(content=response.json(), status_code=response.status_code)

--- a/services/users/app/core/config.py
+++ b/services/users/app/core/config.py
@@ -22,6 +22,7 @@ class Settings(BaseSettings):
     RABBITMQ_URL: str
     RABBITMQ_EXCHANGE: str
     LOG_LEVEL: str
+    AI_SERVICE_URL: str = "http://localhost:8082/api/v1"
     model_config = SettingsConfigDict(env_file=ENV_FILE, case_sensitive=False, extra="ignore")
 
 

--- a/services/users/main.py
+++ b/services/users/main.py
@@ -2,7 +2,7 @@ import os
 from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
-from app.api import user_routes, customer_routes, auth_routes
+from app.api import user_routes, customer_routes, auth_routes, ai_settings_routes
 from app.db.init_db import init_db
 from fastapi.openapi.utils import get_openapi
 from app.core.config import settings
@@ -63,6 +63,7 @@ instrument_fastapi(app)
 app.include_router(user_routes.router, prefix="/api")
 app.include_router(customer_routes.router, prefix="/api")
 app.include_router(auth_routes.router, prefix="/api")
+app.include_router(ai_settings_routes.router, prefix="/api")
 app.add_route("/metrics", metrics_endpoint, methods=["GET"])
 
 

--- a/services/users/migrations/versions/000003_add_admin_role.py
+++ b/services/users/migrations/versions/000003_add_admin_role.py
@@ -1,0 +1,32 @@
+"""Add admin role to users role check constraint
+
+Revision ID: 000003
+Revises: 000002
+Create Date: 2026-06-24 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = "000003"
+down_revision: Union[str, Sequence[str], None] = "000002"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute("ALTER TABLE users DROP CONSTRAINT IF EXISTS users_role_check")
+    op.execute(
+        "ALTER TABLE users ADD CONSTRAINT users_role_check "
+        "CHECK (role IN ('superuser', 'admin', 'user'))"
+    )
+
+
+def downgrade() -> None:
+    op.execute("ALTER TABLE users DROP CONSTRAINT IF EXISTS users_role_check")
+    op.execute(
+        "ALTER TABLE users ADD CONSTRAINT users_role_check "
+        "CHECK (role IN ('superuser', 'user'))"
+    )

--- a/services/users/migrations/versions/15c513b8d0f9_initial_migration.py
+++ b/services/users/migrations/versions/15c513b8d0f9_initial_migration.py
@@ -5,6 +5,7 @@ Revises:
 Create Date: 2026-06-05 10:55:03.792656
 
 """
+
 from typing import Sequence, Union
 
 from alembic import op
@@ -12,9 +13,8 @@ import sqlalchemy as sa
 from sqlalchemy.dialects.postgresql import ENUM as PgEnum
 import shared
 
-
 # revision identifiers, used by Alembic.
-revision: str = '15c513b8d0f9'
+revision: str = "15c513b8d0f9"
 down_revision: Union[str, Sequence[str], None] = None
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
@@ -32,48 +32,48 @@ def upgrade() -> None:
 
     # customers — type column intentionally omitted; migration 000001 handles it
     op.create_table(
-        'customers',
-        sa.Column('id', shared.db.type_decorators.GUID(), nullable=False),
-        sa.Column('name', sa.String(), nullable=False),
-        sa.Column('country', sa.String(), nullable=False),
-        sa.Column('currency', sa.String(), nullable=False),
-        sa.PrimaryKeyConstraint('id'),
+        "customers",
+        sa.Column("id", shared.db.type_decorators.GUID(), nullable=False),
+        sa.Column("name", sa.String(), nullable=False),
+        sa.Column("country", sa.String(), nullable=False),
+        sa.Column("currency", sa.String(), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
         if_not_exists=True,
     )
     op.execute("CREATE INDEX IF NOT EXISTS ix_customers_id ON customers (id)")
 
     op.create_table(
-        'users',
-        sa.Column('id', shared.db.type_decorators.GUID(), nullable=False),
-        sa.Column('first_name', sa.String(), server_default=sa.text("''"), nullable=False),
-        sa.Column('last_name', sa.String(), server_default=sa.text("''"), nullable=False),
-        sa.Column('email', sa.String(), nullable=False),
-        sa.Column('role', sa.String(), nullable=False),
-        sa.Column('hashed_password', sa.String(), nullable=True),
-        sa.Column('customer_id', shared.db.type_decorators.GUID(), nullable=True),
+        "users",
+        sa.Column("id", shared.db.type_decorators.GUID(), nullable=False),
+        sa.Column("first_name", sa.String(), server_default=sa.text("''"), nullable=False),
+        sa.Column("last_name", sa.String(), server_default=sa.text("''"), nullable=False),
+        sa.Column("email", sa.String(), nullable=False),
+        sa.Column("role", sa.String(), nullable=False),
+        sa.Column("hashed_password", sa.String(), nullable=True),
+        sa.Column("customer_id", shared.db.type_decorators.GUID(), nullable=True),
         sa.Column(
-            'status',
-            PgEnum('active', 'pending', 'disabled', name='userstatus', create_type=False),
+            "status",
+            PgEnum("active", "pending", "disabled", name="userstatus", create_type=False),
             server_default=sa.text("'pending'"),
             nullable=False,
         ),
-        sa.ForeignKeyConstraint(['customer_id'], ['customers.id']),
-        sa.PrimaryKeyConstraint('id'),
+        sa.ForeignKeyConstraint(["customer_id"], ["customers.id"]),
+        sa.PrimaryKeyConstraint("id"),
         if_not_exists=True,
     )
     op.execute("CREATE UNIQUE INDEX IF NOT EXISTS ix_users_email ON users (email)")
     op.execute("CREATE INDEX IF NOT EXISTS ix_users_id ON users (id)")
 
     op.create_table(
-        'user_sessions',
-        sa.Column('id', shared.db.type_decorators.GUID(), nullable=False),
-        sa.Column('user_id', shared.db.type_decorators.GUID(), nullable=False),
-        sa.Column('issued_at', sa.DateTime(), nullable=False),
-        sa.Column('expires_at', sa.DateTime(), nullable=False),
-        sa.Column('revoked', sa.Boolean(), nullable=False),
-        sa.Column('refresh_token_hash', sa.String(), nullable=True),
-        sa.ForeignKeyConstraint(['user_id'], ['users.id']),
-        sa.PrimaryKeyConstraint('id'),
+        "user_sessions",
+        sa.Column("id", shared.db.type_decorators.GUID(), nullable=False),
+        sa.Column("user_id", shared.db.type_decorators.GUID(), nullable=False),
+        sa.Column("issued_at", sa.DateTime(), nullable=False),
+        sa.Column("expires_at", sa.DateTime(), nullable=False),
+        sa.Column("revoked", sa.Boolean(), nullable=False),
+        sa.Column("refresh_token_hash", sa.String(), nullable=True),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"]),
+        sa.PrimaryKeyConstraint("id"),
         if_not_exists=True,
     )
     op.execute("CREATE INDEX IF NOT EXISTS ix_user_sessions_id ON user_sessions (id)")
@@ -82,9 +82,9 @@ def upgrade() -> None:
 def downgrade() -> None:
     """Downgrade schema."""
     op.execute("DROP INDEX IF EXISTS ix_user_sessions_id")
-    op.drop_table('user_sessions')
+    op.drop_table("user_sessions")
     op.execute("DROP INDEX IF EXISTS ix_users_id")
     op.execute("DROP INDEX IF EXISTS ix_users_email")
-    op.drop_table('users')
+    op.drop_table("users")
     op.execute("DROP INDEX IF EXISTS ix_customers_id")
-    op.drop_table('customers')
+    op.drop_table("customers")

--- a/shared/schemas/user_schema.py
+++ b/shared/schemas/user_schema.py
@@ -12,6 +12,7 @@ class UserStatus(str, enum.Enum):
 
 class UserRole(str, enum.Enum):
     superuser = "superuser"
+    admin = "admin"
     user = "user"
 
 


### PR DESCRIPTION
- Add `admin` to UserRole enum with migration
- AES-256-GCM encryption for user API keys (ENCRYPTION_KEY env var)
- AIProvider table: vendor-agnostic provider registry (anthropic, ollama)
- AIModelName enum: finite set of platform-supported models
- UserProviderKey: per-user provider config (key, model, base_url)
- AnthropicProvider via official anthropic SDK with streaming
- resolve_provider: BYOK key → provider, no key → NullProvider (no silent fallbacks)
- Settings routes: GET/PUT/DELETE /ai/settings with role guard (admin/superuser)
- Users service proxies AI settings routes through to AI service
- Frontend Settings page with per-provider cards (model selector, key/URL input)
- 59 tests passing