### PR TITLE
feat: add ai POST /ai/decide stateless decision endpoint

### DIFF
--- a/services/ai/app/api/chat_routes.py
+++ b/services/ai/app/api/chat_routes.py
@@ -1,5 +1,5 @@
 import httpx
-from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi import APIRouter, Depends, Request
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
 
@@ -15,8 +15,8 @@ from app.services.chat_agent import ChatDeps, build_agent
 from app.services.chat_orchestrator import TurnResult
 from app.services.chat_stream import build_chat_sse_stream
 from app.services.provider import ResolvedModel, get_resolved_model
-from app.services.rate_limiter import check_and_increment
-from app.utils.security import get_validated_user
+from app.services.rate_limiter import enforce_rate_limit
+from app.utils.security import get_validated_user, resolve_customer_id
 
 router = APIRouter(prefix="/ai", tags=["AI Chat"])
 
@@ -41,7 +41,7 @@ async def stream_chat(
     resolved: ResolvedModel | None = Depends(get_resolved_model),
 ):
     user_id = str(valid_user["user_id"])
-    customer_id = str(valid_user["customer_id"]) if valid_user.get("customer_id") else user_id
+    customer_id = resolve_customer_id(valid_user)
     token = valid_user.get("token", "")
 
     if resolved is None:
@@ -56,13 +56,7 @@ async def stream_chat(
             _unavailable(), media_type="text/event-stream", headers=_SSE_HEADERS
         )
 
-    allowed, retry_after = await check_and_increment(customer_id)
-    if not allowed:
-        raise HTTPException(
-            status_code=429,
-            detail="Rate limit exceeded. Try again later.",
-            headers={"Retry-After": str(retry_after), **_SSE_HEADERS},
-        )
+    await enforce_rate_limit(customer_id, extra_headers=_SSE_HEADERS)
 
     http_client: httpx.AsyncClient = request.app.state.http_client
 

--- a/services/ai/app/api/decide_routes.py
+++ b/services/ai/app/api/decide_routes.py
@@ -1,0 +1,51 @@
+"""Stateless decision endpoint — specs/ai-decide/spec.md.
+
+The only way domain-facing services (chat, and whatever comes after it)
+obtain LLM reasoning. Holds no conversation state and makes no outbound
+calls to any domain service — BYOK provider resolution and rate limiting
+are the only things this route does beyond calling decide_service.
+"""
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic_ai.exceptions import AgentRunError
+
+from app.core.logging import get_logger
+from app.services.decide_service import decide
+from app.services.provider import ResolvedModel, get_resolved_model
+from app.services.rate_limiter import enforce_rate_limit
+from app.utils.security import get_validated_user, resolve_customer_id
+from shared.ai_client.schemas import DecideRequest, ToolCall
+
+logger = get_logger(__name__)
+
+router = APIRouter(prefix="/ai", tags=["AI Decide"])
+
+
+@router.post("/decide")
+async def decide_route(
+    body: DecideRequest,
+    valid_user=Depends(get_validated_user),
+    resolved: ResolvedModel | None = Depends(get_resolved_model),
+):
+    customer_id = resolve_customer_id(valid_user)
+
+    if resolved is None:
+        raise HTTPException(status_code=503, detail={"code": "no_provider"})
+
+    await enforce_rate_limit(customer_id)
+
+    try:
+        decision = await decide(
+            resolved_model=resolved,
+            message=body.message,
+            history=body.conversation_history,
+            tools=body.available_tools,
+            domain_context=body.domain_context,
+        )
+    except AgentRunError as exc:
+        logger.error("decide_model_error", customer_id=customer_id, error=str(exc))
+        raise HTTPException(status_code=502, detail={"code": "model_error"}) from exc
+
+    if isinstance(decision, ToolCall):
+        return {"decision": {"type": "tool_call", "name": decision.name, "params": decision.params}}
+    return {"decision": {"type": "reply", "text": decision.text}}

