### PR TITLE
Platform/Issue 119/fix insecure http redirect location behind caddy

### DIFF
--- a/services/ai/entrypoint.sh
+++ b/services/ai/entrypoint.sh
@@ -15,7 +15,9 @@ alembic upgrade head
 
 echo "Migrations complete. Starting AI service..."
 if [ "$ENV" = "production" ]; then
-  exec uvicorn main:app --host 0.0.0.0 --port 8000
+  # --proxy-headers: trust Caddy's X-Forwarded-Proto so redirects/URLs use
+  # https, not the plain-http scheme of the internal Docker connection.
+  exec uvicorn main:app --host 0.0.0.0 --port 8000 --proxy-headers --forwarded-allow-ips='*'
 else
   exec uvicorn main:app --host 0.0.0.0 --port 8000 --reload
 fi

--- a/services/budget/entrypoint.sh
+++ b/services/budget/entrypoint.sh
@@ -21,7 +21,9 @@ echo "Migrations complete. Starting FastAPI application..."
 
 # Start the FastAPI application
 if [ "$ENV" = "production" ]; then
-  exec uvicorn main:app --host 0.0.0.0 --port 8000
+  # --proxy-headers: trust Caddy's X-Forwarded-Proto so redirects/URLs use
+  # https, not the plain-http scheme of the internal Docker connection.
+  exec uvicorn main:app --host 0.0.0.0 --port 8000 --proxy-headers --forwarded-allow-ips='*'
 else
   exec uvicorn main:app --host 0.0.0.0 --port 8000 --reload
 fi

--- a/services/users/entrypoint.sh
+++ b/services/users/entrypoint.sh
@@ -21,7 +21,9 @@ echo "Migrations complete. Starting FastAPI application..."
 
 # Start the FastAPI application
 if [ "$ENV" = "production" ]; then
-  exec uvicorn main:app --host 0.0.0.0 --port 8000
+  # --proxy-headers: trust Caddy's X-Forwarded-Proto so redirects/URLs use
+  # https, not the plain-http scheme of the internal Docker connection.
+  exec uvicorn main:app --host 0.0.0.0 --port 8000 --proxy-headers --forwarded-allow-ips='*'
 else
   exec uvicorn main:app --host 0.0.0.0 --port 8000 --reload
 fi


### PR DESCRIPTION
## Summary
- Live bug: `POST https://api.opengrantflow.com/api/v1/register` returned a 307 with `Location: http://api.opengrantflow.com/api/register` (plain HTTP) — browsers on an HTTPS page can't follow that.
- Caddy sets `X-Forwarded-Proto: https` correctly, but uvicorn doesn't trust proxy headers by default, so redirect URLs used the scheme of the internal Docker connection (http) instead.
- Adds `--proxy-headers --forwarded-allow-ips='*'` to the production uvicorn invocation in users/budget/ai.

Closes #119

🤖 Generated with [Claude Code](https://claude.com/claude-code)