### PR TITLE
feat: Add report and report line services, models, and routes

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -6,3 +6,6 @@ check_untyped_defs = True
 
 [mypy-app.*]
 ignore_errors = False
+
+[mypy-dateutil.*]
+ignore_missing_imports = True

--- a/openspec/changes/budget-reports/tasks.md
+++ b/openspec/changes/budget-reports/tasks.md
@@ -28,25 +28,25 @@ Workflow rule: **one group = one GitHub ticket = one PR, merged before the next 
 
 ## 3. Report submission lifecycle — ticket #146 (`Budget/Issue-146/report-submission-lifecycle`)
 
-- [ ] 3.1 Create `services/budget/app/models/report.py` with `ReportStatus` enum and `ReportModel`, `ReportLineModel`, mirroring `budget.py`'s `AuditMixin`/GUID style
-- [ ] 3.2 Add `reports` relationship to `BudgetModel` in `services/budget/app/models/budget.py`
-- [ ] 3.3 Register the new models in `services/budget/app/models/__init__.py`
-- [ ] 3.4 Write Alembic migration `000004_add_reports_report_lines.py` (down_revision `000003`) creating `reports`, `report_lines`, with matching `downgrade()`
-- [ ] 3.5 Run `alembic upgrade head` / `alembic downgrade -1` locally to verify the migration applies and reverses cleanly
-- [ ] 3.6 Add `shared/schemas/report_schema.py` (`ReportStatus`, `ReportBase/Create/Update`, `Report`, `ReportWithLines`)
-- [ ] 3.7 Add `shared/schemas/report_line_schema.py` (`ReportLineBase/Create/Update`, `ReportLine`)
-- [ ] 3.8 Add thin re-export modules in `services/budget/app/schemas/` for both, and update `services/budget/app/schemas/__init__.py`
-- [ ] 3.9 Add `services/budget/app/crud/report_crud.py` (create/get/list/update/delete/transition_status)
-- [ ] 3.10 Add `services/budget/app/crud/report_line_crud.py` (create/get/list/update/delete)
-- [ ] 3.11 Add `services/budget/app/services/report_services.py`: create (rejects unless `budget.status == confirmed`; defaults `period_start`/`period_end` to the budget's full span — `budget.start_date` through `budget.start_date + duration_months` — when not supplied; rejects if the resulting period overlaps any other report already existing for the same budget, regardless of that report's status), get/list/update/delete, `submit_report_service` (draft→submitted), `review_report_service` (submitted→approved/rejected; authorization is the user matching `budget.funding_customer_id` when set, else the budget owner when `funding_customer_id` is `None`), reopen (rejected→draft)
-- [ ] 3.12 Add `services/budget/app/services/report_line_services.py`: create/get/list/update/delete, enforcing draft-only lock and same-budget cross-check between `budget_line_id` and the report's budget
-- [ ] 3.13 Add `services/budget/app/api/report_routes.py`: CRUD + `POST /{id}/submit` + `POST /{id}/review`
-- [ ] 3.14 Add `services/budget/app/api/report_line_routes.py`: CRUD + `GET /by-report/{report_id}`
-- [ ] 3.15 Register both routers in `services/budget/main.py`
-- [ ] 3.16 Add `services/budget/tests/factories/report.py`: `ReportFactory`, `ReportLineFactory`
-- [ ] 3.17 Add `services/budget/tests/test_report_routes.py`: CRUD, permission checks (owner/funder/neither), report creation rejected against a non-`confirmed` budget, report creation defaults period to the budget's full span when omitted, report creation rejected on period overlap (including against a `rejected` report) and allowed on non-overlapping periods regardless of status, submit transition, review transition (funder-only enforcement when `funding_customer_id` is set, owner self-review when it is not)
-- [ ] 3.18 Add `services/budget/tests/test_report_line_routes.py`: create/update rejected on non-draft report, cross-budget `budget_line_id` rejected
-- [ ] 3.19 Run `pytest services/budget` and `flake8 --max-line-length=100`; PR merged
+- [x] 3.1 Create `services/budget/app/models/report.py` with `ReportStatus` enum and `ReportModel`, `ReportLineModel`, mirroring `budget.py`'s `AuditMixin`/GUID style
+- [x] 3.2 Add `reports` relationship to `BudgetModel` in `services/budget/app/models/budget.py`
+- [x] 3.3 Register the new models in `services/budget/app/models/__init__.py`
+- [x] 3.4 Write Alembic migration `000005_add_reports_report_lines.py` (down_revision `000004`) creating `reports`, `report_lines`, with matching `downgrade()`
+- [x] 3.5 Run `alembic upgrade head` / `alembic downgrade -1` locally to verify the migration applies and reverses cleanly
+- [x] 3.6 Add `shared/schemas/report_schema.py` (`ReportStatus`, `ReportBase/Create/Update`, `Report`, `ReportWithLines`, `ReportReviewRequest`)
+- [x] 3.7 Add `shared/schemas/report_line_schema.py` (`ReportLineBase/Create/Update`, `ReportLine`)
+- [x] 3.8 Add thin re-export modules in `services/budget/app/schemas/` for both, and update `services/budget/app/schemas/__init__.py`
+- [x] 3.9 Add `services/budget/app/crud/report_crud.py` (create/get/list/update/delete/transition_status/list_overlapping_reports)
+- [x] 3.10 Add `services/budget/app/crud/report_line_crud.py` (create/get/list/update/delete)
+- [x] 3.11 Add `services/budget/app/services/report_services.py`: create (rejects unless `budget.status == confirmed`; defaults `period_start`/`period_end` to the budget's full span — `budget.start_date` through `budget.start_date + duration_months` — when not supplied; rejects if the resulting period overlaps any other report already existing for the same budget, regardless of that report's status), get/list/update/delete, `submit_report_service` (draft→submitted), `review_report_service` (submitted→approved/rejected; authorization is the user matching `budget.funding_customer_id` when set, else the budget owner when `funding_customer_id` is `None`), reopen (rejected→draft)
+- [x] 3.12 Add `services/budget/app/services/report_line_services.py`: create/get/list/update/delete, enforcing draft-only lock and same-budget cross-check between `budget_line_id` and the report's budget
+- [x] 3.13 Add `services/budget/app/api/report_routes.py`: CRUD + `POST /{id}/submit` + `POST /{id}/review` + `POST /{id}/reopen` (added beyond the original list — required to expose `reopen_report_service`/the spec's "rejected → draft" transition through the API at all)
+- [x] 3.14 Add `services/budget/app/api/report_line_routes.py`: CRUD + `GET /by-report/{report_id}`
+- [x] 3.15 Register both routers in `services/budget/main.py`
+- [x] 3.16 Add `services/budget/tests/factories/report.py`: `ReportFactory`, `ReportLineFactory`
+- [x] 3.17 Add `services/budget/tests/test_report_routes.py`: CRUD, permission checks (owner/funder/neither), report creation rejected against a non-`confirmed` budget, report creation defaults period to the budget's full span when omitted, report creation rejected on period overlap (including against a `rejected` report) and allowed on non-overlapping periods regardless of status, submit transition, review transition (funder-only enforcement when `funding_customer_id` is set, owner self-review when it is not) — 33 tests, mostly real-sqlite-session service-layer tests plus a thin TestClient wiring class. Also covers two bugs a review pass caught (neither had spec.md coverage, which only tested full-omission/full-supply of the period): partial period supply silently defaulting to the full span instead of being rejected, and no `period_end >= period_start` check letting a partial update save an inverted period.
+- [x] 3.18 Add `services/budget/tests/test_report_line_routes.py`: create/update rejected on non-draft report, cross-budget `budget_line_id` rejected — 10 tests
+- [ ] 3.19 Run `pytest services/budget` and `flake8 --max-line-length=100`; PR merged — tests/flake8/black(`./app`)/mypy all verified clean (125/125 tests), **but no PR has been opened or merged yet** — leaving this unchecked until that actually happens, per this file's own one-ticket-one-PR workflow rule.
 
 ## 4. Report attachments — ticket #147 (`Budget/Issue-147/report-attachments`)
 

--- a/services/budget/app/api/report_line_routes.py
+++ b/services/budget/app/api/report_line_routes.py
@@ -1,0 +1,66 @@
+# /services/budget/app/api/report_line_routes.py
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+from typing import List
+from uuid import UUID
+
+from app.db.session import SessionLocal
+from app.schemas.report_line_schema import ReportLine, ReportLineCreate, ReportLineUpdate
+from app.services.report_line_services import (
+    create_report_line_service,
+    get_report_line_by_id_service,
+    list_report_lines_service,
+    update_report_line_service,
+    delete_report_line_service,
+)
+from shared.security.dependencies import get_validated_user  # noqa: F401
+
+router = APIRouter(prefix="/report-lines", tags=["Report Lines"])
+
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+@router.post("/", response_model=ReportLine)
+def create_report_line_view(
+    report_line: ReportLineCreate,
+    db: Session = Depends(get_db),
+    valid_user=Depends(get_validated_user),
+):
+    return create_report_line_service(db, valid_user, report_line)
+
+
+@router.get("/by-report/{report_id}", response_model=List[ReportLine])
+def list_report_lines_by_report_view(
+    report_id: UUID, db: Session = Depends(get_db), valid_user=Depends(get_validated_user)
+):
+    return list_report_lines_service(db, valid_user, report_id)
+
+
+@router.get("/{report_line_id}", response_model=ReportLine)
+def get_report_line_view(
+    report_line_id: UUID, db: Session = Depends(get_db), valid_user=Depends(get_validated_user)
+):
+    return get_report_line_by_id_service(db, valid_user, report_line_id)
+
+
+@router.patch("/{report_line_id}", response_model=ReportLine)
+def update_report_line_view(
+    report_line_id: UUID,
+    report_line: ReportLineUpdate,
+    db: Session = Depends(get_db),
+    valid_user=Depends(get_validated_user),
+):
+    return update_report_line_service(db, valid_user, report_line_id, report_line)
+
+
+@router.delete("/{report_line_id}")
+def delete_report_line_view(
+    report_line_id: UUID, db: Session = Depends(get_db), valid_user=Depends(get_validated_user)
+):
+    return {"success": delete_report_line_service(db, valid_user, report_line_id)}

--- a/services/budget/app/api/report_routes.py
+++ b/services/budget/app/api/report_routes.py
@@ -1,0 +1,99 @@
+# /services/budget/app/api/report_routes.py
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+from typing import List
+from uuid import UUID
+
+from app.db.session import SessionLocal
+from app.schemas.report_schema import (
+    Report,
+    ReportCreate,
+    ReportUpdate,
+    ReportWithLines,
+    ReportReviewRequest,
+)
+from app.services.report_services import (
+    create_report_service,
+    get_report_service,
+    list_reports_service,
+    update_report_service,
+    delete_report_service,
+    submit_report_service,
+    review_report_service,
+    reopen_report_service,
+)
+from shared.security.dependencies import get_validated_user  # noqa: F401
+
+router = APIRouter(prefix="/reports", tags=["Reports"])
+
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+@router.post("/", response_model=Report)
+def create_report_view(
+    report: ReportCreate,
+    db: Session = Depends(get_db),
+    valid_user=Depends(get_validated_user),
+):
+    return create_report_service(db, valid_user, report)
+
+
+@router.get("/by-budget/{budget_id}", response_model=List[Report])
+def list_reports_by_budget_view(
+    budget_id: UUID, db: Session = Depends(get_db), valid_user=Depends(get_validated_user)
+):
+    return list_reports_service(db, valid_user, budget_id)
+
+
+@router.get("/{report_id}", response_model=ReportWithLines)
+def get_report_view(
+    report_id: UUID, db: Session = Depends(get_db), valid_user=Depends(get_validated_user)
+):
+    return get_report_service(db, valid_user, report_id)
+
+
+@router.patch("/{report_id}", response_model=Report)
+def update_report_view(
+    report_id: UUID,
+    report: ReportUpdate,
+    db: Session = Depends(get_db),
+    valid_user=Depends(get_validated_user),
+):
+    return update_report_service(db, valid_user, report_id, report)
+
+
+@router.delete("/{report_id}")
+def delete_report_view(
+    report_id: UUID, db: Session = Depends(get_db), valid_user=Depends(get_validated_user)
+):
+    return {"success": delete_report_service(db, valid_user, report_id)}
+
+
+@router.post("/{report_id}/submit", response_model=Report)
+def submit_report_view(
+    report_id: UUID, db: Session = Depends(get_db), valid_user=Depends(get_validated_user)
+):
+    return submit_report_service(db, valid_user, report_id)
+
+
+@router.post("/{report_id}/review", response_model=Report)
+def review_report_view(
+    report_id: UUID,
+    review: ReportReviewRequest,
+    db: Session = Depends(get_db),
+    valid_user=Depends(get_validated_user),
+):
+    return review_report_service(db, valid_user, report_id, review.decision, review.review_notes)
+
+
+@router.post("/{report_id}/reopen", response_model=Report)
+def reopen_report_view(
+    report_id: UUID, db: Session = Depends(get_db), valid_user=Depends(get_validated_user)
+):
+    return reopen_report_service(db, valid_user, report_id)

--- a/services/budget/app/crud/report_crud.py
+++ b/services/budget/app/crud/report_crud.py
@@ -1,0 +1,103 @@
+from datetime import date, datetime, timezone
+
+from sqlalchemy.orm import Session
+from app.models.report import ReportModel
+from app.schemas.report_schema import ReportStatus
+from uuid import UUID
+
+
+def create_report(
+    session: Session,
+    user_id: UUID,
+    budget_id: UUID,
+    name: str,
+    period_start: date,
+    period_end: date,
+) -> ReportModel:
+    report = ReportModel(
+        budget_id=budget_id,
+        name=name,
+        period_start=period_start,
+        period_end=period_end,
+        status=ReportStatus.draft,
+        created_by=user_id,
+        updated_by=user_id,
+    )
+    session.add(report)
+    session.commit()
+    session.refresh(report)
+    return report
+
+
+def get_report(session: Session, report_id: UUID) -> ReportModel | None:
+    return session.query(ReportModel).filter(ReportModel.id == report_id).first()
+
+
+def list_reports(session: Session, budget_id: UUID | None = None) -> list[ReportModel]:
+    query = session.query(ReportModel)
+    if budget_id:
+        query = query.filter(ReportModel.budget_id == budget_id)
+    return query.all()
+
+
+def list_overlapping_reports(
+    session: Session,
+    budget_id: UUID,
+    period_start: date,
+    period_end: date,
+    exclude_report_id: UUID | None = None,
+) -> list[ReportModel]:
+    """Any report for this budget whose period overlaps the given range,
+    regardless of status — the non-overlap rule applies to all reports."""
+    query = session.query(ReportModel).filter(
+        ReportModel.budget_id == budget_id,
+        ReportModel.period_start <= period_end,
+        ReportModel.period_end >= period_start,
+    )
+    if exclude_report_id:
+        query = query.filter(ReportModel.id != exclude_report_id)
+    return query.all()
+
+
+def update_report(
+    session: Session,
+    report: ReportModel,
+    name: str | None = None,
+    period_start: date | None = None,
+    period_end: date | None = None,
+) -> ReportModel:
+    if name is not None:
+        report.name = name
+    if period_start is not None:
+        report.period_start = period_start
+    if period_end is not None:
+        report.period_end = period_end
+    session.commit()
+    session.refresh(report)
+    return report
+
+
+def delete_report(session: Session, report: ReportModel) -> bool:
+    session.delete(report)
+    session.commit()
+    return True
+
+
+def transition_status(
+    session: Session,
+    report: ReportModel,
+    new_status: ReportStatus,
+    user_id: UUID | None = None,
+    review_notes: str | None = None,
+) -> ReportModel:
+    report.status = new_status
+    now = datetime.now(timezone.utc)
+    if new_status == ReportStatus.submitted:
+        report.submitted_at = now
+    elif new_status in (ReportStatus.approved, ReportStatus.rejected):
+        report.reviewed_at = now
+        report.reviewed_by = user_id
+        report.review_notes = review_notes
+    session.commit()
+    session.refresh(report)
+    return report

--- a/services/budget/app/crud/report_line_crud.py
+++ b/services/budget/app/crud/report_line_crud.py
@@ -1,0 +1,62 @@
+from sqlalchemy.orm import Session
+from app.models.report import ReportLineModel
+from uuid import UUID
+
+
+def create_report_line(
+    session: Session,
+    user_id: UUID,
+    report_id: UUID,
+    budget_line_id: UUID,
+    description: str,
+    amount: float,
+    extra_fields: dict | None = None,
+) -> ReportLineModel:
+    report_line = ReportLineModel(
+        report_id=report_id,
+        budget_line_id=budget_line_id,
+        description=description,
+        amount=amount,
+        extra_fields=extra_fields,
+        created_by=user_id,
+        updated_by=user_id,
+    )
+    session.add(report_line)
+    session.commit()
+    session.refresh(report_line)
+    return report_line
+
+
+def get_report_line(session: Session, report_line_id: UUID) -> ReportLineModel | None:
+    return session.query(ReportLineModel).filter(ReportLineModel.id == report_line_id).first()
+
+
+def list_report_lines(session: Session, report_id: UUID | None = None) -> list[ReportLineModel]:
+    query = session.query(ReportLineModel)
+    if report_id:
+        query = query.filter(ReportLineModel.report_id == report_id)
+    return query.all()
+
+
+def update_report_line(
+    session: Session,
+    report_line: ReportLineModel,
+    description: str | None = None,
+    amount: float | None = None,
+    extra_fields: dict | None = None,
+) -> ReportLineModel:
+    if description is not None:
+        report_line.description = description
+    if amount is not None:
+        report_line.amount = amount
+    if extra_fields is not None:
+        report_line.extra_fields = {**(report_line.extra_fields or {}), **extra_fields}
+    session.commit()
+    session.refresh(report_line)
+    return report_line
+
+
+def delete_report_line(session: Session, report_line: ReportLineModel) -> bool:
+    session.delete(report_line)
+    session.commit()
+    return True

--- a/services/budget/app/models/__init__.py
+++ b/services/budget/app/models/__init__.py
@@ -7,6 +7,7 @@ from app.models.mapping import (
 )
 from app.models.budget_templates import UploadedTemplateModel, TemplateToBudgetMappingModel
 from app.models.user_cache import UserProfileModel
+from app.models.report import ReportModel, ReportLineModel
 
 __all__ = [
     "BudgetModel",
@@ -18,4 +19,6 @@ __all__ = [
     "TemplateToBudgetMappingModel",
     "SemanticFieldMappingModel",
     "UserProfileModel",
+    "ReportModel",
+    "ReportLineModel",
 ]

--- a/services/budget/app/models/budget.py
+++ b/services/budget/app/models/budget.py
@@ -14,6 +14,7 @@ from app.schemas.budget_schema import BudgetStatus
 
 if TYPE_CHECKING:
     from app.models.mapping import DonorTemplateModel
+    from app.models.report import ReportModel, ReportLineModel
 
 
 class BudgetModel(Base, AuditMixin):
@@ -49,6 +50,7 @@ class BudgetModel(Base, AuditMixin):
     lines: Mapped[list["BudgetLineModel"]] = relationship(
         "BudgetLineModel", back_populates="budget"
     )
+    reports: Mapped[list["ReportModel"]] = relationship("ReportModel", back_populates="budget")
 
 
 class BudgetLineModel(Base, AuditMixin):
@@ -70,6 +72,9 @@ class BudgetLineModel(Base, AuditMixin):
     budget: Mapped["BudgetModel"] = relationship("BudgetModel", back_populates="lines")
     category: Mapped["BudgetCategoryModel"] = relationship(
         "BudgetCategoryModel", back_populates="lines"
+    )
+    report_lines: Mapped[list["ReportLineModel"]] = relationship(
+        "ReportLineModel", back_populates="budget_line"
     )
 
 

--- a/services/budget/app/models/report.py
+++ b/services/budget/app/models/report.py
@@ -1,0 +1,66 @@
+# /services/budget/app/models/report.py
+from __future__ import annotations
+import uuid
+from datetime import date, datetime
+from sqlalchemy import String, ForeignKey, Float, JSON, Date, DateTime, Enum as SQLEnum, text
+from sqlalchemy.orm import relationship, Mapped, mapped_column
+from app.utils.db import GUID
+
+from app.models.base import Base
+
+from shared.db.audit_mixin import AuditMixin
+from typing import TYPE_CHECKING
+from app.schemas.report_schema import ReportStatus
+
+if TYPE_CHECKING:
+    from app.models.budget import BudgetModel, BudgetLineModel
+
+
+class ReportModel(Base, AuditMixin):
+    __tablename__ = "reports"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        GUID(),
+        primary_key=True,
+        index=True,
+        default=lambda: str(uuid.uuid4()),
+    )
+    budget_id: Mapped[uuid.UUID] = mapped_column(GUID(), ForeignKey("budgets.id"), nullable=False)
+    name: Mapped[str] = mapped_column(String, nullable=False)
+    status: Mapped[ReportStatus] = mapped_column(
+        SQLEnum(ReportStatus, name="report_status"),
+        nullable=False,
+        default=ReportStatus.draft,
+        server_default=text(f"'{ReportStatus.draft.value}'"),
+    )
+    period_start: Mapped[date] = mapped_column(Date, nullable=False)
+    period_end: Mapped[date] = mapped_column(Date, nullable=False)
+    submitted_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    reviewed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    reviewed_by: Mapped[uuid.UUID | None] = mapped_column(GUID(), nullable=True)
+    review_notes: Mapped[str | None] = mapped_column(String, nullable=True)
+
+    budget: Mapped["BudgetModel"] = relationship("BudgetModel", back_populates="reports")
+    lines: Mapped[list["ReportLineModel"]] = relationship(
+        "ReportLineModel", back_populates="report"
+    )
+
+
+class ReportLineModel(Base, AuditMixin):
+    __tablename__ = "report_lines"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        GUID(), primary_key=True, index=True, default=lambda: uuid.uuid4()
+    )
+    report_id: Mapped[uuid.UUID] = mapped_column(GUID(), ForeignKey("reports.id"), nullable=False)
+    budget_line_id: Mapped[uuid.UUID] = mapped_column(
+        GUID(), ForeignKey("budget_lines.id"), nullable=False
+    )
+    description: Mapped[str | None] = mapped_column(String, nullable=True)
+    amount: Mapped[float | None] = mapped_column(Float, nullable=True)
+    extra_fields: Mapped[dict | None] = mapped_column(JSON, nullable=True, default=dict)
+
+    report: Mapped["ReportModel"] = relationship("ReportModel", back_populates="lines")
+    budget_line: Mapped["BudgetLineModel"] = relationship(
+        "BudgetLineModel", back_populates="report_lines"
+    )

