### PR TITLE
Backend: donor commitment, estimated exchange rate, confirmed_at

### DIFF
--- a/openspec/changes/budget-report-iteration-2/tasks.md
+++ b/openspec/changes/budget-report-iteration-2/tasks.md
@@ -1,17 +1,17 @@
-One task group = one GitHub ticket = one PR, merged before the next group starts.
+Workflow rule: **one group = one GitHub ticket = one PR, merged before the next group starts.** Tickets are already created (see each group's heading); branch per ticket as shown. Do not start a group until the previous one's PR is merged. Every PR: backend `flake8 --max-line-length=100` / frontend `npm run lint` clean; commits/pushes only with explicit user approval.
 
-## 1. Backend: donor commitment, estimated rate, confirmed_at
+## 1. Backend: donor commitment, estimated rate, confirmed_at — ticket #179 (`Budget/Issue-179/donor-commitment-fields`)
 
-- [ ] 1.1 Add a migration for `budgets.donor_total_amount` (nullable float), `budgets.estimated_exchange_rate` (nullable float), and `budgets.confirmed_at` (nullable timestamp). No backfill.
-- [ ] 1.2 Add the three fields to `BudgetModel` (`services/budget/app/models/budget.py`).
-- [ ] 1.3 Add `donor_total_amount`/`estimated_exchange_rate` to `BudgetCreate`/`BudgetUpdate`/`BudgetPatched` and the budget response schema; add read-only `confirmed_at` and computed `estimated_local_cap` to the response schema (`services/budget/app/schemas/budget_schema.py`).
-- [ ] 1.4 Add `donor_total_amount`/`estimated_exchange_rate` to `_is_metadata_edit` (`services/budget/app/services/budget_services.py:82-97`) so both are locked by the existing `is_budget_locked` / confirmed-budget check, same as `local_currency`/`actual_currency`.
-- [ ] 1.5 In `update_budget_service`'s confirm-transition branch (`services/budget/app/services/budget_services.py:196` onward), set `confirmed_at` to the current time on confirm; ensure it's set again (not left stale) if a budget is reverted to `draft` and confirmed a second time.
-- [ ] 1.6 Add `estimated_local_cap` as a computed field (`donor_total_amount × estimated_exchange_rate`; `null` when either input is unset or zero) assembled at read time, not persisted.
-- [ ] 1.7 Add/extend backend tests: set `donor_total_amount`/`estimated_exchange_rate` on an unconfirmed budget; reject the same updates on a confirmed budget; `confirmed_at` set on first confirm and updated on re-confirm after a revert; `estimated_local_cap` correct when both inputs are set, `null` when either is missing.
-- [ ] 1.8 Run `services/budget`'s tests and lint clean; PR merged.
+- [x] 1.1 Add a migration for `budgets.donor_total_amount` (nullable float), `budgets.estimated_exchange_rate` (nullable float), and `budgets.confirmed_at` (nullable timestamp). No backfill. — `000009_add_budget_donor_commitment_fields.py` (down_revision `000008`), verified `alembic upgrade head`/`downgrade -1`/`upgrade head` against real local Postgres.
+- [x] 1.2 Add the three fields to `BudgetModel` (`services/budget/app/models/budget.py`).
+- [x] 1.3 Add `donor_total_amount`/`estimated_exchange_rate` to `BudgetCreate`/`BudgetUpdate`/`BudgetPatched` and the budget response schema; add read-only `confirmed_at` and computed `estimated_local_cap` to the response schema (`services/budget/app/schemas/budget_schema.py`). — `BudgetPatched` doesn't exist on the backend (frontend-only type, correctly handled in ticket #180/group 2's 2.1); backend fields added to `BudgetBase` (covers `BudgetCreate`/`BudgetUpdate`) plus `confirmed_at`/`estimated_local_cap` added to `Budget` and `BudgetWithLines` (the latter is the actual `GET /budgets/{id}` response model).
+- [x] 1.4 Add `donor_total_amount`/`estimated_exchange_rate` to `_is_metadata_edit` (`services/budget/app/services/budget_services.py:82-97`) so both are locked by the existing `is_budget_locked` / confirmed-budget check, same as `local_currency`/`actual_currency`.
+- [x] 1.5 In `update_budget_service`'s confirm-transition branch (`services/budget/app/services/budget_services.py:196` onward), set `confirmed_at` to the current time on confirm; ensure it's set again (not left stale) if a budget is reverted to `draft` and confirmed a second time.
+- [x] 1.6 Add `estimated_local_cap` as a computed field (`donor_total_amount × estimated_exchange_rate`; `null` when either input is unset or zero) assembled at read time, not persisted. — `_compute_estimated_local_cap` in `budget_services.py`, wired into `populate_budget_with_user_details`.
+- [x] 1.7 Add/extend backend tests: set `donor_total_amount`/`estimated_exchange_rate` on an unconfirmed budget; reject the same updates on a confirmed budget; `confirmed_at` set on first confirm and updated on re-confirm after a revert; `estimated_local_cap` correct when both inputs are set, `null` when either is missing. — `tests/test_budget_donor_commitment.py` (12 new tests); also updated `test_budget_currency_fields.py`'s exact-kwargs assertion to account for the new `update_budget` call args.
+- [ ] 1.8 Run `services/budget`'s tests and lint clean; PR merged. — tests/lint/mypy clean (207/207 passing, flake8 `--max-line-length=100` clean, black clean, mypy has only a pre-existing unrelated error); PR not yet opened/merged.
 
