### PR TITLE
Platform/Issue 111/terraform provision hetzner server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -226,3 +226,11 @@ docs/Supabase
 openspec/
 frontend-typescript/.env.development
 .env.ovh-secrets.prod
+
+# Terraform — state and real var files contain sensitive data/resource IDs;
+# .terraform.lock.hcl and terraform.tfvars.example ARE committed on purpose.
+terraform/.terraform/
+terraform/*.tfstate
+terraform/*.tfstate.*
+terraform/terraform.tfvars
+terraform/*.auto.tfvars

--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -1,0 +1,23 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hetznercloud/hcloud" {
+  version     = "1.66.1"
+  constraints = "~> 1.48"
+  hashes = [
+    "h1:R+S77AiRWQQnVROR+HNqMXnhX8fDxZVBG1PwlpxGyss=",
+    "zh:113070176eb4fb26a3758b3d1031bb904e34a74f7c4f99f90df2301ca4468a51",
+    "zh:1bfc988bdcd7c9422e09c262c736ad265a205684f0402fa4a83e63c0b08e09ea",
+    "zh:37d92b4cf0f344295b0d780aabbc1408f02db31141cd4408276455a458071e54",
+    "zh:386bd1207b3ed284b513294ddad9b9f59047a693c3aa375605f858f9d9758b58",
+    "zh:43d26f0a4f5a64bf0ade1c5a278b40153d4ae8c77508933b9c8bb7f7860dae6d",
+    "zh:6a1fe681a1706be87f0d03b749f1dc69c838d663c6ab08a00ae8d87be2e4425e",
+    "zh:7032556ae2a74b2e1b7d68add9b96158e4f7202ebb8fbd75e0e8a1581719df7b",
+    "zh:893296927373b4afa7ec3639abb1ebab3c1b6cb9cfe427877cfa7bf69a33480d",
+    "zh:8d58b340e21428a59cc27dc4f5a7fcd2035ee1aa9372c3932f7962647532fe0d",
+    "zh:93509170347bf097ca38e288a6e921811bb769bb2dfac3c339eb2032ae8454c1",
+    "zh:9c00443cb5ae2401089a62e223d7d741eedb04f6a73c357b6a7443b6ae71b0be",
+    "zh:9c356be5ce8cb7b1d83d5cf2276823242f106dbd0c43fe992055f0fa11290f95",
+    "zh:f619116583c7e47751e0baefffca216c83f9f42edf99325121b85ee075db78cc",
+  ]
+}

--- a/terraform/cloud-init.yaml
+++ b/terraform/cloud-init.yaml
@@ -1,0 +1,26 @@
+#cloud-config
+# Fully automates the one-time bootstrap that was previously done by hand over
+# SSH for the OVH VPS (see docs/deployment/DEPLOYMENT_MODES.md §4): create a
+# non-root deploy user, install Docker, clone the repo. No root password or
+# manual SSH session needed at all.
+
+users:
+  - name: deploy
+    groups: [sudo, docker]
+    shell: /bin/bash
+    lock_passwd: true
+    sudo: ["ALL=(ALL) NOPASSWD:ALL"]
+    ssh_authorized_keys:
+      - ${ssh_public_key}
+
+package_update: true
+packages:
+  - gettext-base
+
+runcmd:
+  - curl -fsSL https://get.docker.com | sh
+  - apt-get install -y docker-compose-plugin
+  - usermod -aG docker deploy
+  - mkdir -p /opt/grandflow
+  - chown deploy:deploy /opt/grandflow
+  - su - deploy -c "git clone ${git_repo_url} /opt/grandflow"

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,51 @@
+resource "hcloud_ssh_key" "deploy" {
+  name       = "grantflow-deploy"
+  public_key = var.ssh_public_key
+}
+
+resource "hcloud_firewall" "grandflow" {
+  name = "grandflow-prod"
+
+  rule {
+    direction = "in"
+    protocol  = "tcp"
+    port      = "22"
+    # Open to everyone rather than restricted to var.allowed_ssh_cidrs: the
+    # GitHub Actions deploy workflow (.github/workflows/deploy.yml) needs to
+    # reach this port from GitHub's own runner infrastructure, which has no
+    # stable/predictable IP range. Key-only auth (deploy user has no password
+    # at all) is the actual security boundary here, not IP restriction.
+    source_ips = ["0.0.0.0/0", "::/0"]
+  }
+
+  rule {
+    direction  = "in"
+    protocol   = "tcp"
+    port       = "80"
+    source_ips = ["0.0.0.0/0", "::/0"]
+  }
+
+  rule {
+    direction  = "in"
+    protocol   = "tcp"
+    port       = "443"
+    source_ips = ["0.0.0.0/0", "::/0"]
+  }
+
+  # Everything else (Postgres/Redis/RabbitMQ/raw service ports) is implicitly
+  # denied — Hetzner firewalls default-deny anything not explicitly allowed.
+}
+
+resource "hcloud_server" "grandflow" {
+  name         = "grandflow-prod"
+  server_type  = var.server_type
+  image        = "ubuntu-24.04"
+  location     = var.location
+  ssh_keys     = [hcloud_ssh_key.deploy.id]
+  firewall_ids = [hcloud_firewall.grandflow.id]
+
+  user_data = templatefile("${path.module}/cloud-init.yaml", {
+    ssh_public_key = var.ssh_public_key
+    git_repo_url   = var.git_repo_url
+  })
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,0 +1,9 @@
+output "server_ipv4" {
+  description = "Public IPv4 of the provisioned server — use for the VPS_HOST GitHub secret and the api.opengrantflow.com A record."
+  value       = hcloud_server.grandflow.ipv4_address
+}
+
+output "server_ipv6" {
+  description = "Public IPv6 of the provisioned server."
+  value       = hcloud_server.grandflow.ipv6_address
+}

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -1,0 +1,8 @@
+# Copy to terraform.tfvars (gitignored) and fill in, OR export as TF_VAR_hcloud_token
+# instead of writing the token to disk at all.
+
+hcloud_token = "your-hetzner-project-api-token"
+
+# Defaults in variables.tf are already correct for this project; only override
+# if your IP changes or you want a different server_type/location.
+# allowed_ssh_cidrs = ["203.0.113.5/32"]

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,29 @@
+variable "hcloud_token" {
+  description = "Hetzner Cloud API token (project-scoped). Set via TF_VAR_hcloud_token env var, never committed."
+  type        = string
+  sensitive   = true
+}
+
+variable "ssh_public_key" {
+  description = "Public half of the existing GrandFlow deploy keypair (private half is already the VPS_SSH_KEY GitHub secret)."
+  type        = string
+  default     = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFwx+pb2+mTW+jIVitpWIZ9ZRUvnv4mqWKQDxrDmHKrd github-actions-deploy@grantflow"
+}
+
+variable "server_type" {
+  description = "Hetzner server type."
+  type        = string
+  default     = "cx23"
+}
+
+variable "location" {
+  description = "Hetzner datacenter location."
+  type        = string
+  default     = "hel1"
+}
+
+variable "git_repo_url" {
+  description = "Repo cloned onto the server by cloud-init at first boot."
+  type        = string
+  default     = "https://github.com/arutsh/GrantFlow.git"
+}

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.9"
+
+  required_providers {
+    hcloud = {
+      source  = "hetznercloud/hcloud"
+      version = "~> 1.48"
+    }
+  }
+}
+
+provider "hcloud" {
+  token = var.hcloud_token
+}


### PR DESCRIPTION
Portfolio goal: replace the manually-ordered OVH classic VPS (no Terraform-manageable API surface) with a Hetzner Cloud server that Terraform genuinely owns end-to-end.

- terraform/: hcloud provider, hcloud_ssh_key (reuses the existing deploy keypair already in the VPS_SSH_KEY GitHub secret), hcloud_firewall (80/443 open, 22 open — GitHub Actions' deploy workflow needs to reach SSH from an unpredictable runner IP, so key-only auth is the real security boundary here, not IP restriction), hcloud_server (CX23, Helsinki, cloud-init bootstrap).
- cloud-init.yaml replaces the manual OVH bootstrap (deploy user + docker + ufw + authorized_keys, all typed by hand over SSH) with a fully automated first-boot script — zero manual SSH steps, and `deploy` gets working NOPASSWD sudo (unlike the OVH setup where sudo was effectively broken due to the disabled password).
- docker-compose.prod.yml / Caddyfile / deploy.yml needed zero changes — confirmed provider-agnostic already.
- State kept local (gitignored); remote backend is a noted future upgrade, not needed at this scale.

Verified end-to-end: terraform fmt/init/validate/plan/apply all clean, new server confirmed via SSH (deploy user, docker + sudo groups, /opt/grandflow cloned), deploy workflow now reaches it successfully.

Closes #111