--- a/services/budget/app/schemas/__init__.py
+++ b/services/budget/app/schemas/__init__.py
@@ -1,3 +1,12 @@
 from .budget_line_schema import BudgetLine, BudgetLineCreate, BudgetLineUpdate  # noqa: F401
 from .budget_schema import Budget, BudgetCreate  # noqa: F401
 from .budget_line_schema import BudgetCategory, BudgetCategoryCreate  # noqa: F401
+from .report_schema import (  # noqa: F401
+    ReportStatus,
+    Report,
+    ReportCreate,
+    ReportUpdate,
+    ReportWithLines,
+    ReportReviewRequest,
+)
+from .report_line_schema import ReportLine, ReportLineCreate, ReportLineUpdate  # noqa: F401

--- a/services/budget/app/schemas/report_line_schema.py
+++ b/services/budget/app/schemas/report_line_schema.py
@@ -1,0 +1,4 @@
+from shared.schemas.report_line_schema import ReportLineBase  # noqa: F401
+from shared.schemas.report_line_schema import ReportLineCreate  # noqa: F401
+from shared.schemas.report_line_schema import ReportLineUpdate  # noqa: F401
+from shared.schemas.report_line_schema import ReportLine  # noqa: F401

--- a/services/budget/app/schemas/report_schema.py
+++ b/services/budget/app/schemas/report_schema.py
@@ -1,0 +1,7 @@
+from shared.schemas.report_schema import ReportStatus  # noqa: F401
+from shared.schemas.report_schema import ReportBase  # noqa: F401
+from shared.schemas.report_schema import ReportCreate  # noqa: F401
+from shared.schemas.report_schema import ReportUpdate  # noqa: F401
+from shared.schemas.report_schema import Report  # noqa: F401
+from shared.schemas.report_schema import ReportWithLines  # noqa: F401
+from shared.schemas.report_schema import ReportReviewRequest  # noqa: F401