-## 2. Frontend: donor commitment display — depends on 1
+## 2. Frontend: donor commitment display — ticket #180 (`Frontend/Issue-180/donor-commitment-display`) — depends on 1
 
 - [ ] 2.1 Add `donor_total_amount`, `estimated_exchange_rate`, `confirmed_at`, `estimated_local_cap` to `Budget`, and the first two to `BudgetUpdate`/`BudgetPatched` (`frontend-typescript/src/pages/Budgets/types/budget.ts`).
 - [ ] 2.2 Add editable `donor_total_amount` and `estimated_exchange_rate` fields to the budget edit form, disabled under the same condition the form already disables `actual_currency` (confirmed budget).
@@ -20,7 +20,7 @@ One task group = one GitHub ticket = one PR, merged before the next group starts
 - [ ] 2.5 Add/extend tests for the edit form and both display sites covering: estimate shown when `estimated_local_cap` is set, local-only fallback when it's `null`.
 - [ ] 2.6 Run the frontend test suite and lint clean; PR merged.
 
-## 3. Frontend: budget-lines table currency toggle — depends on 1
+## 3. Frontend: budget-lines table currency toggle — ticket #181 (`Frontend/Issue-181/lines-currency-toggle`) — depends on 1
 
 - [ ] 3.1 Add a Local / Donor (estimated) / Both toggle to `BudgetViewLinesTable.tsx`, rendered only when `budget.estimated_exchange_rate` is non-null; hidden otherwise (identical to current behavior).
 - [ ] 3.2 Convert the `Amount` column per the selected toggle state using `estimated_exchange_rate`, labeling donor/both figures as estimated.
@@ -28,7 +28,7 @@ One task group = one GitHub ticket = one PR, merged before the next group starts
 - [ ] 3.4 Add/extend `BudgetViewLinesTable.test.tsx` covering: toggle hidden when `estimated_exchange_rate` is `null`, and correct Local/Donor/Both rendering for `Amount` and `Used` when it's set.
 - [ ] 3.5 Run the frontend test suite and lint clean; PR merged.
 