--- a/services/ai/app/api/parse_routes.py
+++ b/services/ai/app/api/parse_routes.py
@@ -1,11 +1,11 @@
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends
 from fastapi.responses import StreamingResponse
 
 from app.core.config import settings
 from app.services.parse_service import build_parse_stream
 from app.services.provider import ResolvedModel, get_resolved_model
-from app.services.rate_limiter import check_and_increment
-from app.utils.security import get_validated_user
+from app.services.rate_limiter import enforce_rate_limit
+from app.utils.security import get_validated_user, resolve_customer_id
 
 router = APIRouter(prefix="/ai", tags=["AI"])
 
@@ -22,18 +22,9 @@ async def stream_parse_budget(
     resolved: ResolvedModel | None = Depends(get_resolved_model),
 ):
     user_id = str(valid_user["user_id"])
-    customer_id = str(valid_user["customer_id"]) if valid_user.get("customer_id") else user_id
+    customer_id = resolve_customer_id(valid_user)
 
-    allowed, retry_after = await check_and_increment(customer_id)
-    if not allowed:
-        raise HTTPException(
-            status_code=429,
-            detail="Rate limit exceeded. Try again later.",
-            headers={
-                "Retry-After": str(retry_after),
-                **_SSE_HEADERS,
-            },
-        )
+    await enforce_rate_limit(customer_id, extra_headers=_SSE_HEADERS)
 
     if resolved is None:
 

--- a/services/ai/app/api/settings_routes.py
+++ b/services/ai/app/api/settings_routes.py
@@ -9,7 +9,7 @@ from app.db.session import AsyncSessionLocal
 from app.models.ai_provider import AIModelName
 from app.services.provider import _REGISTRY
 from app.utils.encryption import encrypt
-from app.utils.security import get_validated_user
+from app.utils.security import get_validated_user, resolve_customer_id
 
 router = APIRouter(prefix="/ai/settings", tags=["AI Settings"])
 