--- a/services/budget/app/services/report_line_services.py
+++ b/services/budget/app/services/report_line_services.py
@@ -1,0 +1,93 @@
+from fastapi import status
+from uuid import UUID
+
+from app.crud.budget_line_crud import get_budget_line
+from app.crud.report_line_crud import (
+    create_report_line,
+    get_report_line,
+    list_report_lines,
+    update_report_line,
+    delete_report_line,
+)
+from app.core.exceptions import DomainError
+from app.schemas.report_schema import ReportStatus
+from app.schemas.report_line_schema import ReportLineCreate, ReportLineUpdate
+from app.services.report_services import (
+    _get_owned_report,
+    _get_viewable_budget,
+    _get_report_or_404,
+)
+
+
+def _get_report_line_or_404(db, report_line_id: UUID):
+    report_line = get_report_line(db, report_line_id)
+    if not report_line:
+        raise DomainError("Report Line Not found", status.HTTP_400_BAD_REQUEST)
+    return report_line
+
+
+def create_report_line_service(db, valid_user: dict, report_line: ReportLineCreate):
+    report = _get_owned_report(db, valid_user, report_line.report_id)
+    if report.status != ReportStatus.draft:
+        raise DomainError(
+            "Report lines can only be added to a draft report", status.HTTP_400_BAD_REQUEST
+        )
+
+    budget_line = get_budget_line(db, report_line.budget_line_id)
+    if not budget_line or budget_line.budget_id != report.budget_id:
+        raise DomainError(
+            "budget_line_id must belong to the same budget as the report",
+            status.HTTP_400_BAD_REQUEST,
+        )
+
+    return create_report_line(
+        session=db,
+        user_id=valid_user["user_id"],
+        report_id=report.id,
+        budget_line_id=report_line.budget_line_id,
+        description=report_line.description,
+        amount=report_line.amount,
+        extra_fields=report_line.extra_fields,
+    )
+
+
+def get_report_line_by_id_service(db, valid_user: dict, report_line_id: UUID):
+    report_line = _get_report_line_or_404(db, report_line_id)
+    report = _get_report_or_404(db, report_line.report_id)
+    _get_viewable_budget(db, valid_user, report.budget_id)
+    return report_line
+
+
+def list_report_lines_service(db, valid_user: dict, report_id: UUID):
+    report = _get_report_or_404(db, report_id)
+    _get_viewable_budget(db, valid_user, report.budget_id)
+    return list_report_lines(db, report_id=report_id)
+
+
+def update_report_line_service(
+    db, valid_user: dict, report_line_id: UUID, report_line_update: ReportLineUpdate
+):
+    report_line = _get_report_line_or_404(db, report_line_id)
+    report = _get_owned_report(db, valid_user, report_line.report_id)
+    if report.status != ReportStatus.draft:
+        raise DomainError(
+            "Report lines can only be edited on a draft report", status.HTTP_400_BAD_REQUEST
+        )
+
+    return update_report_line(
+        session=db,
+        report_line=report_line,
+        description=report_line_update.description,
+        amount=report_line_update.amount,
+        extra_fields=report_line_update.extra_fields,
+    )
+
+
+def delete_report_line_service(db, valid_user: dict, report_line_id: UUID):
+    report_line = _get_report_line_or_404(db, report_line_id)
+    report = _get_owned_report(db, valid_user, report_line.report_id)
+    if report.status != ReportStatus.draft:
+        raise DomainError(
+            "Report lines can only be deleted on a draft report", status.HTTP_400_BAD_REQUEST
+        )
+    return delete_report_line(db, report_line)

