### PR TITLE
Frontend/Issue 108/fix SPA routes 404ing on Vercel

### DIFF
--- a/frontend-typescript/vercel.json
+++ b/frontend-typescript/vercel.json
@@ -1,0 +1,5 @@
+{
+  "rewrites": [
+    { "source": "/(.*)", "destination": "/index.html" }
+  ]
+}


### PR DESCRIPTION
opengrantflow.com/login (and any other client-side route) returned a Vercel 404 — the app uses react-router-dom's BrowserRouter, which needs a server-side rewrite to index.html for direct navigation to work, and there was no vercel.json at all.

Closes #108