@@ -98,7 +98,7 @@ async def save_ai_settings(
     await _validate_key_with_provider(provider.name, provider.key_prefix, body.key)
     encrypted = encrypt(body.key, settings.ENCRYPTION_KEY) if body.key else None
     user_id = str(valid_user["user_id"])
-    customer_id = str(valid_user["customer_id"]) if valid_user.get("customer_id") else user_id
+    customer_id = resolve_customer_id(valid_user)
     await upsert_key(
         user_id=user_id,
         provider_id=str(provider.id),

--- a/services/ai/app/services/decide_service.py
+++ b/services/ai/app/services/decide_service.py
@@ -1,0 +1,133 @@
+"""Stateless decision service backing POST /ai/decide (specs/ai-decide/spec.md).
+
+Builds a fresh PydanticAI Agent per request (same key-isolation pattern as
+chat_agent.build_agent), exposes the caller-supplied tools as an
+ExternalToolset (tools this agent never executes itself), and classifies the
+result as either a tool call or a plain-text reply. No conversation state is
+held between calls, and no domain service is ever contacted from here.
+"""
+
+from dataclasses import replace
+
+from pydantic_ai import Agent, DeferredToolRequests, ExternalToolset, ToolDefinition
+from pydantic_ai.exceptions import UnexpectedModelBehavior
+from pydantic_ai.messages import ModelRequest, ModelResponse, TextPart, UserPromptPart
+
+from app.services.provider import ResolvedModel
+from shared.ai_client.schemas import AiDecision, ChatTurn, Reply, ToolCall, ToolDef
+
+# ExternalToolset hardcodes max_retries=0 per tool, so a malformed or
+# schema-invalid tool call raises immediately instead of letting the model
+# self-correct. Retrying is only worth it where it's free: self-hosted
+# providers with no per-call billing. Anthropic is deliberately absent — a
+# retry there re-bills the customer's own BYOK key for another completion.
+_TOOL_CALL_RETRIES_BY_PROVIDER = {
+    "ollama": 3,
+}
+
+
+class _RetryableExternalToolset(ExternalToolset):
+    """ExternalToolset with a configurable per-tool retry budget.
+
+    ExternalToolset.get_tools() always returns max_retries=0 with no
+    constructor override, so this re-stamps each tool after the fact.
+    """
+
+    def __init__(self, tool_defs: list[ToolDefinition], *, max_retries: int):
+        super().__init__(tool_defs=tool_defs)
+        self._max_retries = max_retries
+
+    async def get_tools(self, ctx):
+        tools = await super().get_tools(ctx)
+        return {name: replace(tool, max_retries=self._max_retries) for name, tool in tools.items()}
+
+
+SYSTEM_PROMPT = """You are a domain-neutral decision engine used by several different services.
+Given the user's message, the conversation so far, and a list of tools you may call, decide ONE
+of the following:
+- Call at most one tool, and only when every one of its required parameters is already known from
+  the message or conversation history.
+- Otherwise, reply in plain text — ask for whatever information is missing, or answer directly if
+  no tool applies to what the user asked.
+
+Never invent a parameter value the user did not provide. Never call more than one tool per turn.
+Your plain-text replies are shown to the user verbatim: natural language only, no JSON, no tool
+names, no code blocks."""
+
+
+def _history_to_model_messages(history: list[ChatTurn]) -> list[ModelRequest | ModelResponse]:
+    """Bridge chat's plain role/content pairs into pydantic-ai's own message envelopes.
+
+    pydantic-ai needs ModelRequest (things sent to the model) / ModelResponse
+    (things the model said) rather than flat dicts, since it has to
+    losslessly re-serialize history for whichever provider is active. Only
+    plain text is ever replayed here — no prior tool calls, no attachments —
+    so a single part per turn is enough.
+    """
+    messages: list[ModelRequest | ModelResponse] = []
+    for turn in history:
+        if turn.role == "user":
+            messages.append(ModelRequest(parts=[UserPromptPart(content=turn.content)]))
+        else:
+            messages.append(ModelResponse(parts=[TextPart(content=turn.content)]))
+    return messages
+
+
+def _build_toolset(tools: list[ToolDef], provider_name: str) -> ExternalToolset:
+    tool_defs = [
+        ToolDefinition(
+            name=tool.name,
+            description=tool.description,
+            parameters_json_schema=tool.parameters,
+        )
+        for tool in tools
+    ]
+    max_retries = _TOOL_CALL_RETRIES_BY_PROVIDER.get(provider_name, 0)
+    return _RetryableExternalToolset(tool_defs, max_retries=max_retries)
+
+
+def build_agent(resolved_model: ResolvedModel, tools: list[ToolDef]) -> "Agent[None, str]":
+    """Return a fresh Agent bound to the resolved model and this request's toolset.
+
+    A new Agent (and toolset) is built per request so the model (Anthropic
+    key / Ollama URL) is never shared across requests.
+    """
+    agent = Agent(
+        resolved_model.model,
+        toolsets=[_build_toolset(tools, resolved_model.provider_name)],
+        output_type=[str, DeferredToolRequests],
+        system_prompt=SYSTEM_PROMPT,
+        model_settings={"temperature": 0.1},
+        retries=3,
+    )
+    agent.instrument = True
+    return agent
+
+
+async def decide(
+    resolved_model: ResolvedModel,
+    message: str,
+    history: list[ChatTurn],
+    tools: list[ToolDef],
+    domain_context: dict | None,
+) -> AiDecision:
+    """Classify one turn: a tool call (with params) or a plain-text reply."""
+    if domain_context:
+        message = f"[context: {domain_context}]\n{message}"
+
+    agent = build_agent(resolved_model, tools)
+    message_history = _history_to_model_messages(history)
+
+    result = await agent.run(message, message_history=message_history)
+    output = result.output
+
+    if isinstance(output, str):
+        return Reply(text=output)
+
+    if len(output.calls) > 1:
+        raise UnexpectedModelBehavior(
+            f"model requested {len(output.calls)} tool calls in one turn, expected at most 1"
+        )
+
+    call = output.calls[0]
+    return ToolCall(name=call.tool_name, params=call.args_as_dict())

--- a/services/ai/app/services/provider.py
+++ b/services/ai/app/services/provider.py
@@ -6,7 +6,7 @@ from pydantic_ai.models.anthropic import AnthropicModel
 from pydantic_ai.models.openai import OpenAIChatModel
 
 from app.core.logging import get_logger
-from app.utils.security import get_validated_user
+from app.utils.security import get_validated_user, resolve_customer_id
 
 logger = get_logger(__name__)
 
@@ -93,8 +93,7 @@ async def get_resolved_model(
     from app.crud.user_provider_key import get_active_key_for_customer
     from app.db.session import AsyncSessionLocal
 
-    user_id = str(valid_user["user_id"])
-    customer_id = str(valid_user["customer_id"]) if valid_user.get("customer_id") else user_id
+    customer_id = resolve_customer_id(valid_user)
 
     async with AsyncSessionLocal() as db:
         user_key = await get_active_key_for_customer(customer_id, db)

--- a/services/ai/app/services/rate_limiter.py
+++ b/services/ai/app/services/rate_limiter.py
@@ -1,4 +1,6 @@
 import redis.asyncio as aioredis
+from fastapi import HTTPException
+
 from app.core.config import settings
 from app.core.logging import get_logger
 
@@ -34,3 +36,14 @@ async def check_and_increment(customer_id: str, limit: int | None = None) -> tup
     except Exception:
         logger.warning("rate_limiter_unavailable", customer_id=customer_id)
         return True, 0
+
+
+async def enforce_rate_limit(customer_id: str, *, extra_headers: dict | None = None) -> None:
+    """Raise 429 with a Retry-After header when the customer is over their hourly limit."""
+    allowed, retry_after = await check_and_increment(customer_id)
+    if not allowed:
+        raise HTTPException(
+            status_code=429,
+            detail="Rate limit exceeded. Try again later.",
+            headers={"Retry-After": str(retry_after), **(extra_headers or {})},
+        )

--- a/services/ai/app/utils/security.py
+++ b/services/ai/app/utils/security.py
@@ -1,1 +1,9 @@
 from shared.security.dependencies import get_validated_user  # noqa: F401
+
+
+def resolve_customer_id(valid_user: dict) -> str:
+    """The tenant/billing identity for a request: customer_id, falling back to
+    user_id for superusers, who aren't linked to a customer.
+    """
+    customer_id = valid_user.get("customer_id")
+    return str(customer_id) if customer_id else str(valid_user["user_id"])

--- a/services/ai/main.py
+++ b/services/ai/main.py
@@ -9,7 +9,7 @@ from opentelemetry.instrumentation.redis import RedisInstrumentor
 from opentelemetry.instrumentation.sqlalchemy import SQLAlchemyInstrumentor
 from opentelemetry.sdk.trace import TracerProvider as SDKTracerProvider
 
-from app.api import chat_routes, parse_routes, settings_routes
+from app.api import chat_routes, decide_routes, parse_routes, settings_routes
 from app.core.config import settings
 from app.core.logging import setup_logging, get_logger
 from app.db.session import engine
@@ -54,6 +54,7 @@ instrument_fastapi(app)
 app.include_router(parse_routes.router, prefix="/api/v1")
 app.include_router(settings_routes.router, prefix="/api/v1")
 app.include_router(chat_routes.router, prefix="/api/v1")
+app.include_router(decide_routes.router, prefix="/api/v1")
 app.add_route("/metrics", metrics_endpoint, methods=["GET"])
 
 

--- a/services/ai/tests/test_chat_routes.py
+++ b/services/ai/tests/test_chat_routes.py
@@ -22,7 +22,7 @@ def _happy_route(fake_session, turn):
     session_local = MagicMock()
     session_local.return_value.__aenter__.return_value = AsyncMock()
     with (
-        patch("app.api.chat_routes.check_and_increment", AsyncMock(return_value=(True, 0))),
+        patch("app.services.rate_limiter.check_and_increment", AsyncMock(return_value=(True, 0))),
         patch("app.api.chat_routes.AsyncSessionLocal", session_local),
         patch(
             "app.api.chat_routes.get_or_create_session", AsyncMock(return_value=fake_session)
@@ -48,7 +48,7 @@ class TestStreamChat:
     def test_rate_limiter(self, make_client):
         client = make_client(resolved=True)
         with patch(
-            "app.api.chat_routes.check_and_increment", AsyncMock(return_value=(False, 3600))
+            "app.services.rate_limiter.check_and_increment", AsyncMock(return_value=(False, 3600))
         ):
             resp = client.post("/api/v1/ai/chat/stream", json={"message": "hi"})
         assert resp.status_code == 429

--- a/services/ai/tests/test_decide_routes.py
+++ b/services/ai/tests/test_decide_routes.py
@@ -1,0 +1,83 @@
+from unittest.mock import AsyncMock, patch
+
+from pydantic_ai.exceptions import UnexpectedModelBehavior
+
+from shared.ai_client.schemas import Reply, ToolCall
+
+
+def _body(**overrides) -> dict:
+    body = {
+        "message": "create a budget",
+        "conversation_history": [],
+        "available_tools": [],
+        "domain_context": None,
+    }
+    body.update(overrides)
+    return body
+
+
+class TestDecideRoute:
+    def test_unavailable_when_no_provider(self, make_client):
+        client = make_client(resolved=None)
+        resp = client.post("/api/v1/ai/decide", json=_body())
+        assert resp.status_code == 503
+        assert resp.json()["detail"]["code"] == "no_provider"
+
+    def test_rate_limited(self, make_client):
+        client = make_client(resolved=True)
+        with patch(
+            "app.services.rate_limiter.check_and_increment", AsyncMock(return_value=(False, 120))
+        ):
+            resp = client.post("/api/v1/ai/decide", json=_body())
+        assert resp.status_code == 429
+        assert resp.headers["Retry-After"] == "120"
+
+    def test_tool_call_decision(self, make_client):
+        client = make_client(resolved=True)
+        decision = ToolCall(name="create_budget", params={"budget_name": "USAID Grant"})
+        with (
+            patch(
+                "app.services.rate_limiter.check_and_increment", AsyncMock(return_value=(True, 0))
+            ),
+            patch("app.api.decide_routes.decide", AsyncMock(return_value=decision)),
+        ):
+            resp = client.post("/api/v1/ai/decide", json=_body())
+
+        assert resp.status_code == 200
+        assert resp.json() == {
+            "decision": {
+                "type": "tool_call",
+                "name": "create_budget",
+                "params": {"budget_name": "USAID Grant"},
+            }
+        }
+
+    def test_model_error_returns_502(self, make_client):
+        client = make_client(resolved=True)
+        with (
+            patch(
+                "app.services.rate_limiter.check_and_increment", AsyncMock(return_value=(True, 0))
+            ),
+            patch(
+                "app.api.decide_routes.decide",
+                AsyncMock(side_effect=UnexpectedModelBehavior("tool exceeded max retries")),
+            ),
+        ):
+            resp = client.post("/api/v1/ai/decide", json=_body())
+
+        assert resp.status_code == 502
+        assert resp.json()["detail"]["code"] == "model_error"
+
+    def test_reply_decision(self, make_client):
+        client = make_client(resolved=True)
+        decision = Reply(text="What's the funder name?")
+        with (
+            patch(
+                "app.services.rate_limiter.check_and_increment", AsyncMock(return_value=(True, 0))
+            ),
+            patch("app.api.decide_routes.decide", AsyncMock(return_value=decision)),
+        ):
+            resp = client.post("/api/v1/ai/decide", json=_body())
+
+        assert resp.status_code == 200
+        assert resp.json() == {"decision": {"type": "reply", "text": "What's the funder name?"}}

--- a/services/ai/tests/test_decide_service.py
+++ b/services/ai/tests/test_decide_service.py
@@ -1,0 +1,167 @@
+import pytest
+from pydantic_ai.exceptions import UnexpectedModelBehavior
+from pydantic_ai.messages import ModelResponse, TextPart, ToolCallPart
+from pydantic_ai.models.function import AgentInfo, FunctionModel
+
+from app.services.decide_service import decide
+from app.services.provider import ResolvedModel
+from shared.ai_client.schemas import ChatTurn, Reply, ToolCall, ToolDef
+
+CREATE_BUDGET_TOOL = ToolDef(
+    name="create_budget",
+    description="Create a new budget",
+    parameters={
+        "type": "object",
+        "properties": {"budget_name": {"type": "string"}},
+        "required": ["budget_name"],
+    },
+)
+DELETE_BUDGET_TOOL = ToolDef(
+    name="delete_budget",
+    description="Delete a budget",
+    parameters={
+        "type": "object",
+        "properties": {"budget_id": {"type": "string"}},
+        "required": ["budget_id"],
+    },
+)
+
+
+def _resolved(model) -> ResolvedModel:
+    return ResolvedModel(model=model, provider_name="test", model_name="test")
+
+
+class TestDecideToolCall:
+    @pytest.mark.anyio
+    async def test_tool_schema_reaches_model(self):
+        seen: dict = {}
+
+        def respond(messages, agent_info: AgentInfo) -> ModelResponse:
+            seen["tools"] = agent_info.function_tools
+            return ModelResponse(parts=[TextPart(content="ok")])
+
+        await decide(
+            resolved_model=_resolved(FunctionModel(respond)),
+            message="hi",
+            history=[],
+            tools=[CREATE_BUDGET_TOOL],
+            domain_context=None,
+        )
+
+        assert len(seen["tools"]) == 1
+        assert seen["tools"][0].name == "create_budget"
+        assert seen["tools"][0].parameters_json_schema == CREATE_BUDGET_TOOL.parameters
+
+    @pytest.mark.anyio
+    async def test_deferred_call_maps_to_tool_call(self):
+        def respond(messages, agent_info: AgentInfo) -> ModelResponse:
+            return ModelResponse(
+                parts=[
+                    ToolCallPart(
+                        tool_name="create_budget",
+                        args={"budget_name": "USAID Grant"},
+                        tool_call_id="call-1",
+                    )
+                ]
+            )
+
+        result = await decide(
+            resolved_model=_resolved(FunctionModel(respond)),
+            message="make a budget called USAID Grant",
+            history=[],
+            tools=[CREATE_BUDGET_TOOL],
+            domain_context=None,
+        )
+
+        assert isinstance(result, ToolCall)
+        assert result.name == "create_budget"
+        assert result.params == {"budget_name": "USAID Grant"}
+
+    @pytest.mark.anyio
+    async def test_multiple_tool_calls_raises(self):
+        def respond(messages, agent_info: AgentInfo) -> ModelResponse:
+            return ModelResponse(
+                parts=[
+                    ToolCallPart(
+                        tool_name="create_budget",
+                        args={"budget_name": "USAID Grant"},
+                        tool_call_id="call-1",
+                    ),
+                    ToolCallPart(
+                        tool_name="delete_budget",
+                        args={"budget_id": "b-1"},
+                        tool_call_id="call-2",
+                    ),
+                ]
+            )
+
+        with pytest.raises(UnexpectedModelBehavior):
+            await decide(
+                resolved_model=_resolved(FunctionModel(respond)),
+                message="make a budget then delete another",
+                history=[],
+                tools=[CREATE_BUDGET_TOOL, DELETE_BUDGET_TOOL],
+                domain_context=None,
+            )
+
+
+class TestDecideReply:
+    @pytest.mark.anyio
+    async def test_text_output_maps_to_reply(self):
+        def respond(messages, agent_info: AgentInfo) -> ModelResponse:
+            return ModelResponse(parts=[TextPart(content="What's the funder name?")])
+
+        result = await decide(
+            resolved_model=_resolved(FunctionModel(respond)),
+            message="make a budget",
+            history=[],
+            tools=[CREATE_BUDGET_TOOL],
+            domain_context=None,
+        )
+
+        assert isinstance(result, Reply)
+        assert result.text == "What's the funder name?"
+
+    @pytest.mark.anyio
+    async def test_history_is_replayed(self):
+        seen: dict = {}
+
+        def respond(messages, agent_info: AgentInfo) -> ModelResponse:
+            seen["messages"] = messages
+            return ModelResponse(parts=[TextPart(content="ok")])
+
+        history = [
+            ChatTurn(role="user", content="hi"),
+            ChatTurn(role="assistant", content="hello, how can I help?"),
+        ]
+        await decide(
+            resolved_model=_resolved(FunctionModel(respond)),
+            message="make a budget",
+            history=history,
+            tools=[],
+            domain_context=None,
+        )
+
+        # 2 replayed history messages + 1 new request message
+        assert len(seen["messages"]) == 3
+
+    @pytest.mark.anyio
+    async def test_domain_context_folded_into_message(self):
+        seen: dict = {}
+
+        def respond(messages, agent_info: AgentInfo) -> ModelResponse:
+            seen["messages"] = messages
+            return ModelResponse(parts=[TextPart(content="ok")])
+
+        await decide(
+            resolved_model=_resolved(FunctionModel(respond)),
+            message="add a line",
+            history=[],
+            tools=[],
+            domain_context={"page": "budgets", "context_id": "b-1"},
+        )
+
+        last_request = seen["messages"][-1]
+        prompt_part = last_request.parts[-1]
+        assert "b-1" in prompt_part.content
+        assert "add a line" in prompt_part.content

--- a/services/ai/tests/test_parse_route.py
+++ b/services/ai/tests/test_parse_route.py
@@ -57,7 +57,7 @@ class TestParseBudgetStream:
     def test_null_provider_stream_returns_unavailable_event(self):
         app.dependency_overrides[get_resolved_model] = lambda: None
         with patch(
-            "app.api.parse_routes.check_and_increment", new=AsyncMock(return_value=(True, 0))
+            "app.services.rate_limiter.check_and_increment", new=AsyncMock(return_value=(True, 0))
         ):
             response = client.get("/api/v1/ai/parse-budget/stream?text=test")
         assert response.status_code == 200

--- a/services/ai/tests/test_rate_limiter.py
+++ b/services/ai/tests/test_rate_limiter.py
@@ -116,7 +116,7 @@ class TestRateLimiterEndpoint:
         app.dependency_overrides[get_resolved_model] = lambda: None
         client = TestClient(app)
 
-        with patch("app.api.parse_routes.check_and_increment", _fake_check):
+        with patch("app.services.rate_limiter.check_and_increment", _fake_check):
             response = client.get("/api/v1/ai/parse-budget/stream?text=test")
 
         app.dependency_overrides = {}

--- a/services/ai/tests/test_sse_endpoint.py
+++ b/services/ai/tests/test_sse_endpoint.py
@@ -32,7 +32,7 @@ _VALID_OUTPUT = {
 
 _LOAD_PROMPT = "app.services.parse_service.load_prompt"
 _AUDIT = "app.services.parse_service.write_audit_log"
-_RATE = "app.api.parse_routes.check_and_increment"
+_RATE = "app.services.rate_limiter.check_and_increment"
 _AGENT = "app.services.parse_service.Agent"
 
 

--- a/shared/ai_client/__init__.py
+++ b/shared/ai_client/__init__.py
@@ -1,6 +1,6 @@
 from shared.ai_client.client import AiClient
 from shared.ai_client.errors import AiClientError, AiRateLimitedError, AiUnavailableError
-from shared.ai_client.schemas import AiDecision, ChatTurn, Reply, ToolCall, ToolDef
+from shared.ai_client.schemas import AiDecision, ChatTurn, DecideRequest, Reply, ToolCall, ToolDef
 
 __all__ = [
     "AiClient",
@@ -9,6 +9,7 @@ __all__ = [
     "AiUnavailableError",
     "AiDecision",
     "ChatTurn",
+    "DecideRequest",
     "Reply",
     "ToolCall",
     "ToolDef",

--- a/shared/ai_client/client.py
+++ b/shared/ai_client/client.py
@@ -1,9 +1,10 @@
 import asyncio
 
 import httpx
+from pydantic import ValidationError
 
 from shared.ai_client.errors import AiClientError, AiRateLimitedError, AiUnavailableError
-from shared.ai_client.schemas import AiDecision, ChatTurn, Reply, ToolCall, ToolDef
+from shared.ai_client.schemas import AiDecision, ChatTurn, DecideRequest, Reply, ToolCall, ToolDef
 
 
 class AiClient:
@@ -34,12 +35,15 @@ class AiClient:
         domain_context: dict | None,
         user_token: str,
     ) -> AiDecision:
-        payload = {
-            "message": message,
-            "conversation_history": [turn.model_dump() for turn in history],
-            "available_tools": [tool.model_dump() for tool in tools],
-            "domain_context": domain_context,
-        }
+        try:
+            payload = DecideRequest(
+                message=message,
+                conversation_history=history,
+                available_tools=tools,
+                domain_context=domain_context,
+            ).model_dump()
+        except ValidationError as exc:
+            raise AiClientError(f"Invalid decide() request: {exc}") from exc
         headers = {"Authorization": f"Bearer {user_token}"}
 
         resp = await self._post_with_retry(payload, headers)

--- a/shared/ai_client/schemas.py
+++ b/shared/ai_client/schemas.py
@@ -56,3 +56,14 @@ class Reply(BaseModel):
 # — AiClient.decide() reads that tag itself rather than relying on Pydantic to
 # guess which model matches.
 AiDecision = Union[ToolCall, Reply]
+
+
+class DecideRequest(BaseModel):
+    """Request body for POST /ai/decide — decide_routes.py uses this directly
+    as its FastAPI request model, so the two sides can never drift apart.
+    """
+
+    message: str
+    conversation_history: list[ChatTurn]
+    available_tools: list[ToolDef]
+    domain_context: dict | None = None

--- a/shared/tests/test_ai_client.py
+++ b/shared/tests/test_ai_client.py
@@ -92,6 +92,15 @@ class TestErrorMapping:
         with pytest.raises(AiClientError):
             await client.decide("hi", [], [], None, "tok")
 
+    @pytest.mark.anyio
+    async def test_invalid_request_raises_ai_client_error(self):
+        def handler(request: httpx.Request) -> httpx.Response:
+            raise AssertionError("should not reach the network for an invalid request")
+
+        client = _client(handler)
+        with pytest.raises(AiClientError):
+            await client.decide("hi", None, [], None, "tok")  # type: ignore[arg-type]
+
 
 class TestRetryBehavior:
     @pytest.mark.anyio


### PR DESCRIPTION
Implements the stateless decision endpoint per specs/ai-decide/spec.md: a per-request PydanticAI Agent exposing caller-supplied tools as an ExternalToolset, BYOK provider resolution (503 no_provider), and rate limiting (429). shared/ai_client gains DecideRequest as the single source of truth for the wire contract between chat's AiClient and this route.

Hardening found in review: model failures now surface as 502 instead of an unhandled 500; a model returning more than one tool call in a turn raises instead of silently dropping the extras; malformed tool-call args get a retry budget only for self-hosted providers (Ollama) where a retry doesn't re-bill the customer's own BYOK key; and invalid AiClient.decide() input raises AiClientError instead of a raw pydantic ValidationError. Also centralizes customer_id resolution and rate-limit enforcement, which this ticket had reintroduced as duplicated per-route logic.