--- a/services/budget/app/services/report_services.py
+++ b/services/budget/app/services/report_services.py
@@ -1,0 +1,205 @@
+from dateutil.relativedelta import relativedelta
+from fastapi import status
+from uuid import UUID
+
+from app.crud.budget_crud import get_budget
+from app.crud.report_crud import (
+    create_report,
+    get_report,
+    list_reports,
+    list_overlapping_reports,
+    update_report,
+    delete_report,
+    transition_status,
+)
+from app.core.exceptions import DomainError, PermissionDenied
+from app.models.budget import BudgetModel
+from app.schemas.budget_schema import BudgetStatus
+from app.schemas.report_schema import ReportCreate, ReportUpdate, ReportStatus
+from app.services.budget_services import _can_view_budget
+
+
+def _get_report_or_404(db, report_id: UUID):
+    report = get_report(db, report_id)
+    if not report:
+        raise DomainError("Report Not found", status.HTTP_400_BAD_REQUEST)
+    return report
+
+
+def _get_budget_or_404(db, budget_id: UUID) -> BudgetModel:
+    budget = get_budget(db, budget_id)
+    if not budget:
+        raise DomainError("Budget Not found", status.HTTP_400_BAD_REQUEST)
+    return budget
+
+
+def _get_viewable_budget(db, valid_user: dict, budget_id: UUID) -> BudgetModel:
+    budget = _get_budget_or_404(db, budget_id)
+    if valid_user["role"] != "superuser" and not _can_view_budget(budget, valid_user):
+        raise DomainError("Budget Not found", status.HTTP_400_BAD_REQUEST)
+    return budget
+
+
+def _is_owner(budget: BudgetModel, valid_user: dict) -> bool:
+    return valid_user["role"] == "superuser" or str(budget.owner_id) == str(
+        valid_user.get("customer_id")
+    )
+
+
+def _can_review(budget: BudgetModel, valid_user: dict) -> bool:
+    if valid_user["role"] == "superuser":
+        return True
+    customer_id = valid_user.get("customer_id")
+    if budget.funding_customer_id:
+        return str(budget.funding_customer_id) == str(customer_id)
+    return str(budget.owner_id) == str(customer_id)
+
+
+def _validate_period(period_start, period_end) -> None:
+    if period_end < period_start:
+        raise DomainError("period_end cannot be before period_start", status.HTTP_400_BAD_REQUEST)
+
+
+def _get_owned_report(db, valid_user: dict, report_id: UUID):
+    report = _get_report_or_404(db, report_id)
+    budget = _get_viewable_budget(db, valid_user, report.budget_id)
+    if not _is_owner(budget, valid_user):
+        raise PermissionDenied()
+    return report
+
+
+def create_report_service(db, valid_user: dict, report: ReportCreate):
+    budget = _get_viewable_budget(db, valid_user, report.budget_id)
+
+    if budget.status != BudgetStatus.confirmed:
+        raise DomainError(
+            "Reports can only be created against a confirmed budget",
+            status.HTTP_400_BAD_REQUEST,
+        )
+
+    period_start = report.period_start
+    period_end = report.period_end
+    if bool(period_start) != bool(period_end):
+        raise DomainError(
+            "period_start and period_end must be provided together, or neither",
+            status.HTTP_400_BAD_REQUEST,
+        )
+    if not period_start and not period_end:
+        if not budget.start_date:
+            # update_budget_service enforces start_date before confirming a budget,
+            # but this guards against any future path that sets confirmed directly.
+            raise DomainError(
+                "Budget has no start_date set; cannot default the report period",
+                status.HTTP_400_BAD_REQUEST,
+            )
+        period_start = budget.start_date
+        period_end = budget.start_date + relativedelta(months=budget.duration_months or 0)
+
+    _validate_period(period_start, period_end)
+
+    overlapping = list_overlapping_reports(db, budget.id, period_start, period_end)
+    if overlapping:
+        raise DomainError(
+            "Report period overlaps an existing report for this budget",
+            status.HTTP_400_BAD_REQUEST,
+        )
+
+    return create_report(
+        session=db,
+        user_id=valid_user["user_id"],
+        budget_id=budget.id,
+        name=report.name,
+        period_start=period_start,
+        period_end=period_end,
+    )
+
+
+def get_report_service(db, valid_user: dict, report_id: UUID):
+    report = _get_report_or_404(db, report_id)
+    _get_viewable_budget(db, valid_user, report.budget_id)
+    return report
+
+
+def list_reports_service(db, valid_user: dict, budget_id: UUID):
+    _get_viewable_budget(db, valid_user, budget_id)
+    return list_reports(db, budget_id=budget_id)
+
+
+def update_report_service(db, valid_user: dict, report_id: UUID, report_update: ReportUpdate):
+    report = _get_owned_report(db, valid_user, report_id)
+    if report.status != ReportStatus.draft:
+        raise DomainError("Only a draft report can be updated", status.HTTP_400_BAD_REQUEST)
+
+    period_start = report_update.period_start or report.period_start
+    period_end = report_update.period_end or report.period_end
+    if report_update.period_start or report_update.period_end:
+        _validate_period(period_start, period_end)
+        overlapping = list_overlapping_reports(
+            db, report.budget_id, period_start, period_end, exclude_report_id=report.id
+        )
+        if overlapping:
+            raise DomainError(
+                "Report period overlaps an existing report for this budget",
+                status.HTTP_400_BAD_REQUEST,
+            )
+
+    return update_report(
+        session=db,
+        report=report,
+        name=report_update.name,
+        period_start=report_update.period_start,
+        period_end=report_update.period_end,
+    )
+
+
+def delete_report_service(db, valid_user: dict, report_id: UUID):
+    report = _get_owned_report(db, valid_user, report_id)
+    if report.status != ReportStatus.draft:
+        raise DomainError("Only a draft report can be deleted", status.HTTP_400_BAD_REQUEST)
+    return delete_report(db, report)
+
+
+def submit_report_service(db, valid_user: dict, report_id: UUID):
+    report = _get_owned_report(db, valid_user, report_id)
+    if report.status != ReportStatus.draft:
+        raise DomainError("Only a draft report can be submitted", status.HTTP_400_BAD_REQUEST)
+    return transition_status(db, report, ReportStatus.submitted)
+
+
+def review_report_service(
+    db,
+    valid_user: dict,
+    report_id: UUID,
+    decision: ReportStatus,
+    review_notes: str | None = None,
+):
+    if decision not in (ReportStatus.approved, ReportStatus.rejected):
+        raise DomainError(
+            "Review decision must be approved or rejected", status.HTTP_400_BAD_REQUEST
+        )
+
+    report = _get_report_or_404(db, report_id)
+    # Visibility gate first (owner-or-funder), same info-hiding as every other
+    # report endpoint: a total stranger gets "not found", not a permission
+    # error that would confirm the report exists. Only a user who can already
+    # see the report (but isn't the funder) reaches the review-specific check
+    # below and gets PermissionDenied — that discloses nothing new to them.
+    budget = _get_viewable_budget(db, valid_user, report.budget_id)
+    if not _can_review(budget, valid_user):
+        raise PermissionDenied()
+
+    if report.status != ReportStatus.submitted:
+        raise DomainError("Only a submitted report can be reviewed", status.HTTP_400_BAD_REQUEST)
+
+    return transition_status(
+        db, report, decision, user_id=valid_user["user_id"], review_notes=review_notes
+    )
+
+
+def reopen_report_service(db, valid_user: dict, report_id: UUID):
+    report = _get_owned_report(db, valid_user, report_id)
+    if report.status != ReportStatus.rejected:
+        raise DomainError(
+            "Only a rejected report can be reopened to draft", status.HTTP_400_BAD_REQUEST
+        )
+    return transition_status(db, report, ReportStatus.draft)

