### PR TITLE
Platform/Issue 114/bind postgres to loopback for ssh tunnel access

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -2,7 +2,7 @@ version: "3.9"
 name: grandflow-prod
 
 # ============================================================
-# PRODUCTION MODE: backend only, deployed on the OVH VPS.
+# PRODUCTION MODE: backend only, deployed on Hetzner Cloud (see terraform/).
 # Frontend is hosted separately on Vercel (not part of this stack).
 # The .env.prod (root) and services/*/.env.*.prod files committed in this
 # repo are templates with placeholder secret values — the deploy workflow
@@ -22,6 +22,11 @@ services:
       - POSTGRES_USER=${POSTGRES_USER}
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
       - POSTGRES_DB=${POSTGRES_DB}
+    ports:
+      # Loopback-only — reachable solely from processes on this host (e.g. an
+      # SSH tunnel endpoint for admin DB access), never from the public
+      # internet, regardless of the Hetzner firewall's other rules.
+      - "127.0.0.1:5432:5432"
     volumes:
       - grandflow_prod_data:/var/lib/postgresql/data
       - ./docker/postgres/init-db.sh:/docker-entrypoint-initdb.d/init-db.sh


### PR DESCRIPTION
Enables ad-hoc DB inspection (e.g. VS Code's Postgres extension) via an SSH tunnel: grandflow-db now publishes 127.0.0.1:5432:5432 — loopback-only, so it's reachable solely from processes on the Hetzner box itself, never from the public internet regardless of the firewall's other rules (loopback traffic never reaches the interface those rules apply to).

Also fixed a stale "OVH VPS" reference in the file header comment (migrated to Hetzner in #111/#113).

Closes #114