-## 4. Backend: cross-budget reports directory
+## 4. Backend: cross-budget reports directory — ticket #182 (`Budget/Issue-182/reports-directory-api`)
 
 - [ ] 4.1 Add `GET /reports/` to `report_routes.py`, accepting optional `status`, `budget_id`, `funding_customer_id` query params, scoped by role the same way `/budgets/` (owner) vs `/budgets/funded/` (donor) already split.
 - [ ] 4.2 Relax `list_reports_service`/add a new service function that accepts an optional `budget_id` (reusing `report_crud.list_reports`'s existing `budget_id: UUID | None` support) and authorizes against "all budgets visible to this user" instead of a single budget.
@@ -36,7 +36,7 @@ One task group = one GitHub ticket = one PR, merged before the next group starts
 - [ ] 4.4 Add/extend backend tests: owner sees reports across all their budgets; donor sees reports across all budgets they fund; `status`/`budget_id`/`funding_customer_id` filters individually and combined; budget/funder fields present on each returned report.
 - [ ] 4.5 Run `services/budget`'s tests and lint clean; PR merged.
 
-## 5. Frontend: reports directory page — depends on 4
+## 5. Frontend: reports directory page — ticket #183 (`Frontend/Issue-183/reports-directory-ui`) — depends on 4
 
 - [ ] 5.1 Add the new reports-directory page and its `/reports` route in `App.tsx`, fixing the dead nav link in `DashboardLayout.tsx`.
 - [ ] 5.2 Build the table with columns Report / Budget / Donor / Period / Status / Actions (View Report, View Budget), reusing the existing status-badge styling and mobile-card fallback pattern from `BudgetReportsPage.tsx`.
@@ -45,7 +45,7 @@ One task group = one GitHub ticket = one PR, merged before the next group starts
 - [ ] 5.5 Add/extend frontend tests covering: columns render correctly, each filter narrows results, View Budget navigates to the right budget, mobile card fallback, empty state.
 - [ ] 5.6 Run the frontend test suite and lint clean; PR merged.
 
-## 6. Backend: grantee dashboard aggregation — depends on 1
+## 6. Backend: grantee dashboard aggregation — ticket #184 (`Budget/Issue-184/grantee-dashboard-api`) — depends on 1
 
 - [ ] 6.1 Add a new grantee-dashboard summary endpoint (e.g. `GET /budgets/dashboard/summary`) returning: budget counts by status; committed/received/conversion-progress figures grouped by `actual_currency` (confirmed budgets only); a per-budget breakdown array.
 - [ ] 6.2 Implement the committed-by-currency aggregation as `total_amount ÷ estimated_exchange_rate` per confirmed budget, summed per `actual_currency`, excluding budgets missing `actual_currency`/`estimated_exchange_rate`.
@@ -54,7 +54,7 @@ One task group = one GitHub ticket = one PR, merged before the next group starts
 - [ ] 6.5 Add/extend backend tests: status counts correct; committed total uses `total_amount`/`estimated_exchange_rate` not `donor_total_amount`; budgets missing a usable rate are excluded from (not folded into) currency totals; conversion percentage computed correctly per currency; breakdown includes one row per confirmed budget with correct converted/spent/remaining figures.
 - [ ] 6.6 Run `services/budget`'s tests and lint clean; PR merged.
 
-## 7. Frontend: grantee dashboard — depends on 6
+## 7. Frontend: grantee dashboard — ticket #185 (`Frontend/Issue-185/grantee-dashboard-ui`) — depends on 6
 
 - [ ] 7.1 Replace `Dashboard.tsx`'s hardcoded `stats` array and static "Recent Activity" with data fetched from the new summary endpoint.
 - [ ] 7.2 Render budget-status counts, and the committed/received/conversion-progress figures as separate per-currency stat cards (never blended across currencies).

--- a/services/budget/app/crud/budget_crud.py
+++ b/services/budget/app/crud/budget_crud.py
@@ -1,4 +1,4 @@
-from datetime import date
+from datetime import date, datetime
 
 from sqlalchemy import func
 from sqlalchemy.orm import Session
@@ -77,6 +77,9 @@ def update_budget(
     local_currency: str | None = None,
     actual_currency: str | None = None,
     start_date: date | None = None,
+    donor_total_amount: float | None = None,
+    estimated_exchange_rate: float | None = None,
+    confirmed_at: datetime | None = None,
 ) -> BudgetModel | None:
     budget = get_budget(session, budget_id)
     if not budget:
@@ -100,6 +103,12 @@ def update_budget(
         budget.funding_customer_id = funding_customer_id
     if external_funder_name is not None:
         budget.external_funder_name = external_funder_name
+    if donor_total_amount is not None:
+        budget.donor_total_amount = donor_total_amount
+    if estimated_exchange_rate is not None:
+        budget.estimated_exchange_rate = estimated_exchange_rate
+    if confirmed_at is not None:
+        budget.confirmed_at = confirmed_at
     session.commit()
     session.refresh(budget)
     return budget

--- a/services/budget/app/models/budget.py
+++ b/services/budget/app/models/budget.py
@@ -1,8 +1,18 @@
 # /services/budget/app/models/budget.py
 from __future__ import annotations
 import uuid
-from datetime import date
-from sqlalchemy import String, ForeignKey, Float, JSON, Integer, Date, Enum as SQLEnum, text
+from datetime import date, datetime
+from sqlalchemy import (
+    String,
+    ForeignKey,
+    Float,
+    JSON,
+    Integer,
+    Date,
+    DateTime,
+    Enum as SQLEnum,
+    text,
+)
 from sqlalchemy.orm import relationship, Mapped, mapped_column
 from app.utils.db import GUID
 
@@ -47,6 +57,12 @@ class BudgetModel(Base, AuditMixin):
     total_amount: Mapped[float | None] = mapped_column(
         Float, nullable=True, default=0, server_default=text("0")
     )
+    # Donor's stated commitment (in actual_currency) and the grantee's own
+    # planning-time rate estimate — distinct from the currency-ledger's real,
+    # bank-derived rate. See budget-report-iteration-2/design.md Decisions 1-4.
+    donor_total_amount: Mapped[float | None] = mapped_column(Float, nullable=True)
+    estimated_exchange_rate: Mapped[float | None] = mapped_column(Float, nullable=True)
+    confirmed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     lines: Mapped[list["BudgetLineModel"]] = relationship(
         "BudgetLineModel", back_populates="budget"
     )

--- a/services/budget/app/services/budget_services.py
+++ b/services/budget/app/services/budget_services.py
@@ -1,5 +1,6 @@
 import asyncio
 import structlog
+from datetime import datetime, timezone
 from dateutil.relativedelta import relativedelta
 from fastapi import status, HTTPException
 from sqlalchemy.exc import IntegrityError
@@ -82,7 +83,8 @@ def is_budget_locked(budget) -> bool:
 def _is_metadata_edit(budget: BudgetCreate) -> bool:
     """True if the payload touches anything beyond a bare status/start_date
     transition (confirm or revert-to-draft) or a currency-only update — i.e.
-    name/duration/local_currency/funder/owner fields. `actual_currency` is
+    name/duration/local_currency/funder/owner/donor_total_amount/
+    estimated_exchange_rate fields. `actual_currency` is
     deliberately excluded: it's the donor-transfer currency the currency-
     ledger UI needs set, and the ledger's "set actual currency" prompt only
     ever appears on an already-confirmed budget (see budget-report-frontend
@@ -98,6 +100,8 @@ def _is_metadata_edit(budget: BudgetCreate) -> bool:
             budget.external_funder_name,
             budget.funding_customer_id,
             budget.owner_id,
+            budget.donor_total_amount,
+            budget.estimated_exchange_rate,
         )
     )
 
@@ -201,6 +205,11 @@ async def update_budget_service(budget_id: UUID, budget: BudgetCreate, valid_use
                 status.HTTP_400_BAD_REQUEST,
             )
 
+    # Set on every confirm transition (is_confirm_attempt is only reachable
+    # here from draft/ai_draft, per the guard above) so a later revert +
+    # reconfirm always overwrites the prior value, never left stale.
+    confirmed_at = datetime.now(timezone.utc) if is_confirm_attempt else None
+
     if is_reverting:
         non_draft_reports = [r for r in valid_budget.reports if r.status != ReportStatus.draft]
         if non_draft_reports:
@@ -229,6 +238,9 @@ async def update_budget_service(budget_id: UUID, budget: BudgetCreate, valid_use
         owner_id=owner_id,
         funding_customer_id=budget.funding_customer_id,
         external_funder_name=budget.external_funder_name,
+        donor_total_amount=budget.donor_total_amount,
+        estimated_exchange_rate=budget.estimated_exchange_rate,
+        confirmed_at=confirmed_at,
     )
 
 
@@ -415,6 +427,15 @@ def _compute_end_date(budget: BudgetModel):
     return budget.start_date + relativedelta(months=budget.duration_months or 0)
 
 
+def _compute_estimated_local_cap(budget: BudgetModel) -> float | None:
+    """donor_total_amount × estimated_exchange_rate, derived at read time —
+    never persisted (see design.md Decision 2). `null` when either input is
+    unset or zero, not just when unset."""
+    if not budget.donor_total_amount or not budget.estimated_exchange_rate:
+        return None
+    return budget.donor_total_amount * budget.estimated_exchange_rate
+
+
 async def populate_budget_with_user_details(budgets: List[BudgetModel], valid_user: dict):
     # Collect unique user and customer IDs
     user_ids = {b.created_by for b in budgets if b.created_by}
@@ -447,6 +468,10 @@ async def populate_budget_with_user_details(budgets: List[BudgetModel], valid_us
             "start_date": b.start_date,
             "end_date": _compute_end_date(b),
             "total_amount": b.total_amount,
+            "donor_total_amount": b.donor_total_amount,
+            "estimated_exchange_rate": b.estimated_exchange_rate,
+            "confirmed_at": b.confirmed_at,
+            "estimated_local_cap": _compute_estimated_local_cap(b),
             "owner": customers_map.get(b.owner_id),
             # Preserve `id` from the budget's own funding_customer_id even
             # when the customer-name lookup is empty/failed, so a real

--- a/services/budget/migrations/versions/000009_add_budget_donor_commitment_fields.py
+++ b/services/budget/migrations/versions/000009_add_budget_donor_commitment_fields.py
@@ -1,0 +1,34 @@
+"""Add budgets.donor_total_amount/estimated_exchange_rate/confirmed_at
+
+Revision ID: 000009
+Revises: 000008
+Create Date: 2026-08-01 00:00:00.000000
+
+Additive-only, no backfill: existing budgets simply have none of these set,
+identical to their current state. `confirmed_at` stays null for already-
+confirmed budgets rather than being backfilled from `updated_at` (not a
+reliable proxy — see budget-report-iteration-2/design.md's Context).
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "000009"
+down_revision: Union[str, Sequence[str], None] = "000008"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column("budgets", sa.Column("donor_total_amount", sa.Float(), nullable=True))
+    op.add_column("budgets", sa.Column("estimated_exchange_rate", sa.Float(), nullable=True))
+    op.add_column("budgets", sa.Column("confirmed_at", sa.DateTime(timezone=True), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("budgets", "confirmed_at")
+    op.drop_column("budgets", "estimated_exchange_rate")
+    op.drop_column("budgets", "donor_total_amount")

--- a/services/budget/tests/factories/budget.py
+++ b/services/budget/tests/factories/budget.py
@@ -49,3 +49,6 @@ class BudgetFactory(factory.Factory):
     local_currency = "GBP"
     actual_currency = None
     start_date = None
+    donor_total_amount = None
+    estimated_exchange_rate = None
+    confirmed_at = None

--- a/services/budget/tests/test_budget_currency_fields.py
+++ b/services/budget/tests/test_budget_currency_fields.py
@@ -99,9 +99,7 @@ class TestConfirmRequiresStartDate:
             with pytest.raises((DomainError, HTTPException)):
                 import asyncio
 
-                asyncio.run(
-                    update_budget_service(existing.id, payload, _valid_user(), DB)
-                )
+                asyncio.run(update_budget_service(existing.id, payload, _valid_user(), DB))
 
     def test_confirm_with_start_date_already_on_record_is_allowed(self):
         existing = BudgetFactory.build(
@@ -127,9 +125,7 @@ class TestConfirmRequiresStartDate:
         ):
             import asyncio
 
-            result = asyncio.run(
-                update_budget_service(existing.id, payload, _valid_user(), DB)
-            )
+            result = asyncio.run(update_budget_service(existing.id, payload, _valid_user(), DB))
 
         assert result is existing
         mock_update.assert_called_once()
@@ -155,12 +151,17 @@ class TestConfirmRequiresStartDate:
         ):
             import asyncio
 
-            result = asyncio.run(
-                update_budget_service(existing.id, payload, _valid_user(), DB)
-            )
+            result = asyncio.run(update_budget_service(existing.id, payload, _valid_user(), DB))
 
         assert result is existing
-        mock_update.assert_called_once_with(
+        mock_update.assert_called_once()
+        # confirmed_at (budget-report-iteration-2, ticket #179) is a freshly
+        # generated timestamp on every successful confirm — asserted
+        # separately from the rest of the static kwargs below.
+        call_kwargs = dict(mock_update.call_args.kwargs)
+        confirmed_at = call_kwargs.pop("confirmed_at")
+        assert confirmed_at is not None
+        assert call_kwargs == dict(
             session=DB,
             budget_id=existing.id,
             name=payload.name,
@@ -172,6 +173,8 @@ class TestConfirmRequiresStartDate:
             owner_id=None,
             funding_customer_id=payload.funding_customer_id,
             external_funder_name=payload.external_funder_name,
+            donor_total_amount=payload.donor_total_amount,
+            estimated_exchange_rate=payload.estimated_exchange_rate,
         )
 
     def test_non_confirm_update_does_not_require_start_date(self):
@@ -195,9 +198,7 @@ class TestConfirmRequiresStartDate:
         ):
             import asyncio
 
-            result = asyncio.run(
-                update_budget_service(existing.id, payload, _valid_user(), DB)
-            )
+            result = asyncio.run(update_budget_service(existing.id, payload, _valid_user(), DB))
 
         assert result is existing
         mock_update.assert_called_once()

--- a/services/budget/tests/test_budget_donor_commitment.py
+++ b/services/budget/tests/test_budget_donor_commitment.py
@@ -1,0 +1,317 @@
+"""
+Tests for ticket #179 (budget-report-iteration-2, group 1): donor_total_amount,
+estimated_exchange_rate, confirmed_at, and the derived estimated_local_cap.
+
+Covers: column round-trip (real sqlite session, matching the convention in
+test_budget_currency_fields.py), the metadata-lock on a confirmed budget
+(mocked crud layer, matching update_budget_service's existing test
+convention), confirmed_at set/reset on the confirm transition, and
+estimated_local_cap computed at read time via the full GET /budgets/{id}
+route (matching test_budget_services.py's end_date tests).
+"""
+
+from datetime import date, datetime, timedelta, timezone
+from unittest.mock import patch, AsyncMock
+from uuid import uuid4
+
+import pytest
+from fastapi import HTTPException
+from fastapi.testclient import TestClient
+
+from main import app
+from app.api.budget_routes import get_validated_user
+from tests.factories.user import make_valid_user
+from tests.factories.budget import BudgetFactory
+from app.core.exceptions import DomainError
+from app.schemas.budget_schema import BudgetCreate, BudgetStatus
+from app.services.budget_services import update_budget_service
+
+USER_ID = str(uuid4())
+CUSTOMER_ID = str(uuid4())
+DB = object()  # session is never actually used — every crud call is mocked
+
+client = TestClient(app)
+
+
+def _valid_user():
+    return make_valid_user(user_id=USER_ID, customer_id=CUSTOMER_ID)
+
+
+def _payload(**kwargs):
+    kwargs.setdefault("name", "Grant")
+    kwargs.setdefault("funding_customer_id", uuid4())
+    return BudgetCreate(**kwargs)
+
+
+class TestColumnRoundTrip:
+    def test_new_columns_persist_and_reload(self):
+        from sqlalchemy import create_engine
+        from sqlalchemy.orm import sessionmaker
+        from app.models.base import Base
+        from app.models.budget import BudgetModel
+
+        engine = create_engine("sqlite:///:memory:")
+        Base.metadata.create_all(engine, tables=[BudgetModel.__table__])
+        session = sessionmaker(bind=engine)()
+
+        confirmed_at = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        budget = BudgetModel(
+            name="Downstream",
+            owner_id=uuid4(),
+            local_currency="EUR",
+            actual_currency="USD",
+            donor_total_amount=10000,
+            estimated_exchange_rate=0.8,
+            confirmed_at=confirmed_at,
+        )
+        session.add(budget)
+        session.commit()
+        session.refresh(budget)
+
+        reloaded = session.query(BudgetModel).filter(BudgetModel.id == budget.id).one()
+        assert reloaded.donor_total_amount == 10000
+        assert reloaded.estimated_exchange_rate == 0.8
+        # sqlite drops tzinfo on round-trip (unlike Postgres); compare naive.
+        assert reloaded.confirmed_at.replace(tzinfo=timezone.utc) == confirmed_at
+
+    def test_new_columns_default_to_null(self):
+        from sqlalchemy import create_engine
+        from sqlalchemy.orm import sessionmaker
+        from app.models.base import Base
+        from app.models.budget import BudgetModel
+
+        engine = create_engine("sqlite:///:memory:")
+        Base.metadata.create_all(engine, tables=[BudgetModel.__table__])
+        session = sessionmaker(bind=engine)()
+
+        budget = BudgetModel(name="Plain", owner_id=uuid4())
+        session.add(budget)
+        session.commit()
+        session.refresh(budget)
+
+        assert budget.donor_total_amount is None
+        assert budget.estimated_exchange_rate is None
+        assert budget.confirmed_at is None
+
+
+class TestMetadataLockOnConfirmed:
+    def test_set_donor_commitment_on_unconfirmed_budget_is_accepted(self):
+        existing = BudgetFactory.build(id=uuid4(), owner_id=CUSTOMER_ID, status=BudgetStatus.draft)
+        payload = _payload(donor_total_amount=10000, estimated_exchange_rate=0.8)
+
+        with (
+            patch(
+                "app.services.budget_services.validate_customer_can_fund",
+                return_value=None,
+            ),
+            patch("app.services.budget_services.get_budget", return_value=existing),
+            patch(
+                "app.services.budget_services.update_budget", return_value=existing
+            ) as mock_update,
+        ):
+            import asyncio
+
+            result = asyncio.run(update_budget_service(existing.id, payload, _valid_user(), DB))
+
+        assert result is existing
+        mock_update.assert_called_once()
+        assert mock_update.call_args.kwargs["donor_total_amount"] == 10000
+        assert mock_update.call_args.kwargs["estimated_exchange_rate"] == 0.8
+
+    def test_donor_commitment_edit_rejected_on_confirmed_budget(self):
+        existing = BudgetFactory.build(
+            id=uuid4(),
+            owner_id=CUSTOMER_ID,
+            status=BudgetStatus.confirmed,
+            start_date=date(2026, 1, 1),
+        )
+        payload = _payload(donor_total_amount=10000)
+
+        with (
+            patch(
+                "app.services.budget_services.validate_customer_can_fund",
+                return_value=None,
+            ),
+            patch("app.services.budget_services.get_budget", return_value=existing),
+        ):
+            with pytest.raises((DomainError, HTTPException)):
+                import asyncio
+
+                asyncio.run(update_budget_service(existing.id, payload, _valid_user(), DB))
+
+    def test_estimated_exchange_rate_edit_rejected_on_confirmed_budget(self):
+        existing = BudgetFactory.build(
+            id=uuid4(),
+            owner_id=CUSTOMER_ID,
+            status=BudgetStatus.confirmed,
+            start_date=date(2026, 1, 1),
+        )
+        payload = _payload(estimated_exchange_rate=0.9)
+
+        with (
+            patch(
+                "app.services.budget_services.validate_customer_can_fund",
+                return_value=None,
+            ),
+            patch("app.services.budget_services.get_budget", return_value=existing),
+        ):
+            with pytest.raises((DomainError, HTTPException)):
+                import asyncio
+
+                asyncio.run(update_budget_service(existing.id, payload, _valid_user(), DB))
+
+
+class TestConfirmedAtTransition:
+    def test_confirmed_at_set_on_first_confirm(self):
+        existing = BudgetFactory.build(
+            id=uuid4(),
+            owner_id=CUSTOMER_ID,
+            status=BudgetStatus.draft,
+            start_date=date(2026, 1, 1),
+            confirmed_at=None,
+        )
+        payload = _payload(status=BudgetStatus.confirmed)
+
+        with (
+            patch(
+                "app.services.budget_services.validate_customer_can_fund",
+                return_value=None,
+            ),
+            patch("app.services.budget_services.get_budget", return_value=existing),
+            patch(
+                "app.services.budget_services.update_budget", return_value=existing
+            ) as mock_update,
+        ):
+            import asyncio
+
+            asyncio.run(update_budget_service(existing.id, payload, _valid_user(), DB))
+
+        confirmed_at = mock_update.call_args.kwargs["confirmed_at"]
+        assert confirmed_at is not None
+        assert (datetime.now(timezone.utc) - confirmed_at) < timedelta(seconds=5)
+
+    def test_confirmed_at_updated_on_reconfirm_after_revert(self):
+        stale_confirmed_at = datetime(2020, 1, 1, tzinfo=timezone.utc)
+        existing = BudgetFactory.build(
+            id=uuid4(),
+            owner_id=CUSTOMER_ID,
+            status=BudgetStatus.draft,  # reverted back to draft after a prior confirm
+            start_date=date(2026, 1, 1),
+            confirmed_at=stale_confirmed_at,
+        )
+        payload = _payload(status=BudgetStatus.confirmed)
+
+        with (
+            patch(
+                "app.services.budget_services.validate_customer_can_fund",
+                return_value=None,
+            ),
+            patch("app.services.budget_services.get_budget", return_value=existing),
+            patch(
+                "app.services.budget_services.update_budget", return_value=existing
+            ) as mock_update,
+        ):
+            import asyncio
+
+            asyncio.run(update_budget_service(existing.id, payload, _valid_user(), DB))
+
+        confirmed_at = mock_update.call_args.kwargs["confirmed_at"]
+        assert confirmed_at is not None
+        assert confirmed_at > stale_confirmed_at
+
+    def test_confirmed_at_not_touched_on_non_confirm_update(self):
+        existing = BudgetFactory.build(id=uuid4(), owner_id=CUSTOMER_ID, status=BudgetStatus.draft)
+        payload = _payload(name="Renamed")
+
+        with (
+            patch(
+                "app.services.budget_services.validate_customer_can_fund",
+                return_value=None,
+            ),
+            patch("app.services.budget_services.get_budget", return_value=existing),
+            patch(
+                "app.services.budget_services.update_budget", return_value=existing
+            ) as mock_update,
+        ):
+            import asyncio
+
+            asyncio.run(update_budget_service(existing.id, payload, _valid_user(), DB))
+
+        assert mock_update.call_args.kwargs["confirmed_at"] is None
+
+
+class TestEstimatedLocalCap:
+    """GET /api/v1/budgets/{id} — estimated_local_cap derived at read time."""
+
+    @pytest.fixture(autouse=True)
+    def override_auth(self):
+        app.dependency_overrides[get_validated_user] = lambda: make_valid_user(
+            user_id=USER_ID, customer_id=CUSTOMER_ID
+        )
+        yield
+        app.dependency_overrides = {}
+
+    def _get(self, budget):
+        with (
+            patch("app.services.budget_services.get_budget", return_value=budget),
+            patch(
+                "app.services.budget_services.get_users_by_ids_cached",
+                new_callable=AsyncMock,
+                return_value={},
+            ),
+            patch(
+                "app.services.budget_services.get_customers_by_ids",
+                new_callable=AsyncMock,
+                return_value={},
+            ),
+            patch("app.api.budget_routes.get_viewable_budget_lines_service", return_value=[]),
+        ):
+            return client.get(f"/api/v1/budgets/{budget.id}")
+
+    def test_present_when_both_inputs_set(self):
+        budget = BudgetFactory.build(
+            owner_id=CUSTOMER_ID,
+            created_by=USER_ID,
+            updated_by=USER_ID,
+            donor_total_amount=10000,
+            estimated_exchange_rate=0.8,
+        )
+        response = self._get(budget)
+        assert response.status_code == 200
+        assert response.json()["estimated_local_cap"] == 8000
+
+    def test_null_when_estimated_exchange_rate_missing(self):
+        budget = BudgetFactory.build(
+            owner_id=CUSTOMER_ID,
+            created_by=USER_ID,
+            updated_by=USER_ID,
+            donor_total_amount=10000,
+            estimated_exchange_rate=None,
+        )
+        response = self._get(budget)
+        assert response.status_code == 200
+        assert response.json()["estimated_local_cap"] is None
+
+    def test_null_when_donor_total_amount_missing(self):
+        budget = BudgetFactory.build(
+            owner_id=CUSTOMER_ID,
+            created_by=USER_ID,
+            updated_by=USER_ID,
+            donor_total_amount=None,
+            estimated_exchange_rate=0.8,
+        )
+        response = self._get(budget)
+        assert response.status_code == 200
+        assert response.json()["estimated_local_cap"] is None
+
+    def test_null_when_either_input_is_zero(self):
+        budget = BudgetFactory.build(
+            owner_id=CUSTOMER_ID,
+            created_by=USER_ID,
+            updated_by=USER_ID,
+            donor_total_amount=0,
+            estimated_exchange_rate=0.8,
+        )
+        response = self._get(budget)
+        assert response.status_code == 200
+        assert response.json()["estimated_local_cap"] is None

--- a/shared/schemas/budget_schema.py
+++ b/shared/schemas/budget_schema.py
@@ -27,6 +27,11 @@ class BudgetBase(BaseModel):
     duration_months: int | None = None
     external_funder_name: str | None = None
     total_amount: float | None = None
+    # Donor's stated commitment (in actual_currency) and the grantee's own
+    # planning-time rate estimate, directly entered — never derived. Locked
+    # once the budget is confirmed, same as local_currency/actual_currency.
+    donor_total_amount: float | None = None
+    estimated_exchange_rate: float | None = None
     created_by: UUID | None = None
     updated_by: UUID | None = None
     updated_at: datetime | None = None
@@ -55,6 +60,11 @@ class BudgetUpdate(BudgetBase):
 
 class Budget(BudgetBase):
     id: UUID
+    # Read-only: set by the server (confirm transition) / derived at read
+    # time (donor_total_amount × estimated_exchange_rate) — never accepted
+    # from BudgetCreate/BudgetUpdate payloads since they don't inherit these.
+    confirmed_at: datetime | None = None
+    estimated_local_cap: float | None = None
     lines: list[BudgetLine] = []
     model_config = ConfigDict(from_attributes=True)
 
@@ -98,6 +108,10 @@ class BudgetWithLines(BaseModel):
     # period_end: budget.start_date + relativedelta(months=duration_months)).
     end_date: date | None = None
     total_amount: float | None = None
+    donor_total_amount: float | None = None
+    estimated_exchange_rate: float | None = None
+    confirmed_at: datetime | None = None
+    estimated_local_cap: float | None = None
     owner: CustomerOut | None = None
     funder: CustomerOut | None = None
     trace: TraceOut | None = None


### PR DESCRIPTION
## Summary
- Adds `Budget.donor_total_amount` and `Budget.estimated_exchange_rate` — directly-entered, planning-time figures (donor's stated commitment + the grantee's own rate estimate), distinct from the currency-ledger's real, bank-derived rate. Locked once the budget is confirmed, same as `local_currency`/`actual_currency`.
- Adds `Budget.confirmed_at`, set to a fresh timestamp on every confirm transition (including re-confirm after a revert).
- Adds a derived `estimated_local_cap` (`donor_total_amount × estimated_exchange_rate`), computed at read time, never persisted.

Group 1 of the `budget-report-iteration-2` OpenSpec change (`openspec/changes/budget-report-iteration-2/`) — see `design.md` Decisions 1-4 for full rationale.

## Test plan
- [x] `pytest services/budget` — 207/207 passing
- [x] `flake8 --max-line-length=100` clean
- [x] `black --check` clean
- [x] `mypy` clean (one pre-existing unrelated error confirmed via `git stash`)
- [x] `alembic upgrade head` / `downgrade -1` / `upgrade head` verified against real local Postgres

Closes #179

🤖 Generated with [Claude Code](https://claude.com/claude-code)