### PR TITLE
Platform/Issue 105/fix deploy workflow SSH command timeout

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,6 +27,10 @@ jobs:
           host: ${{ secrets.VPS_HOST }}
           username: ${{ secrets.VPS_USER }}
           key: ${{ secrets.VPS_SSH_KEY }}
+          # Default is 10m — the ai service's ML deps (torch, transformers, etc.)
+          # alone take ~15-20m on a cold build; subsequent deploys reuse the
+          # Docker layer cache on the server and are much faster.
+          command_timeout: 40m
           envs: POSTGRES_USER,POSTGRES_PASSWORD,POSTGRES_DB,RABBITMQ_USER,RABBITMQ_PASS,RABBITMQ_URL,USERS_DATABASE_URL,BUDGET_DATABASE_URL,AI_DATABASE_URL,JWT_SECRET_KEY,ENCRYPTION_KEY
           script: |
             set -euo pipefail


### PR DESCRIPTION
First real deploy (#104) failed after ~10 minutes: appleboy/ssh-action defaults to a 10m command_timeout, and the ai service's ML deps (torch, transformers, etc.) alone take ~15-20m on a cold build. Images had actually finished building and were cached before the timeout killed the session, so `docker compose up -d` never ran.

Closes #105