### PR TITLE
Shared/Issue-89: shared/ai_client library

### DIFF
--- a/.github/workflows/shared.yml
+++ b/.github/workflows/shared.yml
@@ -1,0 +1,50 @@
+name: Shared CI
+
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+    branches: [main, develop]
+
+jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      relevant: ${{ steps.filter.outputs.relevant }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            relevant:
+              - "shared/**"
+
+  shared-test:
+    needs: changes
+    if: needs.changes.outputs.relevant == 'true'
+    runs-on: ubuntu-latest
+    env:
+      LOG_LEVEL: INFO
+      PYTHONPATH: ${{ github.workspace }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r services/ai/requirements.txt
+
+      - name: Lint
+        run: |
+          pip install black flake8
+          black --check shared/ai_client shared/tests
+          flake8 --max-line-length=100 shared/ai_client shared/tests
+
+      - name: Run tests
+        run: python -m pytest shared/tests -v

--- a/shared/ai_client/__init__.py
+++ b/shared/ai_client/__init__.py
@@ -1,0 +1,15 @@
+from shared.ai_client.client import AiClient
+from shared.ai_client.errors import AiClientError, AiRateLimitedError, AiUnavailableError
+from shared.ai_client.schemas import AiDecision, ChatTurn, Reply, ToolCall, ToolDef
+
+__all__ = [
+    "AiClient",
+    "AiClientError",
+    "AiRateLimitedError",
+    "AiUnavailableError",
+    "AiDecision",
+    "ChatTurn",
+    "Reply",
+    "ToolCall",
+    "ToolDef",
+]

--- a/shared/ai_client/client.py
+++ b/shared/ai_client/client.py
@@ -1,0 +1,80 @@
+import asyncio
+
+import httpx
+
+from shared.ai_client.errors import AiClientError, AiRateLimitedError, AiUnavailableError
+from shared.ai_client.schemas import AiDecision, ChatTurn, Reply, ToolCall, ToolDef
+
+
+class AiClient:
+    """Calls ai's stateless `POST /ai/decide` (per `specs/ai-decide/spec.md`).
+
+    One `AiClient` (and its underlying httpx client) is meant to be built
+    once and reused across requests — construction is not per-call.
+    """
+
+    def __init__(
+        self,
+        base_url: str,
+        timeout: float = 60,
+        connect_retries: int = 2,
+        backoff_seconds: float = 0.5,
+        http: httpx.AsyncClient | None = None,
+    ):
+        self.base_url = base_url.rstrip("/")
+        self.connect_retries = connect_retries
+        self.backoff_seconds = backoff_seconds
+        self.http = http if http is not None else httpx.AsyncClient(timeout=timeout)
+
+    async def decide(
+        self,
+        message: str,
+        history: list[ChatTurn],
+        tools: list[ToolDef],
+        domain_context: dict | None,
+        user_token: str,
+    ) -> AiDecision:
+        payload = {
+            "message": message,
+            "conversation_history": [turn.model_dump() for turn in history],
+            "available_tools": [tool.model_dump() for tool in tools],
+            "domain_context": domain_context,
+        }
+        headers = {"Authorization": f"Bearer {user_token}"}
+
+        resp = await self._post_with_retry(payload, headers)
+
+        if resp.status_code == 503:
+            raise AiUnavailableError()
+        if resp.status_code == 429:
+            retry_after = int(resp.headers.get("Retry-After", "0"))
+            raise AiRateLimitedError(retry_after=retry_after)
+        try:
+            resp.raise_for_status()
+        except httpx.HTTPStatusError as exc:
+            raise AiClientError(
+                f"ai service returned {exc.response.status_code}: {exc.response.text[:200]}",
+                status_code=exc.response.status_code,
+            ) from exc
+
+        decision = resp.json()["decision"]
+        if decision["type"] == "tool_call":
+            return ToolCall(name=decision["name"], params=decision["params"])
+        return Reply(text=decision["text"])
+
+    async def _post_with_retry(self, payload: dict, headers: dict) -> httpx.Response:
+        attempt = 0
+        while True:
+            try:
+                return await self.http.post(
+                    f"{self.base_url}/ai/decide", json=payload, headers=headers
+                )
+            except httpx.ConnectError as exc:
+                attempt += 1
+                if attempt > self.connect_retries:
+                    raise AiClientError(f"Could not connect to ai service: {exc}") from exc
+                await asyncio.sleep(self.backoff_seconds * attempt)
+            except httpx.RequestError as exc:
+                # Read timeouts and other non-connect failures are not retried —
+                # LLM calls are not cheap to repeat blindly.
+                raise AiClientError(f"Request to ai service failed: {exc}") from exc

--- a/shared/ai_client/errors.py
+++ b/shared/ai_client/errors.py
@@ -1,0 +1,25 @@
+from fastapi import status
+
+
+class AiClientError(Exception):
+    """Base for all ai_client failures.
+
+    Callers should log at the call site (they have the conversation/tool
+    context this module doesn't) — these classes intentionally carry no
+    logging of their own.
+    """
+
+    def __init__(self, message: str, status_code: int = status.HTTP_502_BAD_GATEWAY):
+        self.message = message
+        self.status_code = status_code
+
+
+class AiUnavailableError(AiClientError):
+    def __init__(self, message: str = "AI provider is unavailable"):
+        super().__init__(message, status_code=status.HTTP_503_SERVICE_UNAVAILABLE)
+
+
+class AiRateLimitedError(AiClientError):
+    def __init__(self, retry_after: int, message: str = "AI provider is rate limited"):
+        super().__init__(message, status_code=status.HTTP_429_TOO_MANY_REQUESTS)
+        self.retry_after = retry_after

--- a/shared/ai_client/schemas.py
+++ b/shared/ai_client/schemas.py
@@ -1,0 +1,58 @@
+from typing import Literal, Union
+
+from pydantic import BaseModel
+
+# Wire contract for POST /ai/decide (specs/ai-decide/spec.md). Both sides of
+# that call import these classes directly — chat as the caller (AiClient),
+# ai as the callee (decide_routes.py) — so there is one source of truth for
+# the request/response shape instead of two hand-kept copies drifting apart.
+
+
+class ToolDef(BaseModel):
+    """One tool chat exposes to ai, as a JSON-schema-shaped description.
+
+    `parameters` is the tool's argument schema (dict, not a Pydantic model)
+    because ai only ever inspects it as JSON to hand to the LLM — it never
+    validates against it, that happens on the chat side once a ToolCall
+    comes back.
+    """
+
+    name: str
+    description: str
+    parameters: dict
+
+
+class ChatTurn(BaseModel):
+    """One replayed turn of conversation history sent to ai.
+
+    role is deliberately just "user"/"assistant" — the two sides of an LLM
+    turn — not an account permission level (admin/superuser live elsewhere,
+    e.g. shared/security, and never belong in this schema).
+    """
+
+    role: Literal["user", "assistant"]
+    content: str
+
+
+class ToolCall(BaseModel):
+    """ai's decision: call this tool with these params.
+
+    ai never supplies resource IDs (e.g. budget_id) — those are injected by
+    chat from the request's context_id, never trusted from the model.
+    """
+
+    name: str
+    params: dict
+
+
+class Reply(BaseModel):
+    """ai's decision: no tool call, just say this back to the user."""
+
+    text: str
+
+
+# The decide() response is always exactly one of these two shapes, tagged by
+# a "type" field on the wire ({"decision": {"type": "tool_call"|"reply", ...}})
+# — AiClient.decide() reads that tag itself rather than relying on Pydantic to
+# guess which model matches.
+AiDecision = Union[ToolCall, Reply]

--- a/shared/tests/conftest.py
+++ b/shared/tests/conftest.py
@@ -1,0 +1,7 @@
+import pytest
+
+
+@pytest.fixture
+def anyio_backend():
+    """Run @pytest.mark.anyio tests on asyncio only (trio isn't installed)."""
+    return "asyncio"

--- a/shared/tests/test_ai_client.py
+++ b/shared/tests/test_ai_client.py
@@ -1,0 +1,134 @@
+"""Tests for shared/ai_client per specs/ai-client/spec.md.
+
+Uses httpx.MockTransport to exercise real httpx exception behavior (connect
+errors vs read timeouts) rather than mocking AsyncClient directly.
+"""
+
+import httpx
+import pytest
+
+from shared.ai_client.client import AiClient
+from shared.ai_client.errors import AiClientError, AiRateLimitedError, AiUnavailableError
+from shared.ai_client.schemas import ChatTurn, Reply, ToolCall, ToolDef
+
+
+def _client(handler, **kwargs) -> AiClient:
+    transport = httpx.MockTransport(handler)
+    http = httpx.AsyncClient(transport=transport)
+    return AiClient(base_url="http://ai-svc", http=http, **kwargs)
+
+
+def _history() -> list[ChatTurn]:
+    return [ChatTurn(role="user", content="hi")]
+
+
+def _tools() -> list[ToolDef]:
+    return [ToolDef(name="create_budget", description="Create a budget", parameters={})]
+
+
+class TestDecisionParsing:
+    @pytest.mark.anyio
+    async def test_tool_call_parsed(self):
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200,
+                json={
+                    "decision": {
+                        "type": "tool_call",
+                        "name": "create_budget",
+                        "params": {"budget_name": "USAID Grant"},
+                    }
+                },
+            )
+
+        client = _client(handler)
+        result = await client.decide("make a budget", _history(), _tools(), None, "tok")
+
+        assert isinstance(result, ToolCall)
+        assert result.name == "create_budget"
+        assert result.params == {"budget_name": "USAID Grant"}
+
+    @pytest.mark.anyio
+    async def test_reply_parsed(self):
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200, json={"decision": {"type": "reply", "text": "What's the funder name?"}}
+            )
+
+        client = _client(handler)
+        result = await client.decide("make a budget", _history(), _tools(), None, "tok")
+
+        assert isinstance(result, Reply)
+        assert result.text == "What's the funder name?"
+
+
+class TestErrorMapping:
+    @pytest.mark.anyio
+    async def test_503_raises_unavailable(self):
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(503, json={"detail": {"code": "no_provider"}})
+
+        client = _client(handler)
+        with pytest.raises(AiUnavailableError):
+            await client.decide("hi", [], [], None, "tok")
+
+    @pytest.mark.anyio
+    async def test_429_raises_rate_limited_with_retry_after(self):
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(429, headers={"Retry-After": "120"})
+
+        client = _client(handler)
+        with pytest.raises(AiRateLimitedError) as exc_info:
+            await client.decide("hi", [], [], None, "tok")
+
+        assert exc_info.value.retry_after == 120
+
+    @pytest.mark.anyio
+    async def test_other_status_raises_ai_client_error(self):
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(500, text="boom")
+
+        client = _client(handler)
+        with pytest.raises(AiClientError):
+            await client.decide("hi", [], [], None, "tok")
+
+
+class TestRetryBehavior:
+    @pytest.mark.anyio
+    async def test_connect_error_retried_then_succeeds(self):
+        calls = {"n": 0}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise httpx.ConnectError("boom", request=request)
+            return httpx.Response(200, json={"decision": {"type": "reply", "text": "ok"}})
+
+        client = _client(handler, connect_retries=2, backoff_seconds=0)
+        result = await client.decide("hi", [], [], None, "tok")
+
+        assert isinstance(result, Reply)
+        assert calls["n"] == 2
+
+    @pytest.mark.anyio
+    async def test_connect_error_exhausts_retries(self):
+        def handler(request: httpx.Request) -> httpx.Response:
+            raise httpx.ConnectError("boom", request=request)
+
+        client = _client(handler, connect_retries=1, backoff_seconds=0)
+        with pytest.raises(AiClientError):
+            await client.decide("hi", [], [], None, "tok")
+
+    @pytest.mark.anyio
+    async def test_read_timeout_not_retried(self):
+        calls = {"n": 0}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            calls["n"] += 1
+            raise httpx.ReadTimeout("timed out", request=request)
+
+        client = _client(handler, connect_retries=2, backoff_seconds=0)
+        with pytest.raises(AiClientError):
+            await client.decide("hi", [], [], None, "tok")
+
+        assert calls["n"] == 1