--- a/services/budget/main.py
+++ b/services/budget/main.py
@@ -2,7 +2,13 @@
 import os
 from contextlib import asynccontextmanager
 from fastapi import FastAPI
-from app.api import budget_routes, budget_line_routes, mapping_routes
+from app.api import (
+    budget_routes,
+    budget_line_routes,
+    mapping_routes,
+    report_routes,
+    report_line_routes,
+)
 from fastapi.openapi.utils import get_openapi
 from app.core.exceptions import DomainError, PermissionDenied
 from app.core.error_handlers import domain_error_handler
@@ -72,6 +78,8 @@ app.include_router(budget_routes.router, prefix="/api/v1")
 app.include_router(budget_routes.private_router, prefix="/api/private/v1")
 app.include_router(budget_line_routes.router, prefix="/api/v1")
 app.include_router(mapping_routes.router, prefix="/api/v1")
+app.include_router(report_routes.router, prefix="/api/v1")
+app.include_router(report_line_routes.router, prefix="/api/v1")
 
 app.add_route("/metrics", metrics_endpoint, methods=["GET"])
 

--- a/services/budget/migrations/versions/000005_add_reports_report_lines.py
+++ b/services/budget/migrations/versions/000005_add_reports_report_lines.py
@@ -1,0 +1,76 @@
+"""Add reports, report_lines
+
+Revision ID: 000005
+Revises: 000004
+Create Date: 2026-07-24 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+import shared.db.type_decorators
+
+revision: str = "000005"
+down_revision: Union[str, Sequence[str], None] = "000004"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "reports",
+        sa.Column("id", shared.db.type_decorators.GUID(), nullable=False),
+        sa.Column("budget_id", shared.db.type_decorators.GUID(), nullable=False),
+        sa.Column("name", sa.String(), nullable=False),
+        sa.Column(
+            "status",
+            sa.Enum("draft", "submitted", "approved", "rejected", name="report_status"),
+            nullable=False,
+            server_default="draft",
+        ),
+        sa.Column("period_start", sa.Date(), nullable=False),
+        sa.Column("period_end", sa.Date(), nullable=False),
+        sa.Column("submitted_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("reviewed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("reviewed_by", shared.db.type_decorators.GUID(), nullable=True),
+        sa.Column("review_notes", sa.String(), nullable=True),
+        sa.Column(
+            "created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False
+        ),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("created_by", shared.db.type_decorators.GUID(), nullable=True),
+        sa.Column("updated_by", shared.db.type_decorators.GUID(), nullable=True),
+        sa.ForeignKeyConstraint(["budget_id"], ["budgets.id"]),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(op.f("ix_reports_id"), "reports", ["id"], unique=False)
+
+    op.create_table(
+        "report_lines",
+        sa.Column("id", shared.db.type_decorators.GUID(), nullable=False),
+        sa.Column("report_id", shared.db.type_decorators.GUID(), nullable=False),
+        sa.Column("budget_line_id", shared.db.type_decorators.GUID(), nullable=False),
+        sa.Column("description", sa.String(), nullable=True),
+        sa.Column("amount", sa.Float(), nullable=True),
+        sa.Column("extra_fields", sa.JSON(), nullable=True),
+        sa.Column(
+            "created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False
+        ),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("created_by", shared.db.type_decorators.GUID(), nullable=True),
+        sa.Column("updated_by", shared.db.type_decorators.GUID(), nullable=True),
+        sa.ForeignKeyConstraint(["report_id"], ["reports.id"]),
+        sa.ForeignKeyConstraint(["budget_line_id"], ["budget_lines.id"]),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(op.f("ix_report_lines_id"), "report_lines", ["id"], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index(op.f("ix_report_lines_id"), table_name="report_lines")
+    op.drop_table("report_lines")
+    op.drop_index(op.f("ix_reports_id"), table_name="reports")
+    op.drop_table("reports")
+    sa.Enum(name="report_status").drop(op.get_bind(), checkfirst=True)

--- a/services/budget/tests/factories/report.py
+++ b/services/budget/tests/factories/report.py
@@ -1,0 +1,42 @@
+import factory
+from uuid import uuid4
+from datetime import date
+
+from app.models.report import ReportModel, ReportLineModel
+from app.schemas.report_schema import ReportStatus
+
+
+class ReportFactory(factory.Factory):
+    class Meta:
+        model = ReportModel
+
+    id = factory.LazyFunction(uuid4)
+    budget_id = factory.LazyFunction(uuid4)
+    name = factory.Faker("sentence", nb_words=3)
+    status = ReportStatus.draft
+    period_start = date(2026, 1, 1)
+    period_end = date(2026, 12, 31)
+    submitted_at = None
+    reviewed_at = None
+    reviewed_by = None
+    review_notes = None
+    created_by = factory.LazyFunction(uuid4)
+    updated_by = factory.LazyFunction(uuid4)
+    created_at = None
+    updated_at = None
+
+
+class ReportLineFactory(factory.Factory):
+    class Meta:
+        model = ReportLineModel
+
+    id = factory.LazyFunction(uuid4)
+    report_id = factory.LazyFunction(uuid4)
+    budget_line_id = factory.LazyFunction(uuid4)
+    description = factory.Faker("sentence", nb_words=4)
+    amount = 250.0
+    extra_fields = None
+    created_by = factory.LazyFunction(uuid4)
+    updated_by = factory.LazyFunction(uuid4)
+    created_at = None
+    updated_at = None

--- a/services/budget/tests/test_report_line_routes.py
+++ b/services/budget/tests/test_report_line_routes.py
@@ -1,0 +1,274 @@
+"""
+Tests for ticket #146: report line create/update/delete against the
+draft-only lock and the same-budget cross-check on budget_line_id.
+
+Same real-sqlite-session convention as test_report_routes.py.
+"""
+
+from datetime import date
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.core.exceptions import DomainError, PermissionDenied
+from app.models.base import Base
+from app.models.budget import BudgetModel, BudgetLineModel, BudgetCategoryModel
+from app.models.report import ReportModel, ReportLineModel
+from app.schemas.budget_schema import BudgetStatus
+from app.schemas.report_schema import ReportStatus
+from app.schemas.report_line_schema import ReportLineCreate, ReportLineUpdate
+from app.services.report_line_services import (
+    create_report_line_service,
+    get_report_line_by_id_service,
+    list_report_lines_service,
+    update_report_line_service,
+    delete_report_line_service,
+)
+from tests.factories.user import make_valid_user
+
+OWNER_ID = str(uuid4())
+FUNDER_ID = str(uuid4())
+STRANGER_ID = str(uuid4())
+
+
+def _valid_user(customer_id):
+    return make_valid_user(customer_id=customer_id)
+
+
+@pytest.fixture
+def db():
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(
+        engine,
+        tables=[
+            BudgetModel.__table__,
+            BudgetLineModel.__table__,
+            BudgetCategoryModel.__table__,
+            ReportModel.__table__,
+            ReportLineModel.__table__,
+        ],
+    )
+    return sessionmaker(bind=engine)()
+
+
+def _make_budget(db, owner_id=OWNER_ID, funding_customer_id=None):
+    budget = BudgetModel(
+        name="Test Budget",
+        owner_id=owner_id,
+        funding_customer_id=funding_customer_id,
+        status=BudgetStatus.confirmed,
+        start_date=date(2026, 1, 1),
+        duration_months=12,
+        local_currency="GBP",
+    )
+    db.add(budget)
+    db.commit()
+    db.refresh(budget)
+    return budget
+
+
+def _make_budget_line(db, budget_id, amount=1000.0):
+    line = BudgetLineModel(budget_id=budget_id, description="Admin costs", amount=amount)
+    db.add(line)
+    db.commit()
+    db.refresh(line)
+    return line
+
+
+def _make_report(db, budget_id, status=ReportStatus.draft):
+    report = ReportModel(
+        budget_id=budget_id,
+        name="Report",
+        status=status,
+        period_start=date(2026, 1, 1),
+        period_end=date(2026, 12, 31),
+    )
+    db.add(report)
+    db.commit()
+    db.refresh(report)
+    return report
+
+
+class TestCreateReportLine:
+    def test_create_against_matching_budget_line(self, db):
+        budget = _make_budget(db)
+        budget_line = _make_budget_line(db, budget.id)
+        report = _make_report(db, budget.id)
+        payload = ReportLineCreate(
+            report_id=report.id,
+            budget_line_id=budget_line.id,
+            description="Receipt #1",
+            amount=250.0,
+        )
+
+        result = create_report_line_service(db, _valid_user(OWNER_ID), payload)
+
+        assert result.report_id == report.id
+        assert result.budget_line_id == budget_line.id
+
+    def test_rejected_for_cross_budget_budget_line(self, db):
+        budget = _make_budget(db)
+        other_budget = _make_budget(db, owner_id=OWNER_ID)
+        other_budget_line = _make_budget_line(db, other_budget.id)
+        report = _make_report(db, budget.id)
+        payload = ReportLineCreate(
+            report_id=report.id,
+            budget_line_id=other_budget_line.id,
+            description="Wrong budget",
+            amount=100.0,
+        )
+
+        with pytest.raises(DomainError):
+            create_report_line_service(db, _valid_user(OWNER_ID), payload)
+
+    def test_rejected_on_non_draft_report(self, db):
+        budget = _make_budget(db)
+        budget_line = _make_budget_line(db, budget.id)
+        report = _make_report(db, budget.id, status=ReportStatus.submitted)
+        payload = ReportLineCreate(
+            report_id=report.id,
+            budget_line_id=budget_line.id,
+            description="Too late",
+            amount=100.0,
+        )
+
+        with pytest.raises(DomainError):
+            create_report_line_service(db, _valid_user(OWNER_ID), payload)
+
+    def test_funder_cannot_create_report_line(self, db):
+        budget = _make_budget(db, funding_customer_id=FUNDER_ID)
+        budget_line = _make_budget_line(db, budget.id)
+        report = _make_report(db, budget.id)
+        payload = ReportLineCreate(
+            report_id=report.id,
+            budget_line_id=budget_line.id,
+            description="Not funder's job",
+            amount=100.0,
+        )
+
+        with pytest.raises(PermissionDenied):
+            create_report_line_service(db, _valid_user(FUNDER_ID), payload)
+
+    def test_multiple_lines_against_same_budget_line(self, db):
+        budget = _make_budget(db)
+        budget_line = _make_budget_line(db, budget.id)
+        report = _make_report(db, budget.id)
+        for i in range(2):
+            payload = ReportLineCreate(
+                report_id=report.id,
+                budget_line_id=budget_line.id,
+                description=f"Receipt #{i}",
+                amount=100.0,
+            )
+            create_report_line_service(db, _valid_user(OWNER_ID), payload)
+
+        lines = list_report_lines_service(db, _valid_user(OWNER_ID), report.id)
+        assert len(lines) == 2
+
+
+class TestReportLineAccess:
+    def test_owner_and_funder_can_view(self, db):
+        budget = _make_budget(db, funding_customer_id=FUNDER_ID)
+        budget_line = _make_budget_line(db, budget.id)
+        report = _make_report(db, budget.id)
+        line = create_report_line_service(
+            db,
+            _valid_user(OWNER_ID),
+            ReportLineCreate(
+                report_id=report.id,
+                budget_line_id=budget_line.id,
+                description="Receipt",
+                amount=50.0,
+            ),
+        )
+
+        assert get_report_line_by_id_service(db, _valid_user(OWNER_ID), line.id).id == line.id
+        assert get_report_line_by_id_service(db, _valid_user(FUNDER_ID), line.id).id == line.id
+
+    def test_stranger_cannot_view(self, db):
+        budget = _make_budget(db, funding_customer_id=FUNDER_ID)
+        budget_line = _make_budget_line(db, budget.id)
+        report = _make_report(db, budget.id)
+        line = create_report_line_service(
+            db,
+            _valid_user(OWNER_ID),
+            ReportLineCreate(
+                report_id=report.id,
+                budget_line_id=budget_line.id,
+                description="Receipt",
+                amount=50.0,
+            ),
+        )
+
+        with pytest.raises(DomainError):
+            get_report_line_by_id_service(db, _valid_user(STRANGER_ID), line.id)
+
+
+class TestUpdateDeleteLock:
+    def test_update_rejected_on_non_draft_report(self, db):
+        budget = _make_budget(db)
+        budget_line = _make_budget_line(db, budget.id)
+        report = _make_report(db, budget.id)
+        line = create_report_line_service(
+            db,
+            _valid_user(OWNER_ID),
+            ReportLineCreate(
+                report_id=report.id,
+                budget_line_id=budget_line.id,
+                description="Receipt",
+                amount=50.0,
+            ),
+        )
+        report.status = ReportStatus.submitted
+        db.commit()
+
+        with pytest.raises(DomainError):
+            update_report_line_service(
+                db,
+                _valid_user(OWNER_ID),
+                line.id,
+                ReportLineUpdate(report_id=report.id, amount=99.0),
+            )
+
+    def test_delete_rejected_on_non_draft_report(self, db):
+        budget = _make_budget(db)
+        budget_line = _make_budget_line(db, budget.id)
+        report = _make_report(db, budget.id)
+        line = create_report_line_service(
+            db,
+            _valid_user(OWNER_ID),
+            ReportLineCreate(
+                report_id=report.id,
+                budget_line_id=budget_line.id,
+                description="Receipt",
+                amount=50.0,
+            ),
+        )
+        report.status = ReportStatus.approved
+        db.commit()
+
+        with pytest.raises(DomainError):
+            delete_report_line_service(db, _valid_user(OWNER_ID), line.id)
+
+    def test_update_allowed_on_draft_report(self, db):
+        budget = _make_budget(db)
+        budget_line = _make_budget_line(db, budget.id)
+        report = _make_report(db, budget.id)
+        line = create_report_line_service(
+            db,
+            _valid_user(OWNER_ID),
+            ReportLineCreate(
+                report_id=report.id,
+                budget_line_id=budget_line.id,
+                description="Receipt",
+                amount=50.0,
+            ),
+        )
+
+        updated = update_report_line_service(
+            db, _valid_user(OWNER_ID), line.id, ReportLineUpdate(report_id=report.id, amount=99.0)
+        )
+
+        assert updated.amount == 99.0

--- a/services/budget/tests/test_report_routes.py
+++ b/services/budget/tests/test_report_routes.py
@@ -1,0 +1,436 @@
+"""
+Tests for ticket #146: report submission lifecycle.
+
+The bulk of this suite calls the service layer directly against a real
+sqlite session (matching the convention in
+test_budget_line_services.py::TestRecalculateBudgetTotalCrud) — period
+overlap detection and the confirmed-budget/permission gates are real SQL
+and cross-record checks that are more reliably exercised this way than by
+mocking every crud call individually. A small TestClient-based class at the
+bottom covers route wiring (auth dependency, status codes) with the service
+layer mocked, matching test_donor_scoped_endpoints.py's convention.
+"""
+
+from datetime import date
+from unittest.mock import patch
+from uuid import uuid4
+
+import pytest
+from dateutil.relativedelta import relativedelta
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.core.exceptions import DomainError, PermissionDenied
+from app.models.base import Base
+from app.models.budget import BudgetModel, BudgetLineModel, BudgetCategoryModel
+from app.models.report import ReportModel, ReportLineModel
+from app.schemas.budget_schema import BudgetStatus
+from app.schemas.report_schema import ReportStatus, ReportCreate, ReportUpdate
+from app.services.report_services import (
+    create_report_service,
+    get_report_service,
+    list_reports_service,
+    update_report_service,
+    delete_report_service,
+    submit_report_service,
+    review_report_service,
+    reopen_report_service,
+)
+from tests.factories.user import make_valid_user
+
+OWNER_ID = str(uuid4())
+FUNDER_ID = str(uuid4())
+STRANGER_ID = str(uuid4())
+
+
+def _valid_user(customer_id):
+    return make_valid_user(customer_id=customer_id)
+
+
+@pytest.fixture
+def db():
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(
+        engine,
+        tables=[
+            BudgetModel.__table__,
+            BudgetLineModel.__table__,
+            BudgetCategoryModel.__table__,
+            ReportModel.__table__,
+            ReportLineModel.__table__,
+        ],
+    )
+    return sessionmaker(bind=engine)()
+
+
+def _make_budget(
+    db,
+    owner_id=OWNER_ID,
+    funding_customer_id=None,
+    status=BudgetStatus.confirmed,
+    start_date=date(2026, 1, 1),
+    duration_months=12,
+):
+    budget = BudgetModel(
+        name="Test Budget",
+        owner_id=owner_id,
+        funding_customer_id=funding_customer_id,
+        status=status,
+        start_date=start_date,
+        duration_months=duration_months,
+        local_currency="GBP",
+    )
+    db.add(budget)
+    db.commit()
+    db.refresh(budget)
+    return budget
+
+
+def _make_report(db, budget_id, status=ReportStatus.draft, period_start=None, period_end=None):
+    report = ReportModel(
+        budget_id=budget_id,
+        name="Interim report",
+        status=status,
+        period_start=period_start or date(2026, 1, 1),
+        period_end=period_end or date(2026, 3, 31),
+    )
+    db.add(report)
+    db.commit()
+    db.refresh(report)
+    return report
+
+
+class TestCreateReportService:
+    def test_defaults_period_to_budget_full_span_when_omitted(self, db):
+        budget = _make_budget(db)
+        payload = ReportCreate(budget_id=budget.id, name="Final report")
+
+        result = create_report_service(db, _valid_user(OWNER_ID), payload)
+
+        assert result.period_start == budget.start_date
+        assert result.period_end == budget.start_date + relativedelta(months=12)
+        assert result.status == ReportStatus.draft
+
+    def test_creates_with_explicit_narrower_period(self, db):
+        budget = _make_budget(db)
+        payload = ReportCreate(
+            budget_id=budget.id,
+            name="Q1 report",
+            period_start=date(2026, 1, 1),
+            period_end=date(2026, 3, 31),
+        )
+
+        result = create_report_service(db, _valid_user(OWNER_ID), payload)
+
+        assert result.period_start == date(2026, 1, 1)
+        assert result.period_end == date(2026, 3, 31)
+
+    def test_rejected_when_only_period_start_supplied(self, db):
+        # Regression: previously silently discarded the supplied period_start
+        # and defaulted both fields to the budget's full span instead of
+        # rejecting the ambiguous partial input ("period-stomping").
+        budget = _make_budget(db)
+        payload = ReportCreate(budget_id=budget.id, name="Partial", period_start=date(2026, 2, 1))
+
+        with pytest.raises(DomainError):
+            create_report_service(db, _valid_user(OWNER_ID), payload)
+
+    def test_rejected_when_only_period_end_supplied(self, db):
+        budget = _make_budget(db)
+        payload = ReportCreate(budget_id=budget.id, name="Partial", period_end=date(2026, 2, 1))
+
+        with pytest.raises(DomainError):
+            create_report_service(db, _valid_user(OWNER_ID), payload)
+
+    def test_rejected_when_period_is_inverted(self, db):
+        budget = _make_budget(db)
+        payload = ReportCreate(
+            budget_id=budget.id,
+            name="Inverted",
+            period_start=date(2026, 6, 1),
+            period_end=date(2026, 1, 1),
+        )
+
+        with pytest.raises(DomainError):
+            create_report_service(db, _valid_user(OWNER_ID), payload)
+
+    def test_rejected_when_budget_not_confirmed(self, db):
+        budget = _make_budget(db, status=BudgetStatus.draft)
+        payload = ReportCreate(budget_id=budget.id, name="Too early")
+
+        with pytest.raises(DomainError):
+            create_report_service(db, _valid_user(OWNER_ID), payload)
+
+    def test_rejected_when_confirmed_budget_has_no_start_date(self, db):
+        # update_budget_service enforces start_date before confirming a budget,
+        # but this guards a hypothetical future path that sets confirmed directly.
+        budget = _make_budget(db, start_date=None)
+        payload = ReportCreate(budget_id=budget.id, name="No start date")
+
+        with pytest.raises(DomainError):
+            create_report_service(db, _valid_user(OWNER_ID), payload)
+
+    def test_rejected_for_user_without_budget_access(self, db):
+        budget = _make_budget(db, funding_customer_id=FUNDER_ID)
+        payload = ReportCreate(budget_id=budget.id, name="Not yours")
+
+        with pytest.raises(DomainError):
+            create_report_service(db, _valid_user(STRANGER_ID), payload)
+
+    def test_funder_has_access_to_create(self, db):
+        budget = _make_budget(db, funding_customer_id=FUNDER_ID)
+        payload = ReportCreate(budget_id=budget.id, name="Funder-created")
+
+        result = create_report_service(db, _valid_user(FUNDER_ID), payload)
+
+        assert result.budget_id == budget.id
+
+    def test_rejected_on_period_overlap_including_against_rejected_report(self, db):
+        budget = _make_budget(db)
+        _make_report(
+            db,
+            budget.id,
+            status=ReportStatus.rejected,
+            period_start=date(2026, 1, 1),
+            period_end=date(2026, 6, 30),
+        )
+        payload = ReportCreate(
+            budget_id=budget.id,
+            name="Overlapping",
+            period_start=date(2026, 6, 1),
+            period_end=date(2026, 9, 30),
+        )
+
+        with pytest.raises(DomainError):
+            create_report_service(db, _valid_user(OWNER_ID), payload)
+
+    def test_non_overlapping_period_allowed_regardless_of_existing_status(self, db):
+        budget = _make_budget(db)
+        _make_report(
+            db,
+            budget.id,
+            status=ReportStatus.submitted,
+            period_start=date(2026, 1, 1),
+            period_end=date(2026, 6, 30),
+        )
+        payload = ReportCreate(
+            budget_id=budget.id,
+            name="Next period",
+            period_start=date(2026, 7, 1),
+            period_end=date(2026, 12, 31),
+        )
+
+        result = create_report_service(db, _valid_user(OWNER_ID), payload)
+
+        assert result.period_start == date(2026, 7, 1)
+
+
+class TestReportAccess:
+    def test_owner_can_get_and_list(self, db):
+        budget = _make_budget(db, funding_customer_id=FUNDER_ID)
+        report = _make_report(db, budget.id)
+
+        assert get_report_service(db, _valid_user(OWNER_ID), report.id).id == report.id
+        assert len(list_reports_service(db, _valid_user(OWNER_ID), budget.id)) == 1
+
+    def test_funder_can_get_and_list(self, db):
+        budget = _make_budget(db, funding_customer_id=FUNDER_ID)
+        report = _make_report(db, budget.id)
+
+        assert get_report_service(db, _valid_user(FUNDER_ID), report.id).id == report.id
+        assert len(list_reports_service(db, _valid_user(FUNDER_ID), budget.id)) == 1
+
+    def test_stranger_cannot_get_or_list(self, db):
+        budget = _make_budget(db, funding_customer_id=FUNDER_ID)
+        report = _make_report(db, budget.id)
+
+        with pytest.raises(DomainError):
+            get_report_service(db, _valid_user(STRANGER_ID), report.id)
+        with pytest.raises(DomainError):
+            list_reports_service(db, _valid_user(STRANGER_ID), budget.id)
+
+
+class TestUpdateDeleteOwnership:
+    def test_funder_cannot_update_or_delete(self, db):
+        budget = _make_budget(db, funding_customer_id=FUNDER_ID)
+        report = _make_report(db, budget.id)
+        update = ReportUpdate(name="Renamed")
+
+        with pytest.raises(PermissionDenied):
+            update_report_service(db, _valid_user(FUNDER_ID), report.id, update)
+        with pytest.raises(PermissionDenied):
+            delete_report_service(db, _valid_user(FUNDER_ID), report.id)
+
+    def test_owner_can_update_and_delete_draft_report(self, db):
+        budget = _make_budget(db)
+        report = _make_report(db, budget.id)
+        update = ReportUpdate(name="Renamed")
+
+        updated = update_report_service(db, _valid_user(OWNER_ID), report.id, update)
+        assert updated.name == "Renamed"
+
+        assert delete_report_service(db, _valid_user(OWNER_ID), report.id) is True
+
+    def test_update_rejected_when_partial_period_would_invert(self, db):
+        # Regression: report starts at period_start=Jan1/period_end=Mar31
+        # (see _make_report). Moving only period_start past the existing,
+        # untouched period_end used to save silently with no ordering check.
+        budget = _make_budget(db)
+        report = _make_report(db, budget.id)
+        update = ReportUpdate(period_start=date(2026, 4, 1))
+
+        with pytest.raises(DomainError):
+            update_report_service(db, _valid_user(OWNER_ID), report.id, update)
+
+    def test_cannot_update_non_draft_report(self, db):
+        budget = _make_budget(db)
+        report = _make_report(db, budget.id, status=ReportStatus.submitted)
+        update = ReportUpdate(name="Too late")
+
+        with pytest.raises(DomainError):
+            update_report_service(db, _valid_user(OWNER_ID), report.id, update)
+
+    def test_cannot_delete_non_draft_report(self, db):
+        budget = _make_budget(db)
+        report = _make_report(db, budget.id, status=ReportStatus.submitted)
+
+        with pytest.raises(DomainError):
+            delete_report_service(db, _valid_user(OWNER_ID), report.id)
+
+
+class TestSubmitTransition:
+    def test_submit_draft_report(self, db):
+        budget = _make_budget(db)
+        report = _make_report(db, budget.id, status=ReportStatus.draft)
+
+        result = submit_report_service(db, _valid_user(OWNER_ID), report.id)
+
+        assert result.status == ReportStatus.submitted
+        assert result.submitted_at is not None
+
+    def test_cannot_resubmit_non_draft_report(self, db):
+        budget = _make_budget(db)
+        report = _make_report(db, budget.id, status=ReportStatus.submitted)
+
+        with pytest.raises(DomainError):
+            submit_report_service(db, _valid_user(OWNER_ID), report.id)
+
+    def test_funder_cannot_submit(self, db):
+        budget = _make_budget(db, funding_customer_id=FUNDER_ID)
+        report = _make_report(db, budget.id, status=ReportStatus.draft)
+
+        with pytest.raises(PermissionDenied):
+            submit_report_service(db, _valid_user(FUNDER_ID), report.id)
+
+
+class TestReviewTransition:
+    def test_funder_approves_submitted_report(self, db):
+        budget = _make_budget(db, funding_customer_id=FUNDER_ID)
+        report = _make_report(db, budget.id, status=ReportStatus.submitted)
+        funder_user = _valid_user(FUNDER_ID)
+
+        result = review_report_service(db, funder_user, report.id, ReportStatus.approved)
+
+        assert result.status == ReportStatus.approved
+        assert result.reviewed_at is not None
+        assert str(result.reviewed_by) == funder_user["user_id"]
+
+    def test_funder_rejects_with_notes(self, db):
+        budget = _make_budget(db, funding_customer_id=FUNDER_ID)
+        report = _make_report(db, budget.id, status=ReportStatus.submitted)
+
+        result = review_report_service(
+            db, _valid_user(FUNDER_ID), report.id, ReportStatus.rejected, "please fix the totals"
+        )
+
+        assert result.status == ReportStatus.rejected
+        assert result.review_notes == "please fix the totals"
+
+    def test_owner_self_reviews_when_no_funder(self, db):
+        budget = _make_budget(db, funding_customer_id=None)
+        report = _make_report(db, budget.id, status=ReportStatus.submitted)
+
+        result = review_report_service(db, _valid_user(OWNER_ID), report.id, ReportStatus.approved)
+
+        assert result.status == ReportStatus.approved
+
+    def test_owner_cannot_review_when_a_real_funder_exists(self, db):
+        budget = _make_budget(db, funding_customer_id=FUNDER_ID)
+        report = _make_report(db, budget.id, status=ReportStatus.submitted)
+
+        with pytest.raises(PermissionDenied):
+            review_report_service(db, _valid_user(OWNER_ID), report.id, ReportStatus.approved)
+
+    def test_stranger_cannot_review(self, db):
+        # A stranger has no view access to the budget at all, so this hits the
+        # same info-hiding "not found" path as every other report endpoint —
+        # not PermissionDenied, which would confirm the report exists.
+        budget = _make_budget(db, funding_customer_id=FUNDER_ID)
+        report = _make_report(db, budget.id, status=ReportStatus.submitted)
+
+        with pytest.raises(DomainError):
+            review_report_service(db, _valid_user(STRANGER_ID), report.id, ReportStatus.approved)
+
+    def test_cannot_review_non_submitted_report(self, db):
+        budget = _make_budget(db, funding_customer_id=FUNDER_ID)
+        report = _make_report(db, budget.id, status=ReportStatus.draft)
+
+        with pytest.raises(DomainError):
+            review_report_service(db, _valid_user(FUNDER_ID), report.id, ReportStatus.approved)
+
+
+class TestReopenTransition:
+    def test_reopen_rejected_report_to_draft(self, db):
+        budget = _make_budget(db)
+        report = _make_report(db, budget.id, status=ReportStatus.rejected)
+
+        result = reopen_report_service(db, _valid_user(OWNER_ID), report.id)
+
+        assert result.status == ReportStatus.draft
+
+    def test_cannot_reopen_non_rejected_report(self, db):
+        budget = _make_budget(db)
+        report = _make_report(db, budget.id, status=ReportStatus.draft)
+
+        with pytest.raises(DomainError):
+            reopen_report_service(db, _valid_user(OWNER_ID), report.id)
+
+
+class TestReportRoutesWiring:
+    """Thin route-level checks with the service layer mocked, matching
+    test_donor_scoped_endpoints.py's convention."""
+
+    def test_create_report_route_delegates_to_service(self, make_client):
+        client = make_client()
+        with patch(
+            "app.api.report_routes.create_report_service", return_value={"id": str(uuid4())}
+        ) as mock_service:
+            response = client.post(
+                "/api/v1/reports/",
+                json={"budget_id": str(uuid4()), "name": "Report"},
+            )
+        assert response.status_code == 200
+        mock_service.assert_called_once()
+
+    def test_submit_report_route_delegates_to_service(self, make_client):
+        client = make_client()
+        report_id = uuid4()
+        with patch(
+            "app.api.report_routes.submit_report_service", return_value={"id": str(report_id)}
+        ) as mock_service:
+            response = client.post(f"/api/v1/reports/{report_id}/submit")
+        assert response.status_code == 200
+        mock_service.assert_called_once()
+
+    def test_review_report_route_delegates_to_service(self, make_client):
+        client = make_client()
+        report_id = uuid4()
+        with patch(
+            "app.api.report_routes.review_report_service", return_value={"id": str(report_id)}
+        ) as mock_service:
+            response = client.post(
+                f"/api/v1/reports/{report_id}/review",
+                json={"decision": "approved"},
+            )
+        assert response.status_code == 200
+        mock_service.assert_called_once()

