### PR TITLE
Platform/Issue 115/fix deploy workflow race on overlapping pushes

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,13 @@ on:
     branches: [main]
   workflow_dispatch:
 
+# Two pushes to main close together (e.g. merging two PRs back-to-back) would
+# otherwise trigger overlapping `docker compose up --build` runs on the same
+# box, racing to recreate the same containers — queue them instead of racing.
+concurrency:
+  group: deploy-to-vps
+  cancel-in-progress: false
+
 jobs:
   deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Merging #113 and #114 back-to-back triggered two overlapping `deploy.yml` runs (started 31s apart), both racing to run `docker compose up -d --build` on the same box — the later run failed with a container name conflict recreating `grandflow-beat`.
- Adds a `concurrency` group so overlapping pushes to `main` queue instead of racing.

Closes #115

🤖 Generated with [Claude Code](https://claude.com/claude-code)