### PR DESCRIPTION
## Summary
- Adds `shared/ai_client/` — typed request/response contract for ai's `POST /ai/decide` (`ToolDef`/`ChatTurn`/`ToolCall`/`Reply`/`AiDecision`), an error taxonomy (`AiUnavailableError`/`AiRateLimitedError`/`AiClientError`), and `AiClient.decide()` with connect-error-only retry (configurable `connect_retries`/`backoff_seconds`).
- No consumers yet — dead code until `services/chat` (later tickets) and ai's `/ai/decide` (#90) land.
- Adds `.github/workflows/shared.yml`: none of the existing service workflows actually execute `shared/tests/` (they only use `shared/**` as a trigger filter for their own `services/<name>/tests`), so the new tests would otherwise never run in CI.

## Test plan
- [x] `shared/tests/test_ai_client.py` — 8 tests via `httpx.MockTransport`: tool_call/reply parsing, 503→unavailable, 429→rate-limited w/ retry_after, connect-error retried then succeeds, connect-retries exhausted, read-timeout NOT retried
- [x] `black --check` / `flake8 --max-line-length=100` clean on `shared/ai_client` + `shared/tests`
- [x] Verified `shared.yml`'s exact install+test commands locally from repo root

Closes #89

Part of the AI chat migration to the chat-service agent-host architecture.