--- a/shared/schemas/report_line_schema.py
+++ b/shared/schemas/report_line_schema.py
@@ -1,0 +1,35 @@
+from pydantic import BaseModel, ConfigDict
+from uuid import UUID
+from datetime import datetime
+from typing import Any
+
+
+class ReportLineBase(BaseModel):
+    report_id: UUID | None = None
+    budget_line_id: UUID | None = None
+    description: str | None = None
+    amount: float | None = None
+    extra_fields: dict[str, Any] | None = None
+    created_by: UUID | None = None
+    updated_by: UUID | None = None
+    updated_at: datetime | None = None
+    created_at: datetime | None = None
+
+
+class ReportLineCreate(ReportLineBase):
+    report_id: UUID
+    budget_line_id: UUID
+    description: str
+    amount: float
+
+
+class ReportLineUpdate(BaseModel):
+    report_id: UUID
+    description: str | None = None
+    amount: float | None = None
+    extra_fields: dict[str, Any] | None = None
+
+
+class ReportLine(ReportLineBase):
+    id: UUID
+    model_config = ConfigDict(from_attributes=True)

--- a/shared/schemas/report_schema.py
+++ b/shared/schemas/report_schema.py
@@ -1,0 +1,52 @@
+from pydantic import BaseModel, ConfigDict
+from uuid import UUID
+from datetime import date, datetime
+from enum import Enum
+
+from shared.schemas.report_line_schema import ReportLine
+
+
+class ReportStatus(str, Enum):
+    draft = "draft"
+    submitted = "submitted"
+    approved = "approved"
+    rejected = "rejected"
+
+
+class ReportBase(BaseModel):
+    budget_id: UUID | None = None
+    name: str | None = None
+    status: ReportStatus = ReportStatus.draft
+    period_start: date | None = None
+    period_end: date | None = None
+    submitted_at: datetime | None = None
+    reviewed_at: datetime | None = None
+    reviewed_by: UUID | None = None
+    review_notes: str | None = None
+    created_by: UUID | None = None
+    updated_by: UUID | None = None
+    updated_at: datetime | None = None
+    created_at: datetime | None = None
+
+
+class ReportCreate(ReportBase):
+    budget_id: UUID
+    name: str
+
+
+class ReportUpdate(ReportBase):
+    id: UUID | None = None
+
+
+class Report(ReportBase):
+    id: UUID
+    model_config = ConfigDict(from_attributes=True)
+
+
+class ReportWithLines(Report):
+    lines: list[ReportLine] = []
+
+
+class ReportReviewRequest(BaseModel):
+    decision: ReportStatus
+    review_notes: str | None = None


### PR DESCRIPTION
- Implemented report and report line services for creating, updating, deleting, and listing reports and report lines.
- Added new schemas for report and report line, including validation and serialization.
- Created database migrations to add reports and report_lines tables with necessary fields and constraints.
- Developed factories for generating test data for reports and report lines.
- Added comprehensive tests for report and report line services, ensuring correct behavior for various scenarios including permission checks and status transitions.
- Updated main application to include new report and report line routes.