### PR TITLE
Add donor commitment display, currency toggle, reports directory, and grantee dashboard aggregation (#180, #181, #182, #184)

### DIFF
--- a/frontend-typescript/src/api/donorDashboardApi.ts
+++ b/frontend-typescript/src/api/donorDashboardApi.ts
@@ -24,6 +24,10 @@ export interface FundedBudgetListItem {
   status: string;
   total_amount?: number;
   local_currency?: string;
+  actual_currency?: string;
+  donor_total_amount?: number | null;
+  estimated_exchange_rate?: number | null;
+  estimated_local_cap?: number | null;
   owner?: { id?: string; name?: string };
 }
 

--- a/frontend-typescript/src/components/ui/Button.tsx
+++ b/frontend-typescript/src/components/ui/Button.tsx
@@ -102,7 +102,9 @@ export function ConfirmDeleteButton({
   if (confirming) {
     return (
       <div className="flex items-center gap-2 flex-wrap">
-        {confirmMessage && <span className="text-sm text-slate-600">{confirmMessage}</span>}
+        {confirmMessage && (
+          <span className="text-sm text-slate-600">{confirmMessage}</span>
+        )}
         <div className="flex items-center space-x-2">
           <Button
             variant="danger"

--- a/frontend-typescript/src/pages/Budgets/SingleBudgetViewContext.test.tsx
+++ b/frontend-typescript/src/pages/Budgets/SingleBudgetViewContext.test.tsx
@@ -53,12 +53,13 @@ function makeLine(overrides: Partial<ReportLine> = {}): ReportLine {
 }
 
 function Consumer() {
-  const { spendByLineId, totalReported } = useDetailedBudget();
+  const { spendByLineId, totalReported, hasReports } = useDetailedBudget();
   return (
     <div>
       <span data-testid="total">{totalReported}</span>
       <span data-testid="bl1">{spendByLineId["bl1"] ?? 0}</span>
       <span data-testid="bl2">{spendByLineId["bl2"] ?? 0}</span>
+      <span data-testid="hasReports">{String(hasReports)}</span>
     </div>
   );
 }
@@ -83,7 +84,10 @@ describe("SingleBudgetViewContext spend aggregation", () => {
   });
 
   it("sums reported spend per budget line across every report on the budget", async () => {
-    listReportsByBudgetMock.mockResolvedValue([makeReport({ id: "r1" }), makeReport({ id: "r2" })]);
+    listReportsByBudgetMock.mockResolvedValue([
+      makeReport({ id: "r1", status: "submitted" }),
+      makeReport({ id: "r2", status: "submitted" }),
+    ]);
     listReportLinesByReportMock.mockImplementation((reportId: string) =>
       Promise.resolve(
         reportId === "r1"
@@ -97,6 +101,7 @@ describe("SingleBudgetViewContext spend aggregation", () => {
     await waitFor(() => expect(screen.getByTestId("bl1")).toHaveTextContent("500"));
     expect(screen.getByTestId("bl2")).toHaveTextContent("0");
     expect(screen.getByTestId("total")).toHaveTextContent("500");
+    expect(screen.getByTestId("hasReports")).toHaveTextContent("true");
   });
 
   it("reports zero spend when the budget has no reports yet", async () => {
@@ -107,5 +112,16 @@ describe("SingleBudgetViewContext spend aggregation", () => {
     await waitFor(() => expect(listReportsByBudgetMock).toHaveBeenCalledWith("b1"));
     expect(screen.getByTestId("total")).toHaveTextContent("0");
     expect(listReportLinesByReportMock).not.toHaveBeenCalled();
+    expect(screen.getByTestId("hasReports")).toHaveTextContent("false");
+  });
+
+  it("does not count a draft-only report — nothing has actually been reported yet", async () => {
+    listReportsByBudgetMock.mockResolvedValue([makeReport({ id: "r1", status: "draft" })]);
+    listReportLinesByReportMock.mockResolvedValue([]);
+
+    renderContext();
+
+    await waitFor(() => expect(listReportsByBudgetMock).toHaveBeenCalledWith("b1"));
+    expect(screen.getByTestId("hasReports")).toHaveTextContent("false");
   });
 });

--- a/frontend-typescript/src/pages/Budgets/SingleBudgetViewContext.tsx
+++ b/frontend-typescript/src/pages/Budgets/SingleBudgetViewContext.tsx
@@ -36,6 +36,11 @@ interface SingleBudgetViewContextType {
   // usual handful of reports per budget.
   spendByLineId: Record<string, number>;
   totalReported: number;
+  // Whether any report has ever been submitted against this budget — gates
+  // whether "Total Reported" is worth showing at all. A draft report with
+  // nothing filled in yet is exactly the always-£0 stat this is meant to
+  // hide, so a draft alone doesn't count.
+  hasReports: boolean;
   // isAddOpen: boolean;
   // openAddModal: () => void;
   // closeAddModal: () => void;
@@ -154,6 +159,7 @@ export const SingleBudgetViewContextProvider: React.FC<{
         existingExtraKeys,
         spendByLineId,
         totalReported,
+        hasReports: (reports ?? []).some((r) => r.status !== "draft"),
       }}
     >
       {children}

--- a/frontend-typescript/src/pages/Budgets/components/BudgetViewHeader.test.tsx
+++ b/frontend-typescript/src/pages/Budgets/components/BudgetViewHeader.test.tsx
@@ -430,8 +430,127 @@ describe("BudgetViewHeader metadata edit", () => {
         name: "Renamed",
         external_funder_name: "Donor 7",
         duration_months: 24,
+        // Sent as explicit null (not omitted) since the budget never had
+        // these set — same as the user clearing them — so the backend
+        // reads it as "no commitment", not "leave untouched".
+        donor_total_amount: null,
+        estimated_exchange_rate: null,
       }),
     );
     await waitFor(() => expect(onBudgetUpdated).toHaveBeenCalledWith(updated));
+  });
+
+  it("shows editable donor commitment and estimated rate fields and saves them", async () => {
+    const user = userEvent.setup();
+    const updated = makeBudget({ donor_total_amount: 10000, estimated_exchange_rate: 0.8 });
+    editBudgetMock.mockResolvedValue(updated);
+    const onBudgetUpdated = vi.fn();
+
+    render(
+      <BudgetViewHeader
+        budget={makeBudget({ actual_currency: "EUR" })}
+        isLocked={false}
+        onBudgetUpdated={onBudgetUpdated}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Edit" }));
+
+    const donorInput = screen.getByText(/donor commitment/i).parentElement!.querySelector(
+      "input",
+    ) as HTMLInputElement;
+    const rateInput = screen.getByText(/estimated rate/i).parentElement!.querySelector(
+      "input",
+    ) as HTMLInputElement;
+    await user.type(donorInput, "10000");
+    await user.type(rateInput, "0.8");
+
+    await user.click(screen.getByRole("button", { name: /save changes/i }));
+
+    await waitFor(() =>
+      expect(editBudgetMock).toHaveBeenCalledWith(
+        "b1",
+        expect.objectContaining({ donor_total_amount: 10000, estimated_exchange_rate: 0.8 }),
+      ),
+    );
+    await waitFor(() => expect(onBudgetUpdated).toHaveBeenCalledWith(updated));
+  });
+
+  it("sends explicit null when an existing donor commitment/rate is cleared, so the backend actually clears it", async () => {
+    const user = userEvent.setup();
+    const updated = makeBudget({ donor_total_amount: null, estimated_exchange_rate: null });
+    editBudgetMock.mockResolvedValue(updated);
+
+    render(
+      <BudgetViewHeader
+        budget={makeBudget({
+          actual_currency: "EUR",
+          donor_total_amount: 10000,
+          estimated_exchange_rate: 0.8,
+        })}
+        isLocked={false}
+        onBudgetUpdated={vi.fn()}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Edit" }));
+
+    const donorInput = screen.getByText(/donor commitment/i).parentElement!.querySelector(
+      "input",
+    ) as HTMLInputElement;
+    const rateInput = screen.getByText(/estimated rate/i).parentElement!.querySelector(
+      "input",
+    ) as HTMLInputElement;
+    await user.clear(donorInput);
+    await user.clear(rateInput);
+
+    await user.click(screen.getByRole("button", { name: /save changes/i }));
+
+    await waitFor(() =>
+      expect(editBudgetMock).toHaveBeenCalledWith(
+        "b1",
+        expect.objectContaining({ donor_total_amount: null, estimated_exchange_rate: null }),
+      ),
+    );
+  });
+
+  it("disables Save and shows an error when the estimated rate is zero or negative", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <BudgetViewHeader
+        budget={makeBudget({ actual_currency: "EUR" })}
+        isLocked={false}
+        onBudgetUpdated={vi.fn()}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Edit" }));
+    const rateInput = screen.getByText(/estimated rate/i).parentElement!.querySelector(
+      "input",
+    ) as HTMLInputElement;
+    await user.type(rateInput, "0");
+
+    expect(screen.getByText("Must be greater than zero.")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /save changes/i })).toBeDisabled();
+  });
+
+  it("shows donor commitment and estimated rate as read-only text, not inputs, during a currency-only edit", () => {
+    const budget = makeBudget({
+      status: "confirmed",
+      donor_total_amount: 10000,
+      estimated_exchange_rate: 0.8,
+      actual_currency: "EUR",
+    });
+
+    const { rerender } = render(
+      <BudgetViewHeader budget={budget} isLocked onBudgetUpdated={vi.fn()} />,
+    );
+    rerender(
+      <BudgetViewHeader budget={budget} isLocked onBudgetUpdated={vi.fn()} editTrigger={1} />,
+    );
+
+    expect(screen.getByText("10000 EUR")).toBeInTheDocument();
+    expect(screen.getByText("0.8")).toBeInTheDocument();
   });
 });

--- a/frontend-typescript/src/pages/Budgets/components/BudgetViewHeader.tsx
+++ b/frontend-typescript/src/pages/Budgets/components/BudgetViewHeader.tsx
@@ -3,13 +3,21 @@ import { Card, CardContent, CardHeader } from "@/components/ui/Card";
 import Button, { ConfirmDeleteButton } from "@/components/ui/Button";
 import Input from "@/components/ui/Input";
 import { editBudget } from "@/api/budgetApi";
-import { getCurrentCustomerId, isBudgetFunder, isBudgetOwner } from "@/utils/roleAccess";
+import {
+  getCurrentCustomerId,
+  isBudgetFunder,
+  isBudgetOwner,
+} from "@/utils/roleAccess";
 import { formatDateOnly } from "@/utils/datetime";
 import { CURRENCY_CODES } from "@/utils/currency";
 import { Budget } from "../types/budget";
 
-function ownerTypeLabel(owner?: { is_ngo?: boolean; is_donor?: boolean } | null): string {
-  const tags = [owner?.is_ngo && "NGO", owner?.is_donor && "Donor"].filter(Boolean);
+function ownerTypeLabel(
+  owner?: { is_ngo?: boolean; is_donor?: boolean } | null,
+): string {
+  const tags = [owner?.is_ngo && "NGO", owner?.is_donor && "Donor"].filter(
+    Boolean,
+  );
   return tags.length ? ` (${tags.join(" / ")})` : "";
 }
 
@@ -63,14 +71,20 @@ export function BudgetViewHeader({
   const [isEditMode, setIsEditMode] = useState(false);
   const [name, setName] = useState(budget.name ?? "");
   const [funderName, setFunderName] = useState(
-    (budget.funder as { name?: string } | null)?.name ?? ""
+    (budget.funder as { name?: string } | null)?.name ?? "",
   );
   const [durationMonths, setDurationMonths] = useState<number | "">(
-    budget.duration_months ?? ""
+    budget.duration_months ?? "",
   );
   const [actualCurrency, setActualCurrency] = useState(
-    budget.actual_currency ?? ""
+    budget.actual_currency ?? "",
   );
+  const [donorTotalAmount, setDonorTotalAmount] = useState<number | "">(
+    budget.donor_total_amount ?? "",
+  );
+  const [estimatedExchangeRate, setEstimatedExchangeRate] = useState<
+    number | ""
+  >(budget.estimated_exchange_rate ?? "");
   const [isSaving, setIsSaving] = useState(false);
   const [error, setError] = useState("");
   // True when edit mode was entered via editTrigger on an already-locked
@@ -100,6 +114,8 @@ export function BudgetViewHeader({
     setFunderName((budget.funder as { name?: string } | null)?.name ?? "");
     setDurationMonths(budget.duration_months ?? "");
     setActualCurrency(budget.actual_currency ?? "");
+    setDonorTotalAmount(budget.donor_total_amount ?? "");
+    setEstimatedExchangeRate(budget.estimated_exchange_rate ?? "");
     setError("");
     setIsCurrencyOnlyEdit(false);
     setIsEditMode(true);
@@ -129,6 +145,14 @@ export function BudgetViewHeader({
     setError("");
   };
 
+  // Donor commitment can be zero (no commitment yet), but the estimated
+  // rate can't — a zero rate divides by zero everywhere it's used to
+  // convert an amount back to the donor's currency (see
+  // BudgetViewLinesTable's toDonorAmount).
+  const donorAmountInvalid = donorTotalAmount !== "" && Number(donorTotalAmount) < 0;
+  const estimatedRateInvalid =
+    estimatedExchangeRate !== "" && Number(estimatedExchangeRate) <= 0;
+
   const saveEdit = async () => {
     setIsSaving(true);
     setError("");
@@ -144,10 +168,19 @@ export function BudgetViewHeader({
               // means the user intentionally cleared it, not "leave
               // unchanged".
               external_funder_name: funderName.trim(),
-              duration_months: durationMonths !== "" ? Number(durationMonths) : undefined,
+              duration_months:
+                durationMonths !== "" ? Number(durationMonths) : undefined,
               actual_currency: actualCurrency.trim() || undefined,
+              // Explicit `null` (not `undefined`) when the user blanks the
+              // field — `undefined` is dropped from the JSON body entirely,
+              // which the backend reads as "field omitted, leave
+              // unchanged", so it could never actually be cleared.
+              donor_total_amount:
+                donorTotalAmount !== "" ? Number(donorTotalAmount) : null,
+              estimated_exchange_rate:
+                estimatedExchangeRate !== "" ? Number(estimatedExchangeRate) : null,
               status: budget.status === "ai_draft" ? "draft" : undefined,
-            }
+            },
       );
       onBudgetUpdated?.(updated);
       setIsEditMode(false);
@@ -163,174 +196,247 @@ export function BudgetViewHeader({
     <>
       <Card className="w-full bg-white rounded-xl border border-slate-200 shadow-sm px-6 py-5">
         <CardHeader>
-        <div className="flex items-start justify-between gap-4 flex-wrap">
-          <div className="flex-1 min-w-[240px]">
-            <StatusBadge status={budget.status} />
-            {isEditMode && !isCurrencyOnlyEdit ? (
+          <div className="flex items-start justify-between gap-4 flex-wrap">
+            <div className="flex-1 min-w-[240px]">
+              <StatusBadge status={budget.status} />
+              {isEditMode && !isCurrencyOnlyEdit ? (
+                <input
+                  type="text"
+                  value={name}
+                  onChange={(e) => setName(e.target.value)}
+                  disabled={isSaving}
+                  className="block w-full max-w-md text-2xl font-semibold border border-slate-300 rounded-lg px-2 py-1 focus:outline-none focus:ring-2 focus:ring-slate-400"
+                />
+              ) : (
+                <h1 className="text-2xl font-semibold">{budget.name}</h1>
+              )}
+            </div>
+            <div className="flex items-center gap-2">
+              {isEditMode ? (
+                <>
+                  <Button
+                    variant="secondary"
+                    onClick={discardEdit}
+                    disabled={isSaving}
+                  >
+                    Discard
+                  </Button>
+                  <Button
+                    variant="primary"
+                    onClick={saveEdit}
+                    disabled={
+                      isSaving ||
+                      (!isCurrencyOnlyEdit &&
+                        (!name.trim() ||
+                          (durationMonths !== "" && durationMonths < 1) ||
+                          donorAmountInvalid ||
+                          estimatedRateInvalid))
+                    }
+                  >
+                    {isSaving ? "Saving..." : "Save Changes"}
+                  </Button>
+                </>
+              ) : owner && isLocked ? (
+                <span
+                  className="inline-flex items-center gap-1.5 text-xs font-medium bg-amber-50 text-amber-700 border border-amber-200 px-2.5 py-1.5 rounded-lg"
+                  title="This budget is confirmed — its metadata and lines are locked to keep reported figures accurate."
+                >
+                  🔒 Locked: confirmed
+                </span>
+              ) : owner ? (
+                <Button
+                  variant="secondary"
+                  onClick={enterEdit}
+                  className="text-sm"
+                  disabled={isActionBusy}
+                >
+                  Edit
+                </Button>
+              ) : null}
+            </div>
+          </div>
+        </CardHeader>
+        <CardContent>
+          {isEditMode && !isCurrencyOnlyEdit ? (
+            <div className="mt-1 flex items-center flex-wrap gap-2 text-sm text-slate-500">
+              <span className="text-slate-700 font-medium">
+                {budget.owner?.name ?? "Unknown"}
+              </span>
+              {ownerTypeLabel(budget.owner)}
+              <span className="text-slate-300">→</span>
               <input
                 type="text"
-                value={name}
-                onChange={(e) => setName(e.target.value)}
+                value={funderName}
+                onChange={(e) => setFunderName(e.target.value)}
                 disabled={isSaving}
-                className="block w-full max-w-md text-2xl font-semibold border border-slate-300 rounded-lg px-2 py-1 focus:outline-none focus:ring-2 focus:ring-slate-400"
+                className="border border-slate-300 rounded-lg px-2 py-1 text-sm text-slate-800 focus:outline-none focus:ring-2 focus:ring-slate-400"
               />
-            ) : (
-              <h1 className="text-2xl font-semibold">{budget.name}</h1>
-            )}
-          </div>
-          <div className="flex items-center gap-2">
-            {isEditMode ? (
-              <>
-                <Button variant="secondary" onClick={discardEdit} disabled={isSaving}>
-                  Discard
-                </Button>
-                <Button
-                  variant="primary"
-                  onClick={saveEdit}
-                  disabled={
-                    isSaving ||
-                    (!isCurrencyOnlyEdit &&
-                      (!name.trim() || (durationMonths !== "" && durationMonths < 1)))
-                  }
-                >
-                  {isSaving ? "Saving..." : "Save Changes"}
-                </Button>
-              </>
-            ) : owner && isLocked ? (
-              <span
-                className="inline-flex items-center gap-1.5 text-xs font-medium bg-amber-50 text-amber-700 border border-amber-200 px-2.5 py-1.5 rounded-lg"
-                title="This budget is confirmed — its metadata and lines are locked to keep reported figures accurate."
-              >
-                🔒 Locked: confirmed
+            </div>
+          ) : (
+            <p className="text-sm text-slate-500 mt-1">
+              <span className="text-slate-700 font-medium">
+                {budget.owner?.name ?? "Unknown"}
               </span>
-            ) : owner ? (
-              <Button
-                variant="secondary"
-                onClick={enterEdit}
-                className="text-sm"
-                disabled={isActionBusy}
-              >
-                Edit
-              </Button>
-            ) : null}
-          </div>
-        </div>
-      </CardHeader>
-      <CardContent>
-        <p className="text-sm text-slate-500 mt-1">
-          Owner: <span className="text-slate-700 font-medium">{budget.owner?.name ?? "Unknown"}</span>
-          {ownerTypeLabel(budget.owner)}
-        </p>
-        {isEditMode && !isCurrencyOnlyEdit ? (
-          <div className="mt-1 flex items-center gap-2 text-sm text-slate-500">
-            <span>Funder:</span>
-            <input
-              type="text"
-              value={funderName}
-              onChange={(e) => setFunderName(e.target.value)}
-              disabled={isSaving}
-              className="border border-slate-300 rounded-lg px-2 py-1 text-sm text-slate-800 focus:outline-none focus:ring-2 focus:ring-slate-400"
-            />
-          </div>
-        ) : (
-          <p className="text-sm text-slate-500">
-            Funder: <span className="text-slate-700 font-medium">{budget.funder?.name ?? "—"}</span>
-          </p>
-        )}
+              {ownerTypeLabel(budget.owner)}
+              <span className="mx-1.5 text-slate-300">→</span>
+              <span className="text-slate-700 font-medium">
+                {budget.funder?.name ?? "—"}
+              </span>
+            </p>
+          )}
 
-        {isCurrencyOnlyEdit && (
-          <p className="text-xs text-amber-700 mt-2">
-            This budget is confirmed — only the actual currency can be updated.
-          </p>
-        )}
+          {isCurrencyOnlyEdit && (
+            <p className="text-xs text-amber-700 mt-2">
+              This budget is confirmed — only the actual currency can be
+              updated.
+            </p>
+          )}
 
-        {error && <p className="text-sm text-red-600 mt-2">{error}</p>}
+          {error && <p className="text-sm text-red-600 mt-2">{error}</p>}
 
-        <div className="mt-4 flex flex-wrap gap-8 pt-4 border-t border-dashed border-slate-200">
-          <div>
-            <div className="text-micro-label">
-              Start date
-            </div>
-            <div className="text-sm font-semibold text-slate-700 mt-0.5">
-              {formatDateOnly(budget.start_date) ?? "—"}
-            </div>
-          </div>
-          <div>
-            <div className="text-micro-label">
-              End date
-            </div>
-            <div className="text-sm font-semibold text-slate-700 mt-0.5">
-              {formatDateOnly(budget.end_date) ?? "—"}
-            </div>
-          </div>
-          <div>
-            <div className="text-micro-label">
-              Duration
-            </div>
-            {isEditMode && !isCurrencyOnlyEdit ? (
-              <input
-                type="number"
-                min={1}
-                value={durationMonths}
-                onChange={(e) =>
-                  setDurationMonths(e.target.value ? parseInt(e.target.value) : "")
-                }
-                disabled={isSaving}
-                className="w-20 mt-0.5 border border-slate-300 rounded-lg px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-slate-400"
-              />
-            ) : (
+          <div className="mt-4 flex flex-wrap gap-8 pt-4 border-t border-dashed border-slate-200">
+            <div>
+              <div className="text-micro-label">Start date</div>
               <div className="text-sm font-semibold text-slate-700 mt-0.5">
-                {budget.duration_months ? `${budget.duration_months} months` : "—"}
+                {formatDateOnly(budget.start_date) ?? "—"}
               </div>
-            )}
-          </div>
-          <div>
-            <div className="text-micro-label">
-              Original currency
             </div>
-            {isEditMode ? (
-              <select
-                value={actualCurrency}
-                onChange={(e) => setActualCurrency(e.target.value)}
-                disabled={isSaving}
-                className="mt-0.5 border border-slate-300 rounded-lg px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-slate-400"
-              >
-                <option value="">—</option>
-                {/* Current value always offered, even if outside the fixed
+            <div>
+              <div className="text-micro-label">End date</div>
+              <div className="text-sm font-semibold text-slate-700 mt-0.5">
+                {formatDateOnly(budget.end_date) ?? "—"}
+              </div>
+            </div>
+            <div>
+              <div className="text-micro-label">Duration</div>
+              {isEditMode && !isCurrencyOnlyEdit ? (
+                <input
+                  type="number"
+                  min={1}
+                  value={durationMonths}
+                  onChange={(e) =>
+                    setDurationMonths(
+                      e.target.value ? parseInt(e.target.value) : "",
+                    )
+                  }
+                  disabled={isSaving}
+                  className="w-20 mt-0.5 border border-slate-300 rounded-lg px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-slate-400"
+                />
+              ) : (
+                <div className="text-sm font-semibold text-slate-700 mt-0.5">
+                  {budget.duration_months
+                    ? `${budget.duration_months} months`
+                    : "—"}
+                </div>
+              )}
+            </div>
+            <div>
+              <div className="text-micro-label">Original currency</div>
+              {isEditMode ? (
+                <select
+                  value={actualCurrency}
+                  onChange={(e) => setActualCurrency(e.target.value)}
+                  disabled={isSaving}
+                  className="mt-0.5 border border-slate-300 rounded-lg px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-slate-400"
+                >
+                  <option value="">—</option>
+                  {/* Current value always offered, even if outside the fixed
                     list below, so an existing budget's actual_currency is
                     never silently blanked out just by entering edit mode. */}
-                {actualCurrency && !CURRENCY_CODES.includes(actualCurrency) && (
-                  <option value={actualCurrency}>{actualCurrency}</option>
-                )}
-                {CURRENCY_CODES.map((code) => (
-                  <option key={code} value={code}>
-                    {code}
-                  </option>
-                ))}
-              </select>
-            ) : (
-              <div className="text-sm font-semibold text-slate-700 mt-0.5">
-                {budget.actual_currency ?? "—"}
-              </div>
-            )}
+                  {actualCurrency &&
+                    !CURRENCY_CODES.includes(actualCurrency) && (
+                      <option value={actualCurrency}>{actualCurrency}</option>
+                    )}
+                  {CURRENCY_CODES.map((code) => (
+                    <option key={code} value={code}>
+                      {code}
+                    </option>
+                  ))}
+                </select>
+              ) : (
+                <div className="text-sm font-semibold text-slate-700 mt-0.5">
+                  {budget.actual_currency ?? "—"}
+                </div>
+              )}
+            </div>
+            <div>
+              <div className="text-micro-label">Donor commitment</div>
+              {isEditMode && !isCurrencyOnlyEdit ? (
+                <input
+                  type="number"
+                  min={0}
+                  step="any"
+                  value={donorTotalAmount}
+                  onChange={(e) =>
+                    setDonorTotalAmount(
+                      e.target.value ? Number(e.target.value) : "",
+                    )
+                  }
+                  disabled={isSaving}
+                  className={`w-28 mt-0.5 border rounded-lg px-2 py-1 text-sm focus:outline-none focus:ring-2 ${
+                    donorAmountInvalid
+                      ? "border-red-300 focus:ring-red-400"
+                      : "border-slate-300 focus:ring-slate-400"
+                  }`}
+                />
+              ) : (
+                <div className="text-sm font-semibold text-slate-700 mt-0.5">
+                  {budget.donor_total_amount != null
+                    ? `${budget.donor_total_amount} ${budget.actual_currency ?? ""}`.trim()
+                    : "—"}
+                </div>
+              )}
+              {donorAmountInvalid && (
+                <p className="text-xs text-red-600 mt-0.5">Must be zero or greater.</p>
+              )}
+            </div>
+            <div>
+              <div className="text-micro-label">Estimated rate</div>
+              {isEditMode && !isCurrencyOnlyEdit ? (
+                <input
+                  type="number"
+                  min={0}
+                  step="any"
+                  value={estimatedExchangeRate}
+                  onChange={(e) =>
+                    setEstimatedExchangeRate(
+                      e.target.value ? Number(e.target.value) : "",
+                    )
+                  }
+                  disabled={isSaving}
+                  className={`w-24 mt-0.5 border rounded-lg px-2 py-1 text-sm focus:outline-none focus:ring-2 ${
+                    estimatedRateInvalid
+                      ? "border-red-300 focus:ring-red-400"
+                      : "border-slate-300 focus:ring-slate-400"
+                  }`}
+                />
+              ) : (
+                <div className="text-sm font-semibold text-slate-700 mt-0.5">
+                  {budget.estimated_exchange_rate ?? "—"}
+                </div>
+              )}
+              {estimatedRateInvalid && (
+                <p className="text-xs text-red-600 mt-0.5">Must be greater than zero.</p>
+              )}
+            </div>
           </div>
-        </div>
-      </CardContent>
-    </Card>
-    {!isEditMode && (
-      <>
-        <BudgetConfirmAction
-          budget={budget}
-          onConfirmed={onBudgetUpdated}
-          onBusyChange={setIsActionBusy}
-        />
-        <BudgetCancelConfirmationAction
-          budget={budget}
-          onReverted={onBudgetUpdated}
-          onBusyChange={setIsActionBusy}
-        />
-      </>
-    )}
+
+          {!isEditMode && (
+            <>
+              <BudgetConfirmAction
+                budget={budget}
+                onConfirmed={onBudgetUpdated}
+                onBusyChange={setIsActionBusy}
+              />
+              <BudgetCancelConfirmationAction
+                budget={budget}
+                onReverted={onBudgetUpdated}
+                onBusyChange={setIsActionBusy}
+              />
+            </>
+          )}
+        </CardContent>
+      </Card>
     </>
   );
 }
@@ -353,9 +459,11 @@ function BudgetConfirmAction({
   const [error, setError] = useState("");
 
   const currentCustomerId = getCurrentCustomerId();
-  const isConfirmable = budget.status === "draft" || budget.status === "ai_draft";
+  const isConfirmable =
+    budget.status === "draft" || budget.status === "ai_draft";
   const canConfirm =
-    isBudgetOwner(budget, currentCustomerId) || isBudgetFunder(budget, currentCustomerId);
+    isBudgetOwner(budget, currentCustomerId) ||
+    isBudgetFunder(budget, currentCustomerId);
 
   // Re-sync whenever the widget becomes visible again (e.g. after a revert),
   // covering the case where this component's state outlives the round trip
@@ -386,20 +494,34 @@ function BudgetConfirmAction({
   };
 
   return (
-    <div className="w-full flex flex-wrap items-end gap-3 bg-slate-50 border border-slate-200 rounded-xl px-4 pt-3 pb-1">
-      <span className="text-sm text-slate-600 mb-4">Confirm this budget to unlock reporting:</span>
-      <Input
-        label="Start Date"
-        name="start_date"
-        type="date"
-        value={startDate}
-        onChange={(e) => setStartDate(e.target.value)}
-        disabled={isSaving}
-      />
-      <Button onClick={handleConfirm} disabled={!startDate || isSaving} className="mb-4">
+    <div className="mt-4 pt-3 border-t border-dashed border-slate-200 flex flex-wrap items-center justify-end gap-2">
+      <span className="text-xs text-slate-400 mr-auto">
+        Confirm to unlock reporting
+      </span>
+      <label htmlFor="start_date" className="text-xs text-slate-500">
+        Start date
+      </label>
+      <div className="[&>div]:mb-0">
+        <Input
+          name="start_date"
+          type="date"
+          value={startDate}
+          onChange={(e) => setStartDate(e.target.value)}
+          disabled={isSaving}
+          showLabel={false}
+        />
+      </div>
+      <Button
+        variant="primary"
+        onClick={handleConfirm}
+        disabled={!startDate || isSaving}
+        className="text-sm"
+      >
         {isSaving ? "Confirming..." : "Confirm Budget"}
       </Button>
-      {error && <p className="text-sm text-red-600 mb-4">{error}</p>}
+      {error && (
+        <p className="text-sm text-red-600 w-full text-right">{error}</p>
+      )}
     </div>
   );
 }
@@ -417,7 +539,11 @@ function BudgetCancelConfirmationAction({
   const [error, setError] = useState("");
 
   const currentCustomerId = getCurrentCustomerId();
-  if (budget.status !== "confirmed" || !isBudgetOwner(budget, currentCustomerId)) return null;
+  if (
+    budget.status !== "confirmed" ||
+    !isBudgetOwner(budget, currentCustomerId)
+  )
+    return null;
 
   const handleCancel = async () => {
     setIsSaving(true);
@@ -427,8 +553,8 @@ function BudgetCancelConfirmationAction({
       const updated = await editBudget(budget.id, { status: "draft" });
       onReverted?.(updated);
     } catch (err) {
-      const detail = (err as { response?: { data?: { detail?: string } } })?.response?.data
-        ?.detail;
+      const detail = (err as { response?: { data?: { detail?: string } } })
+        ?.response?.data?.detail;
       setError(detail || "Failed to cancel confirmation. Please try again.");
     } finally {
       setIsSaving(false);
@@ -437,8 +563,10 @@ function BudgetCancelConfirmationAction({
   };
 
   return (
-    <div className="w-full flex flex-wrap items-center gap-3 bg-slate-50 border border-slate-200 rounded-xl px-4 py-3">
-      <span className="text-sm text-slate-500">This budget is confirmed.</span>
+    <div className="mt-4 pt-3 border-t border-dashed border-slate-200 flex flex-wrap items-center justify-end gap-2">
+      <span className="text-xs text-slate-400 mr-auto">
+        This budget is confirmed
+      </span>
       <ConfirmDeleteButton
         variant="danger"
         onConfirm={handleCancel}
@@ -448,7 +576,9 @@ function BudgetCancelConfirmationAction({
       >
         {isSaving ? "Cancelling..." : "Cancel Confirmation"}
       </ConfirmDeleteButton>
-      {error && <p className="text-sm text-red-600">{error}</p>}
+      {error && (
+        <p className="text-sm text-red-600 w-full text-right">{error}</p>
+      )}
     </div>
   );
 }

--- a/frontend-typescript/src/pages/Budgets/components/BudgetViewLinesTable.test.tsx
+++ b/frontend-typescript/src/pages/Budgets/components/BudgetViewLinesTable.test.tsx
@@ -1,4 +1,5 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { vi, type Mock } from "vitest";
 import { BudgetViewLinesTable } from "./BudgetViewLinesTable";
@@ -20,9 +21,13 @@ function makeLine(overrides: Partial<BudgetLine> = {}): BudgetLine {
   return { id: "bl1", budget_id: "b1", description: "Line", amount: 100, ...overrides };
 }
 
-function renderTable(lines: BudgetLine[], spendByLineId: Record<string, number>) {
+function renderTable(
+  lines: BudgetLine[],
+  spendByLineId: Record<string, number>,
+  budgetOverrides: Partial<Budget> = {},
+) {
   useDetailedBudgetMock.mockReturnValue({
-    budget: makeBudget(),
+    budget: makeBudget(budgetOverrides),
     setBudget: vi.fn(),
     budgetCategories: [],
     budgetCategoryNames: [],
@@ -144,5 +149,79 @@ describe("BudgetViewLinesTable mobile card list", () => {
   it("shows an empty state when there are no lines", () => {
     renderTable([], {});
     expect(screen.getByText("No budget lines yet.")).toBeInTheDocument();
+  });
+});
+
+describe("BudgetViewLinesTable currency toggle", () => {
+  it("hides the toggle when the budget has no estimated_exchange_rate", () => {
+    renderTable(
+      [makeLine({ id: "bl1", amount: 800, category: { id: "c1", name: "Staff", code: "STAFF" } })],
+      { bl1: 400 },
+    );
+
+    expect(screen.queryByRole("group", { name: /currency display/i })).not.toBeInTheDocument();
+    expect(screen.getAllByText("£800").length).toBeGreaterThan(0);
+  });
+
+  it("shows the toggle when the budget has an estimated_exchange_rate", () => {
+    renderTable(
+      [makeLine({ id: "bl1", amount: 800, category: { id: "c1", name: "Staff", code: "STAFF" } })],
+      { bl1: 400 },
+      { actual_currency: "EUR", estimated_exchange_rate: 0.8 },
+    );
+
+    expect(screen.getByRole("group", { name: /currency display/i })).toBeInTheDocument();
+  });
+
+  it("labels Amount/Used with the currency in the column header instead of repeating it inline", () => {
+    renderTable(
+      [makeLine({ id: "bl1", amount: 800, category: { id: "c1", name: "Staff", code: "STAFF" } })],
+      { bl1: 400 },
+      { actual_currency: "EUR", estimated_exchange_rate: 0.8 },
+    );
+
+    expect(screen.getByText("Amount (GBP)")).toBeInTheDocument();
+    expect(screen.getByText("Used")).toBeInTheDocument();
+  });
+
+  it("converts Amount and Used to the donor currency when Donor (estimated) is selected, stating the currency once in the header", async () => {
+    const user = userEvent.setup();
+    renderTable(
+      [makeLine({ id: "bl1", amount: 800, category: { id: "c1", name: "Staff", code: "STAFF" } })],
+      { bl1: 400 },
+      { actual_currency: "EUR", estimated_exchange_rate: 0.8 },
+    );
+
+    await user.click(screen.getByRole("button", { name: "Donor (estimated)" }));
+
+    expect(screen.getByText("Amount (EUR est.)")).toBeInTheDocument();
+    expect(screen.getByText("Used (EUR est.)")).toBeInTheDocument();
+    // The desktop table cell doesn't repeat "(est.)" per row — only the
+    // mobile card fallback (no persistent header) still does.
+    const table = screen.getByRole("table");
+    expect(within(table).getAllByText(/€1,000/).length).toBeGreaterThan(0);
+    expect(within(table).queryByText("€1,000 (est.)")).not.toBeInTheDocument();
+    // Mobile cards keep the inline label since they have no column header.
+    expect(screen.getAllByText("€1,000 (est.)").length).toBeGreaterThan(0);
+  });
+
+  it("splits Amount into two real columns — one per currency — when Both is selected", async () => {
+    const user = userEvent.setup();
+    renderTable(
+      [makeLine({ id: "bl1", amount: 800, category: { id: "c1", name: "Staff", code: "STAFF" } })],
+      { bl1: 0 },
+      { actual_currency: "EUR", estimated_exchange_rate: 0.8 },
+    );
+
+    await user.click(screen.getByRole("button", { name: "Both" }));
+
+    expect(screen.getByText("Amount (GBP)")).toBeInTheDocument();
+    expect(screen.getByText("Amount (EUR est.)")).toBeInTheDocument();
+    const table = screen.getByRole("table");
+    expect(within(table).getAllByText(/£800/).length).toBeGreaterThan(0);
+    expect(within(table).getAllByText(/€1,000/).length).toBeGreaterThan(0);
+
+    expect(screen.getAllByText(/£800/).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/€1,000 \(est\.\)/).length).toBeGreaterThan(0);
   });
 });

--- a/frontend-typescript/src/pages/Budgets/components/BudgetViewLinesTable.tsx
+++ b/frontend-typescript/src/pages/Budgets/components/BudgetViewLinesTable.tsx
@@ -10,12 +10,63 @@ import { formatCurrency } from "@/utils/currency";
 import { Edit2, Trash2 } from "lucide-react";
 const columnHelper = createColumnHelper<any>();
 
-const USED_TONE_CLASSES: Record<"good" | "warn" | "danger" | "neutral", string> = {
+const USED_TONE_CLASSES: Record<
+  "good" | "warn" | "danger" | "neutral",
+  string
+> = {
   good: "bg-green-100 text-green-700",
   warn: "bg-amber-100 text-amber-700",
   danger: "bg-red-100 text-red-700",
   neutral: "bg-slate-100 text-slate-500",
 };
+
+// Local UI state only — not persisted, same footprint as any other
+// client-side view toggle (design.md Decision 6).
+type CurrencyDisplayMode = "local" | "donor" | "both";
+
+// estimated_exchange_rate is actual_currency -> local_currency (e.g. 0.8
+// means 1 EUR ~= 0.8 GBP), so converting a local figure back to the donor's
+// currency divides by the rate. Purely a display-layer estimate, never a
+// stored per-line amount (design.md Decision 5).
+function toDonorAmount(localAmount: number, rate: number): number {
+  return localAmount / rate;
+}
+
+function AmountDisplay({
+  localAmount,
+  mode,
+  localCurrency,
+  actualCurrency,
+  rate,
+  // "(est.)" belongs on the column header wherever a column already states
+  // a single currency unambiguously (desktop table); only a cell that must
+  // convey two currencies at once (a combined "both" cell, or a mobile card
+  // with no persistent header) still needs it repeated inline.
+  labelInline = true,
+}: {
+  localAmount: number;
+  mode: CurrencyDisplayMode;
+  localCurrency: string | undefined;
+  actualCurrency: string | undefined;
+  rate: number | null | undefined;
+  labelInline?: boolean;
+}) {
+  if (mode === "local" || !rate) {
+    return <>{formatCurrency(localAmount, localCurrency)}</>;
+  }
+  const donorAmount = toDonorAmount(localAmount, rate);
+  const donorText = labelInline
+    ? `${formatCurrency(donorAmount, actualCurrency)} (est.)`
+    : formatCurrency(donorAmount, actualCurrency);
+  if (mode === "donor") return <>{donorText}</>;
+  return (
+    <>
+      {formatCurrency(localAmount, localCurrency)}
+      <span className="text-slate-400"> / </span>
+      {donorText}
+    </>
+  );
+}
 
 // Compact-pill treatment for "how much of this budget line has been
 // reported so far" — option B from the spend-tracking mockup
@@ -25,14 +76,28 @@ function UsedPill({
   used,
   allocated,
   currency,
+  displayMode,
+  actualCurrency,
+  rate,
+  labelInline = true,
 }: {
   used: number;
   allocated: number;
   currency: string | undefined;
+  displayMode: CurrencyDisplayMode;
+  actualCurrency: string | undefined;
+  rate: number | null | undefined;
+  labelInline?: boolean;
 }) {
   const pct = allocated > 0 ? Math.round((used / allocated) * 100) : null;
   const tone: "good" | "warn" | "danger" | "neutral" =
-    pct === null || pct > 100 ? "danger" : pct === 100 ? "good" : pct > 0 ? "warn" : "neutral";
+    pct === null || pct > 100
+      ? "danger"
+      : pct === 100
+        ? "good"
+        : pct > 0
+          ? "warn"
+          : "neutral";
 
   return (
     <div>
@@ -42,7 +107,23 @@ function UsedPill({
         {pct === null ? "—" : `${pct}%`}
       </span>
       <div className="text-xs text-slate-400 mt-1">
-        {formatCurrency(used, currency)} / {formatCurrency(allocated, currency)}
+        <AmountDisplay
+          localAmount={used}
+          mode={displayMode}
+          localCurrency={currency}
+          actualCurrency={actualCurrency}
+          rate={rate}
+          labelInline={labelInline}
+        />{" "}
+        /{" "}
+        <AmountDisplay
+          localAmount={allocated}
+          mode={displayMode}
+          localCurrency={currency}
+          actualCurrency={actualCurrency}
+          rate={rate}
+          labelInline={labelInline}
+        />
       </div>
     </div>
   );
@@ -71,6 +152,13 @@ export function BudgetViewLinesTable({
     budgetCategoryNames,
     spendByLineId,
   } = useDetailedBudget();
+  const [displayMode, setDisplayMode] = useState<CurrencyDisplayMode>("local");
+  const rate = budget?.estimated_exchange_rate;
+  // A rate of exactly 0 is meaningless (division by zero downstream in
+  // toDonorAmount) — treat it the same as "no rate set" rather than letting
+  // the toggle (and Both mode's direct toDonorAmount calls, which skip
+  // AmountDisplay's own `!rate` guard) render €Infinity.
+  const showCurrencyToggle = rate != null && rate > 0;
   const extraFieldKeys = useMemo((): string[] => {
     const keys = new Set<string>();
     if (!lines) return [];
@@ -108,100 +196,187 @@ export function BudgetViewLinesTable({
     console.log("Delete clicked for line id:", budget_line_id);
     mutation.mutate(budget_line_id);
   };
-  const columns = useMemo<ColumnDef<BudgetLine>[]>(
-    () => {
-      const cols: ColumnDef<BudgetLine>[] = [
-        {
-          header: "Category",
-          accessorFn: (row) => row.category?.name ?? "—",
-          id: "category",
-          enableSorting: true,
-          enableGrouping: true,
-        },
-        {
-          header: "Description",
-          accessorKey: "description",
-          enableSorting: true,
-        },
-        {
-          header: "Amount",
-          accessorKey: "amount",
+  const localCode = budget?.local_currency ?? "local";
+  const donorCode = budget?.actual_currency ?? "donor";
 
+  const columns = useMemo<ColumnDef<BudgetLine>[]>(() => {
+    // Amount: one column per currency when both are requested at once,
+    // each header stating its own currency so no cell needs an inline
+    // "(est.)" suffix repeated on every row (see budget-view-redesign
+    // proposal, note 6). Local/Donor-only modes stay a single column.
+    const amountColumns: ColumnDef<BudgetLine>[] =
+      displayMode === "both"
+        ? [
+            {
+              header: `Amount (${localCode})`,
+              id: "amount_local",
+              accessorFn: (row: BudgetLine) => row.amount ?? 0,
+              cell: (info) => (
+                <span className="font-semibold text-slate-800">
+                  {formatCurrency(info.getValue<number>(), localCode)}
+                </span>
+              ),
+              aggregationFn: "sum",
+              aggregatedCell: (info) => (
+                <span className="font-semibold text-slate-800">
+                  Subtotal:{" "}
+                  {formatCurrency(info.getValue() as number, localCode)}
+                </span>
+              ),
+            },
+            {
+              header: `Amount (${donorCode} est.)`,
+              id: "amount_donor",
+              accessorFn: (row: BudgetLine) => row.amount ?? 0,
+              cell: (info) => (
+                <span className="font-semibold text-slate-800">
+                  {formatCurrency(
+                    toDonorAmount(info.getValue<number>(), rate!),
+                    donorCode,
+                  )}
+                </span>
+              ),
+              aggregationFn: "sum",
+              aggregatedCell: (info) => (
+                <span className="font-semibold text-slate-800">
+                  Subtotal:{" "}
+                  {formatCurrency(
+                    toDonorAmount(info.getValue() as number, rate!),
+                    donorCode,
+                  )}
+                </span>
+              ),
+            },
+          ]
+        : [
+            {
+              header:
+                displayMode === "donor"
+                  ? `Amount (${donorCode} est.)`
+                  : `Amount (${localCode})`,
+              accessorKey: "amount",
+              cell: (info) => (
+                <span className="font-semibold text-slate-800">
+                  <AmountDisplay
+                    localAmount={info.getValue<number>()}
+                    mode={displayMode}
+                    localCurrency={budget?.local_currency}
+                    actualCurrency={budget?.actual_currency}
+                    rate={rate}
+                    labelInline={false}
+                  />
+                </span>
+              ),
+              aggregationFn: "sum",
+              aggregatedCell: (info) => {
+                const value = info.getValue() as number;
+                return (
+                  <span className="font-semibold text-slate-800">
+                    Subtotal:{" "}
+                    <AmountDisplay
+                      localAmount={value}
+                      mode={displayMode}
+                      localCurrency={budget?.local_currency}
+                      actualCurrency={budget?.actual_currency}
+                      rate={rate}
+                      labelInline={false}
+                    />
+                  </span>
+                );
+              },
+            },
+          ];
+
+    const cols: ColumnDef<BudgetLine>[] = [
+      {
+        header: "Category",
+        accessorFn: (row) => row.category?.name ?? "—",
+        id: "category",
+        enableSorting: true,
+        enableGrouping: true,
+      },
+      {
+        header: "Description",
+        accessorKey: "description",
+        enableSorting: true,
+      },
+      ...amountColumns,
+      {
+        header: displayMode === "donor" ? `Used (${donorCode} est.)` : "Used",
+        id: "used",
+        accessorFn: (row: BudgetLine) => spendByLineId[row.id] ?? 0,
+        aggregationFn: "sum",
+        cell: (info) => (
+          <UsedPill
+            used={info.getValue<number>()}
+            allocated={info.row.original.amount ?? 0}
+            currency={budget?.local_currency}
+            displayMode={displayMode}
+            actualCurrency={budget?.actual_currency}
+            rate={rate}
+            labelInline={displayMode === "both"}
+          />
+        ),
+        aggregatedCell: (info) => (
+          <UsedPill
+            used={info.getValue() as number}
+            allocated={(info.row.getValue("amount") as number) ?? 0}
+            currency={budget?.local_currency}
+            displayMode={displayMode}
+            actualCurrency={budget?.actual_currency}
+            rate={rate}
+            labelInline={displayMode === "both"}
+          />
+        ),
+      },
+      // Dynamically add columns for extra_fields
+      ...extraFieldKeys.map((key: string) => ({
+        header: key,
+        accessorFn: (row: BudgetLine) => row.extra_fields?.[key] ?? "—",
+        id: key, // important for unique identification
+      })),
+    ];
+
+    if (!readOnly) {
+      cols.push(
+        columnHelper.display({
+          id: "actions",
+          enableSorting: false,
           cell: (info) => (
-            <span className="font-semibold text-slate-800">
-              {formatCurrency(info.getValue<number>(), budget?.local_currency)}
-            </span>
-          ),
-          aggregationFn: "sum",
-          aggregatedCell: (info) => {
-            const value = info.getValue() as number;
-            return (
-              <span className="font-semibold text-slate-800">
-                Subtotal: {formatCurrency(value, budget?.local_currency)}
-              </span>
-            );
-          },
-        },
-        {
-          header: "Used",
-          id: "used",
-          accessorFn: (row: BudgetLine) => spendByLineId[row.id] ?? 0,
-          aggregationFn: "sum",
-          cell: (info) => (
-            <UsedPill
-              used={info.getValue<number>()}
-              allocated={info.row.original.amount ?? 0}
-              currency={budget?.local_currency}
-            />
-          ),
-          aggregatedCell: (info) => (
-            <UsedPill
-              used={info.getValue() as number}
-              allocated={(info.row.getValue("amount") as number) ?? 0}
-              currency={budget?.local_currency}
-            />
-          ),
-        },
-        // Dynamically add columns for extra_fields
-        ...extraFieldKeys.map((key: string) => ({
-          header: key,
-          accessorFn: (row: BudgetLine) => row.extra_fields?.[key] ?? "—",
-          id: key, // important for unique identification
-        })),
-      ];
+            <div className="flex items-center space-x-1">
+              <Button
+                variant="icon"
+                onClick={() => onEdit(info.row.original)}
+                title="Edit line"
+              >
+                <Edit2 size={16} />
+              </Button>
 
-      if (!readOnly) {
-        cols.push(
-          columnHelper.display({
-            id: "actions",
-            enableSorting: false,
-            cell: (info) => (
-              <div className="flex items-center space-x-1">
-                <Button
-                  variant="icon"
-                  onClick={() => onEdit(info.row.original)}
-                  title="Edit line"
-                >
-                  <Edit2 size={16} />
-                </Button>
+              <ConfirmDeleteButton
+                variant="icon-danger"
+                title="Delete line"
+                onConfirm={() => onDelete(info.row.original.id)}
+              >
+                <Trash2 size={16} />
+              </ConfirmDeleteButton>
+            </div>
+          ),
+        }),
+      );
+    }
 
-                <ConfirmDeleteButton
-                  variant="icon-danger"
-                  title="Delete line"
-                  onConfirm={() => onDelete(info.row.original.id)}
-                >
-                  <Trash2 size={16} />
-                </ConfirmDeleteButton>
-              </div>
-            ),
-          }),
-        );
-      }
-
-      return cols;
-    },
-    [extraFieldKeys, readOnly, budget?.local_currency, spendByLineId],
-  );
+    return cols;
+  }, [
+    extraFieldKeys,
+    readOnly,
+    budget?.local_currency,
+    budget?.actual_currency,
+    spendByLineId,
+    displayMode,
+    rate,
+    localCode,
+    donorCode,
+  ]);
 
   // Mobile card list: same data as the desktop table, grouped by category
   // like TableCommon's grouping does, but always-expanded (no separate
@@ -220,15 +395,47 @@ export function BudgetViewLinesTable({
 
   return (
     <div className="w-full bg-white rounded-xl border border-slate-200 shadow-sm p-6">
-      <div className="flex items-center justify-between mb-4">
-        <h2 className="text-section-title">
-          Budget Lines
-        </h2>
-        {!readOnly && (
-          <Button variant="secondary" onClick={onNew} className="text-sm">
-            New Budget Line
-          </Button>
-        )}
+      <div className="flex items-center justify-between mb-4 flex-wrap gap-2">
+        <h2 className="text-section-title">Budget Lines</h2>
+        <div className="flex items-center gap-3">
+          {showCurrencyToggle && (
+            <div
+              className="flex space-x-2"
+              role="group"
+              aria-label="Currency display"
+            >
+              <Button
+                variant="toggle"
+                active={displayMode === "local"}
+                onClick={() => setDisplayMode("local")}
+                className="text-xs px-2 py-1"
+              >
+                Local
+              </Button>
+              <Button
+                variant="toggle"
+                active={displayMode === "donor"}
+                onClick={() => setDisplayMode("donor")}
+                className="text-xs px-2 py-1"
+              >
+                Donor (estimated)
+              </Button>
+              <Button
+                variant="toggle"
+                active={displayMode === "both"}
+                onClick={() => setDisplayMode("both")}
+                className="text-xs px-2 py-1"
+              >
+                Both
+              </Button>
+            </div>
+          )}
+          {!readOnly && (
+            <Button variant="primary" onClick={onNew} className="text-sm">
+              New Budget Line
+            </Button>
+          )}
+        </div>
       </div>
 
       <div className="hidden sm:block">
@@ -240,43 +447,78 @@ export function BudgetViewLinesTable({
           <p className="text-sm text-slate-500">No budget lines yet.</p>
         ) : (
           groupedByCategory.map(([categoryName, categoryLines]) => {
-            const subtotal = categoryLines.reduce((sum, l) => sum + (l.amount ?? 0), 0);
+            const subtotal = categoryLines.reduce(
+              (sum, l) => sum + (l.amount ?? 0),
+              0,
+            );
             const categoryUsed = categoryLines.reduce(
               (sum, l) => sum + (spendByLineId[l.id] ?? 0),
               0,
             );
             return (
-              <div key={categoryName} className="border border-slate-200 rounded-lg">
+              <div
+                key={categoryName}
+                className="border border-slate-200 rounded-lg"
+              >
                 <div className="flex items-center justify-between gap-3 px-3 py-2 bg-slate-50 rounded-t-lg">
                   <span className="text-sm font-semibold text-slate-700">
-                    {categoryName} <span className="text-slate-400 font-normal">({categoryLines.length})</span>
+                    {categoryName}{" "}
+                    <span className="text-slate-400 font-normal">
+                      ({categoryLines.length})
+                    </span>
                   </span>
                   <div className="flex items-center gap-3">
                     <span className="text-sm font-semibold text-slate-800">
-                      {formatCurrency(subtotal, budget?.local_currency)}
+                      <AmountDisplay
+                        localAmount={subtotal}
+                        mode={displayMode}
+                        localCurrency={budget?.local_currency}
+                        actualCurrency={budget?.actual_currency}
+                        rate={rate}
+                      />
                     </span>
-                    <UsedPill used={categoryUsed} allocated={subtotal} currency={budget?.local_currency} />
+                    <UsedPill
+                      used={categoryUsed}
+                      allocated={subtotal}
+                      currency={budget?.local_currency}
+                      displayMode={displayMode}
+                      actualCurrency={budget?.actual_currency}
+                      rate={rate}
+                    />
                   </div>
                 </div>
                 <div className="divide-y divide-slate-100">
                   {categoryLines.map((line) => (
                     <div key={line.id} className="p-3 flex flex-col gap-2">
                       <div className="flex items-start justify-between gap-3">
-                        <span className="text-sm text-slate-700">{line.description}</span>
+                        <span className="text-sm text-slate-700">
+                          {line.description}
+                        </span>
                         <span className="text-sm font-semibold text-slate-800 whitespace-nowrap">
-                          {formatCurrency(line.amount ?? 0, budget?.local_currency)}
+                          <AmountDisplay
+                            localAmount={line.amount ?? 0}
+                            mode={displayMode}
+                            localCurrency={budget?.local_currency}
+                            actualCurrency={budget?.actual_currency}
+                            rate={rate}
+                          />
                         </span>
                       </div>
                       <UsedPill
                         used={spendByLineId[line.id] ?? 0}
                         allocated={line.amount ?? 0}
                         currency={budget?.local_currency}
+                        displayMode={displayMode}
+                        actualCurrency={budget?.actual_currency}
+                        rate={rate}
                       />
                       {extraFieldKeys
                         .filter((key) => line.extra_fields?.[key] !== undefined)
                         .map((key) => (
                           <div key={key} className="text-xs text-slate-500">
-                            <span className="font-medium text-slate-600">{key}:</span>{" "}
+                            <span className="font-medium text-slate-600">
+                              {key}:
+                            </span>{" "}
                             {String(line.extra_fields?.[key] ?? "—")}
                           </div>
                         ))}

--- a/frontend-typescript/src/pages/Budgets/components/BudgetViewSummary.test.tsx
+++ b/frontend-typescript/src/pages/Budgets/components/BudgetViewSummary.test.tsx
@@ -26,11 +26,40 @@ function makeBudget(overrides: Partial<Budget> = {}): Budget {
 }
 
 describe("BudgetViewSummary", () => {
-  it("shows Total Reported and its percentage of the budget", () => {
+  it("shows the Total Amount as the hero figure", () => {
+    useDetailedBudgetMock.mockReturnValue({
+      budget: makeBudget(),
+      totalAmount: 2200,
+      totalReported: 0,
+      hasReports: false,
+    });
+
+    render(<BudgetViewSummary />);
+
+    expect(screen.getByText("Total amount")).toBeInTheDocument();
+    expect(screen.getByText("£2,200")).toBeInTheDocument();
+  });
+
+  it("shows line count and categories as a small caption, not equal-weight stat tiles", () => {
+    useDetailedBudgetMock.mockReturnValue({
+      budget: makeBudget(),
+      totalAmount: 2200,
+      totalReported: 0,
+      hasReports: false,
+    });
+
+    render(<BudgetViewSummary />);
+
+    expect(screen.getByText("2")).toBeInTheDocument();
+    expect(screen.getByText("lines")).toBeInTheDocument();
+  });
+
+  it("shows Total Reported and its percentage when at least one report exists", () => {
     useDetailedBudgetMock.mockReturnValue({
       budget: makeBudget(),
       totalAmount: 2200,
       totalReported: 550,
+      hasReports: true,
     });
 
     render(<BudgetViewSummary />);
@@ -40,15 +69,136 @@ describe("BudgetViewSummary", () => {
     expect(screen.getByText("25% of budget")).toBeInTheDocument();
   });
 
-  it("shows 0% of budget when nothing has been reported yet", () => {
+  it("shows 0% of budget when a report exists but nothing has been reported yet", () => {
     useDetailedBudgetMock.mockReturnValue({
       budget: makeBudget(),
       totalAmount: 2200,
       totalReported: 0,
+      hasReports: true,
     });
 
     render(<BudgetViewSummary />);
 
+    expect(screen.getByText("Total Reported")).toBeInTheDocument();
     expect(screen.getByText("0% of budget")).toBeInTheDocument();
+  });
+
+  it("hides Total Reported entirely when no reports exist yet", () => {
+    useDetailedBudgetMock.mockReturnValue({
+      budget: makeBudget(),
+      totalAmount: 2200,
+      totalReported: 0,
+      hasReports: false,
+    });
+
+    render(<BudgetViewSummary />);
+
+    expect(screen.queryByText("Total Reported")).not.toBeInTheDocument();
+  });
+
+  it("shows the donor commitment and estimated local cap when estimated_local_cap is set", () => {
+    useDetailedBudgetMock.mockReturnValue({
+      budget: makeBudget({
+        donor_total_amount: 10000,
+        estimated_exchange_rate: 0.8,
+        estimated_local_cap: 8000,
+        actual_currency: "EUR",
+      }),
+      totalAmount: 2200,
+      totalReported: 0,
+      hasReports: false,
+    });
+
+    render(<BudgetViewSummary />);
+
+    expect(screen.getByText("€10,000")).toBeInTheDocument();
+    expect(
+      screen.getByText("donor commitment @ 0.8 est. → £8,000 local cap"),
+    ).toBeInTheDocument();
+  });
+
+  it("falls back to today's local-only display when estimated_local_cap is null", () => {
+    useDetailedBudgetMock.mockReturnValue({
+      budget: makeBudget({ donor_total_amount: 10000 }),
+      totalAmount: 2200,
+      totalReported: 0,
+      hasReports: false,
+    });
+
+    render(<BudgetViewSummary />);
+
+    expect(screen.queryByText("€10,000")).not.toBeInTheDocument();
+    expect(screen.queryByText(/donor commitment/)).not.toBeInTheDocument();
+  });
+
+  it("flags the total amount green and 'on target' when within tolerance of the cap", () => {
+    useDetailedBudgetMock.mockReturnValue({
+      budget: makeBudget({
+        donor_total_amount: 10000,
+        estimated_exchange_rate: 0.8,
+        estimated_local_cap: 8000,
+        actual_currency: "EUR",
+      }),
+      totalAmount: 8100,
+      totalReported: 0,
+      hasReports: false,
+    });
+
+    render(<BudgetViewSummary />);
+
+    expect(screen.getByText("£8,100")).toHaveClass("text-green-600");
+    expect(screen.getByText("on target")).toBeInTheDocument();
+  });
+
+  it("flags the total amount amber and shows the shortfall when meaningfully below the cap", () => {
+    useDetailedBudgetMock.mockReturnValue({
+      budget: makeBudget({
+        donor_total_amount: 10000,
+        estimated_exchange_rate: 0.8,
+        estimated_local_cap: 8000,
+        actual_currency: "EUR",
+      }),
+      totalAmount: 7000,
+      totalReported: 0,
+      hasReports: false,
+    });
+
+    render(<BudgetViewSummary />);
+
+    expect(screen.getByText("£7,000")).toHaveClass("text-amber-600");
+    expect(screen.getByText("13% under cap")).toBeInTheDocument();
+  });
+
+  it("flags the total amount red and shows the overage when meaningfully above the cap", () => {
+    useDetailedBudgetMock.mockReturnValue({
+      budget: makeBudget({
+        donor_total_amount: 10000,
+        estimated_exchange_rate: 0.8,
+        estimated_local_cap: 8000,
+        actual_currency: "EUR",
+      }),
+      totalAmount: 8500,
+      totalReported: 0,
+      hasReports: false,
+    });
+
+    render(<BudgetViewSummary />);
+
+    expect(screen.getByText("£8,500")).toHaveClass("text-red-600");
+    expect(screen.getByText("6% over cap")).toBeInTheDocument();
+  });
+
+  it("does not show an allocation badge when there is no donor estimate to compare against", () => {
+    useDetailedBudgetMock.mockReturnValue({
+      budget: makeBudget(),
+      totalAmount: 2200,
+      totalReported: 0,
+      hasReports: false,
+    });
+
+    render(<BudgetViewSummary />);
+
+    expect(screen.getByText("£2,200")).toHaveClass("text-slate-900");
+    expect(screen.queryByText(/on target|over cap|under cap/)).not.toBeInTheDocument();
   });
 });

--- a/frontend-typescript/src/pages/Budgets/components/BudgetViewSummary.tsx
+++ b/frontend-typescript/src/pages/Budgets/components/BudgetViewSummary.tsx
@@ -2,6 +2,44 @@ import { Card, CardContent, CardHeader } from "@/components/ui/Card";
 import { useDetailedBudget } from "../SingleBudgetViewContext";
 import { formatCurrency } from "@/utils/currency";
 
+// How far allocated total can drift from the donor's estimated local cap
+// before it's flagged — FX rates are estimates, so small drift is expected.
+const ALLOCATION_TOLERANCE_PCT = 2;
+
+type AllocationTone = "over" | "under" | "onTarget";
+
+function getAllocationTone(totalAmount: number, estimatedLocalCap: number): {
+  tone: AllocationTone;
+  diffPct: number;
+} {
+  if (estimatedLocalCap <= 0) return { tone: "onTarget", diffPct: 0 };
+  const diffPct = ((totalAmount - estimatedLocalCap) / estimatedLocalCap) * 100;
+  if (diffPct > ALLOCATION_TOLERANCE_PCT) return { tone: "over", diffPct };
+  if (diffPct < -ALLOCATION_TOLERANCE_PCT) return { tone: "under", diffPct };
+  return { tone: "onTarget", diffPct };
+}
+
+const ALLOCATION_STYLES: Record<
+  AllocationTone,
+  { text: string; pill: string; label: (diffPct: number) => string }
+> = {
+  over: {
+    text: "text-red-600",
+    pill: "bg-red-100 text-red-700",
+    label: (diffPct) => `${Math.round(diffPct)}% over cap`,
+  },
+  under: {
+    text: "text-amber-600",
+    pill: "bg-amber-100 text-amber-700",
+    label: (diffPct) => `${Math.round(Math.abs(diffPct))}% under cap`,
+  },
+  onTarget: {
+    text: "text-green-600",
+    pill: "bg-green-100 text-green-700",
+    label: () => "on target",
+  },
+};
+
 export function SummaryStat({
   label,
   value,
@@ -23,7 +61,7 @@ export function SummaryStat({
 }
 
 export function BudgetViewSummary() {
-  const { budget, totalAmount, totalReported } = useDetailedBudget();
+  const { budget, totalAmount, totalReported, hasReports } = useDetailedBudget();
 
   const categories = [...new Set(budget?.lines?.map((l) => l?.category?.name))].filter(
     Boolean,
@@ -31,6 +69,13 @@ export function BudgetViewSummary() {
   const totalAmountNumber = Number(totalAmount);
   const reportedPct =
     totalAmountNumber > 0 ? Math.round((totalReported / totalAmountNumber) * 100) : 0;
+  const estimatedLocalCap = budget?.estimated_local_cap;
+  const hasEstimate = estimatedLocalCap != null;
+  const lineCount = budget?.lines?.length ?? 0;
+  const allocation = hasEstimate
+    ? getAllocationTone(totalAmountNumber, estimatedLocalCap!)
+    : null;
+  const allocationStyle = allocation ? ALLOCATION_STYLES[allocation.tone] : null;
   return (
     <Card className="w-full bg-white rounded-xl border border-slate-200 shadow-sm px-6 py-5">
       <CardHeader>
@@ -39,22 +84,68 @@ export function BudgetViewSummary() {
         </h2>
       </CardHeader>
       <CardContent>
-        <div className="grid grid-cols-2 sm:grid-cols-4 gap-x-8 gap-y-4">
-          <SummaryStat label="Total Lines" value={budget?.lines?.length ?? 0} />
-          <SummaryStat
-            label="Total Amount"
-            value={formatCurrency(totalAmountNumber, budget?.local_currency)}
-          />
-          <SummaryStat
-            label="Categories"
-            value={categories.length ? categories.join(", ") : "—"}
-          />
-          <SummaryStat
-            label="Total Reported"
-            value={formatCurrency(totalReported, budget?.local_currency)}
-            sub={`${reportedPct}% of budget`}
-          />
+        {/* Money leads: Total Amount is the hero figure, paired against the
+            donor's promise and its estimated local cap where one exists.
+            Line/category counts are reference-only — see the caption below,
+            not stat tiles of equal visual weight. */}
+        <div className="flex flex-wrap items-baseline gap-x-5 gap-y-2">
+          <div>
+            <div className="text-micro-label">Total amount</div>
+            <div className="flex items-baseline gap-2 mt-0.5">
+              <div
+                className={`text-3xl font-bold ${allocationStyle ? allocationStyle.text : "text-slate-900"}`}
+              >
+                {formatCurrency(totalAmountNumber, budget?.local_currency)}
+              </div>
+              {allocation && allocationStyle && (
+                <span
+                  className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-semibold ${allocationStyle.pill}`}
+                >
+                  {allocationStyle.label(allocation.diffPct)}
+                </span>
+              )}
+            </div>
+          </div>
+          {hasEstimate && (
+            <>
+              <div className="text-2xl text-slate-300 self-center" aria-hidden="true">
+                ≈
+              </div>
+              <div className="flex flex-col">
+                <span className="text-base font-bold text-slate-700">
+                  {formatCurrency(budget!.donor_total_amount!, budget?.actual_currency)}
+                </span>
+                <span className="text-xs text-slate-400">
+                  donor commitment @ {budget!.estimated_exchange_rate} est. →{" "}
+                  {formatCurrency(estimatedLocalCap!, budget?.local_currency)} local cap
+                </span>
+              </div>
+            </>
+          )}
         </div>
+
+        <div className="mt-3 text-xs text-slate-500">
+          <span className="font-semibold text-slate-700">{lineCount}</span>{" "}
+          {lineCount === 1 ? "line" : "lines"}
+          {categories.length > 0 && (
+            <>
+              {" "}
+              across <span className="font-semibold text-slate-700">{categories.join(", ")}</span>
+            </>
+          )}
+        </div>
+
+        {/* A budget with zero reports filed has nothing real to show here —
+            an always-£0/0% stat isn't a signal worth a permanent slot. */}
+        {hasReports && (
+          <div className="mt-4 pt-4 border-t border-dashed border-slate-200">
+            <SummaryStat
+              label="Total Reported"
+              value={formatCurrency(totalReported, budget?.local_currency)}
+              sub={`${reportedPct}% of budget`}
+            />
+          </div>
+        )}
       </CardContent>
     </Card>
   );

--- a/frontend-typescript/src/pages/Budgets/components/BudgetViewTraces.test.tsx
+++ b/frontend-typescript/src/pages/Budgets/components/BudgetViewTraces.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen } from "@testing-library/react";
+import { BudgetViewTraces } from "./BudgetViewTraces";
+
+describe("BudgetViewTraces", () => {
+  it("condenses created/updated into one slim line instead of two cards", () => {
+    render(
+      <BudgetViewTraces
+        budget={{
+          trace: {
+            created: {
+              user: { first_name: "Jane", last_name: "Doe" },
+              event_date: "2026-07-28T10:14:00Z",
+            },
+            updated: {
+              user: { first_name: "Jane", last_name: "Doe" },
+              event_date: "2026-08-02T09:02:00Z",
+            },
+          },
+        }}
+      />,
+    );
+
+    expect(screen.getByText(/Created by Jane Doe/)).toBeInTheDocument();
+    expect(screen.getByText(/Updated by Jane Doe/)).toBeInTheDocument();
+  });
+
+  it("falls back to an em dash when no trace data exists", () => {
+    render(<BudgetViewTraces budget={{}} />);
+
+    expect(screen.getByText(/Created by — · —/)).toBeInTheDocument();
+    expect(screen.getByText(/Updated by — · —/)).toBeInTheDocument();
+  });
+});

--- a/frontend-typescript/src/pages/Budgets/components/BudgetViewTraces.tsx
+++ b/frontend-typescript/src/pages/Budgets/components/BudgetViewTraces.tsx
@@ -1,30 +1,23 @@
-import { Card, CardContent, CardHeader } from "@/components/ui/Card";
+type TraceEvent = {
+  user?: { first_name?: string; last_name?: string; email?: string } | null;
+  event_date?: string | null;
+} | null;
 
-function TraceBlock({ label, event }: { label: string; event?: { user?: { first_name?: string; last_name?: string; email?: string } | null; event_date?: string | null } | null }) {
+function traceText(label: string, event: TraceEvent): string {
   const name = [event?.user?.first_name, event?.user?.last_name].filter(Boolean).join(" ") || "—";
-  return (
-    <div className="p-4 bg-slate-50 rounded-lg border border-slate-200">
-      <h3 className="text-micro-label mb-2">
-        {label}
-      </h3>
-      <p className="text-sm font-medium text-slate-700">{name}</p>
-      <p className="text-sm text-slate-500">{event?.user?.email ?? "—"}</p>
-      <p className="text-xs text-slate-400 mt-1">
-        {event?.event_date ? new Date(event.event_date).toLocaleString() : "—"}
-      </p>
-    </div>
-  );
+  const date = event?.event_date ? new Date(event.event_date).toLocaleString() : "—";
+  return `${label} by ${name} · ${date}`;
 }
 
+// Provenance metadata — the least important thing on this page, so it gets
+// one slim caption line rather than two full padded cards (see
+// budget-view-redesign proposal, note 7).
 export function BudgetViewTraces({ budget }: { budget: any }) {
   return (
-    <Card className="grid md:grid-cols-2 gap-4 p-6 bg-white rounded-xl border border-slate-200 shadow-sm">
-      <CardHeader className="contents">
-        <TraceBlock label="Created" event={budget.trace?.created} />
-      </CardHeader>
-      <CardContent className="contents">
-        <TraceBlock label="Last Updated" event={budget.trace?.updated} />
-      </CardContent>
-    </Card>
+    <div className="px-1 text-xs text-slate-400 flex flex-wrap items-center gap-x-1.5 gap-y-0.5">
+      <span>{traceText("Created", budget.trace?.created)}</span>
+      <span className="text-slate-300">—</span>
+      <span>{traceText("Updated", budget.trace?.updated)}</span>
+    </div>
   );
 }

--- a/frontend-typescript/src/pages/Budgets/types/budget.ts
+++ b/frontend-typescript/src/pages/Budgets/types/budget.ts
@@ -52,6 +52,14 @@ export interface Budget {
   start_date?: string | null; // ISO date string
   end_date?: string | null; // ISO date string — computed backend-side from start_date + duration_months
   total_amount?: number;
+  // Donor's stated commitment, in actual_currency — directly entered, not derived.
+  donor_total_amount?: number | null;
+  // Grantee's own planning-time estimate of actual_currency -> local_currency, entered up front.
+  estimated_exchange_rate?: number | null;
+  // Set when the budget transitions to confirmed; refreshed on revert + re-confirm.
+  confirmed_at?: string | null; // ISO date string
+  // Read-only, computed backend-side as donor_total_amount * estimated_exchange_rate; null when either input is unset.
+  estimated_local_cap?: number | null;
   owner?: CustomerOut;
   funder?: CustomerOut | { name?: string; id?: string };
   trace?: TraceOut;
@@ -68,6 +76,10 @@ export interface BudgetUpdate {
   status?: string;
   actual_currency?: string;
   start_date?: string;
+  // Explicit `null` clears the field on save; `undefined` (the key omitted
+  // entirely) leaves it unchanged — see BudgetViewHeader's saveEdit.
+  donor_total_amount?: number | null;
+  estimated_exchange_rate?: number | null;
 }
 
 export interface BudgetPatched {
@@ -81,6 +93,8 @@ export interface BudgetPatched {
   local_currency?: string;
   actual_currency?: string;
   start_date?: string | null;
+  donor_total_amount?: number | null;
+  estimated_exchange_rate?: number | null;
 }
 
 // Reports

--- a/frontend-typescript/src/pages/DonorDashboard/DonorDashboard.test.tsx
+++ b/frontend-typescript/src/pages/DonorDashboard/DonorDashboard.test.tsx
@@ -154,6 +154,57 @@ describe("DonorDashboard", () => {
     );
   });
 
+  it("shows the donor commitment and estimated rate alongside a budget's total when estimated_local_cap is set", async () => {
+    getFundedBudgetsSummaryMock.mockResolvedValue({
+      total_budgets: 1,
+      total_allocated_by_currency: [{ currency: "GBP", total_allocated: 4200 }],
+    });
+    getFundedGranteesMock.mockResolvedValue([]);
+    getFundedBudgetsMock.mockResolvedValue([
+      {
+        id: "b1",
+        name: "Clean Water Phase 1",
+        status: "draft",
+        total_amount: 6000,
+        local_currency: "GBP",
+        actual_currency: "EUR",
+        donor_total_amount: 10000,
+        estimated_exchange_rate: 0.8,
+        estimated_local_cap: 8000,
+        owner: { id: "g1", name: "Hope Relief NGO" },
+      },
+    ]);
+
+    renderDashboard();
+
+    await waitFor(() => expect(screen.getByText("Clean Water Phase 1")).toBeInTheDocument());
+    expect(screen.getByText("£6,000")).toBeInTheDocument();
+    expect(screen.getByText("€10,000 @ 0.8 (est.)")).toBeInTheDocument();
+  });
+
+  it("shows only the local total for a budget with no estimated_local_cap set", async () => {
+    getFundedBudgetsSummaryMock.mockResolvedValue({
+      total_budgets: 1,
+      total_allocated_by_currency: [{ currency: "GBP", total_allocated: 4200 }],
+    });
+    getFundedGranteesMock.mockResolvedValue([]);
+    getFundedBudgetsMock.mockResolvedValue([
+      {
+        id: "b1",
+        name: "Clean Water Phase 1",
+        status: "draft",
+        total_amount: 1000,
+        local_currency: "GBP",
+        owner: { id: "g1", name: "Hope Relief NGO" },
+      },
+    ]);
+
+    renderDashboard();
+
+    await waitFor(() => expect(screen.getByText("£1,000")).toBeInTheDocument());
+    expect(screen.queryByText(/\(est\.\)/)).not.toBeInTheDocument();
+  });
+
   it("shows an empty state when the donor has zero funded budgets", async () => {
     getFundedBudgetsSummaryMock.mockResolvedValue({
       total_budgets: 0,

--- a/frontend-typescript/src/pages/DonorDashboard/DonorDashboard.tsx
+++ b/frontend-typescript/src/pages/DonorDashboard/DonorDashboard.tsx
@@ -46,9 +46,20 @@ const budgetColumns = [
     header: "Total Allocated",
     cell: (info) => {
       const value = info.getValue();
-      return value != null
+      const local = value != null
         ? formatCurrency(value, info.row.original.local_currency)
         : "—";
+      const { donor_total_amount, estimated_exchange_rate, estimated_local_cap, actual_currency } =
+        info.row.original;
+      if (estimated_local_cap == null) return local;
+      return (
+        <div>
+          <div>{local}</div>
+          <div className="text-xs text-slate-500">
+            {`${formatCurrency(donor_total_amount!, actual_currency)} @ ${estimated_exchange_rate} (est.)`}
+          </div>
+        </div>
+      );
     },
   }),
   budgetColumnHelper.display({

--- a/frontend-typescript/src/style.css
+++ b/frontend-typescript/src/style.css
@@ -1,7 +1,5 @@
 @import "tailwindcss";
 
-@theme {  --color-mint-500: oklch(0.72 0.11 178);}
-
 /* Type-scale tokens from the budget-report-frontend mockup
    (openspec/changes/budget-report-frontend, ticket #160). Adopted going
    forward on new/touched components — not retrofitted across the whole app

--- a/openspec/changes/budget-report-iteration-2/tasks.md
+++ b/openspec/changes/budget-report-iteration-2/tasks.md
@@ -1,5 +1,7 @@
 Workflow rule: **one group = one GitHub ticket = one PR, merged before the next group starts.** Tickets are already created (see each group's heading); branch per ticket as shown. Do not start a group until the previous one's PR is merged. Every PR: backend `flake8 --max-line-length=100` / frontend `npm run lint` clean; commits/pushes only with explicit user approval.
 
+**Exception (2026-08-02, explicit user request, not standard practice):** Groups 2, 3, 4, and 6 all depend only on group 1 (merged, ticket #179) and not on each other, so they are being implemented and shipped together as one PR on branch `Combined/Issue-180-181-182-184/iteration2-batch2`, closing tickets #180, #181, #182, #184 together. Groups 5 and 7 still depend on 4 and 6 respectively and stay in their own later PRs.
+
 ## 1. Backend: donor commitment, estimated rate, confirmed_at — ticket #179 (`Budget/Issue-179/donor-commitment-fields`)
 
 - [x] 1.1 Add a migration for `budgets.donor_total_amount` (nullable float), `budgets.estimated_exchange_rate` (nullable float), and `budgets.confirmed_at` (nullable timestamp). No backfill. — `000009_add_budget_donor_commitment_fields.py` (down_revision `000008`), verified `alembic upgrade head`/`downgrade -1`/`upgrade head` against real local Postgres.
@@ -9,32 +11,32 @@ Workflow rule: **one group = one GitHub ticket = one PR, merged before the next 
 - [x] 1.5 In `update_budget_service`'s confirm-transition branch (`services/budget/app/services/budget_services.py:196` onward), set `confirmed_at` to the current time on confirm; ensure it's set again (not left stale) if a budget is reverted to `draft` and confirmed a second time.
 - [x] 1.6 Add `estimated_local_cap` as a computed field (`donor_total_amount × estimated_exchange_rate`; `null` when either input is unset or zero) assembled at read time, not persisted. — `_compute_estimated_local_cap` in `budget_services.py`, wired into `populate_budget_with_user_details`.
 - [x] 1.7 Add/extend backend tests: set `donor_total_amount`/`estimated_exchange_rate` on an unconfirmed budget; reject the same updates on a confirmed budget; `confirmed_at` set on first confirm and updated on re-confirm after a revert; `estimated_local_cap` correct when both inputs are set, `null` when either is missing. — `tests/test_budget_donor_commitment.py` (12 new tests); also updated `test_budget_currency_fields.py`'s exact-kwargs assertion to account for the new `update_budget` call args.
-- [ ] 1.8 Run `services/budget`'s tests and lint clean; PR merged. — tests/lint/mypy clean (207/207 passing, flake8 `--max-line-length=100` clean, black clean, mypy has only a pre-existing unrelated error); PR not yet opened/merged.
+- [x] 1.8 Run `services/budget`'s tests and lint clean; PR merged. — tests/lint/mypy clean (207/207 passing, flake8 `--max-line-length=100` clean, black clean, mypy has only a pre-existing unrelated error); ticket #179 merged.
 
-## 2. Frontend: donor commitment display — ticket #180 (`Frontend/Issue-180/donor-commitment-display`) — depends on 1
+## 2. Frontend: donor commitment display — ticket #180 (combined into `Combined/Issue-180-181-182-184/iteration2-batch2`, see exception above) — depends on 1
 
-- [ ] 2.1 Add `donor_total_amount`, `estimated_exchange_rate`, `confirmed_at`, `estimated_local_cap` to `Budget`, and the first two to `BudgetUpdate`/`BudgetPatched` (`frontend-typescript/src/pages/Budgets/types/budget.ts`).
-- [ ] 2.2 Add editable `donor_total_amount` and `estimated_exchange_rate` fields to the budget edit form, disabled under the same condition the form already disables `actual_currency` (confirmed budget).
-- [ ] 2.3 Show the donor commitment, the estimated rate, and the estimated local cap alongside the real `total_amount` (labeled "estimated" where derived) wherever the single-budget view currently shows the total (`BudgetViewHeader.tsx` / `SingleBudgetView.tsx`), falling back to today's local-only display when `estimated_local_cap` is `null`.
-- [ ] 2.4 Apply the same donor/local pairing to each budget's total in `DonorDashboard.tsx` wherever a per-budget `total_amount` is listed (not the aggregate `total_allocated` figure — that stays out of scope per design.md).
-- [ ] 2.5 Add/extend tests for the edit form and both display sites covering: estimate shown when `estimated_local_cap` is set, local-only fallback when it's `null`.
-- [ ] 2.6 Run the frontend test suite and lint clean; PR merged.
+- [x] 2.1 Add `donor_total_amount`, `estimated_exchange_rate`, `confirmed_at`, `estimated_local_cap` to `Budget`, and the first two to `BudgetUpdate`/`BudgetPatched` (`frontend-typescript/src/pages/Budgets/types/budget.ts`).
+- [x] 2.2 Add editable `donor_total_amount` and `estimated_exchange_rate` fields to the budget edit form, disabled under the same condition the form already disables `actual_currency` (confirmed budget). — added to `BudgetViewHeader.tsx`'s inline edit form, gated by `isEditMode && !isCurrencyOnlyEdit` (locked same as name/duration, matching the backend's `_is_metadata_edit` list — unlike `actual_currency`, which the backend deliberately excludes from that lock).
+- [x] 2.3 Show the donor commitment, the estimated rate, and the estimated local cap alongside the real `total_amount` (labeled "estimated" where derived) wherever the single-budget view currently shows the total (`BudgetViewHeader.tsx` / `SingleBudgetView.tsx`), falling back to today's local-only display when `estimated_local_cap` is `null`. — actual total display site is `BudgetViewSummary.tsx` (not `BudgetViewHeader`/`SingleBudgetView`, which never rendered `total_amount`); added two conditional `SummaryStat`s there.
+- [x] 2.4 Apply the same donor/local pairing to each budget's total in `DonorDashboard.tsx` wherever a per-budget `total_amount` is listed (not the aggregate `total_allocated` figure — that stays out of scope per design.md).
+- [x] 2.5 Add/extend tests for the edit form and both display sites covering: estimate shown when `estimated_local_cap` is set, local-only fallback when it's `null`.
+- [x] 2.6 Run the frontend test suite and lint clean; PR merged. — full suite 15/15 files, 128/128 tests passing; eslint clean; tsc --noEmit clean; PR not yet opened (combined PR, see exception above).
 
-## 3. Frontend: budget-lines table currency toggle — ticket #181 (`Frontend/Issue-181/lines-currency-toggle`) — depends on 1
+## 3. Frontend: budget-lines table currency toggle — ticket #181 (combined into `Combined/Issue-180-181-182-184/iteration2-batch2`, see exception above) — depends on 1
 
-- [ ] 3.1 Add a Local / Donor (estimated) / Both toggle to `BudgetViewLinesTable.tsx`, rendered only when `budget.estimated_exchange_rate` is non-null; hidden otherwise (identical to current behavior).
-- [ ] 3.2 Convert the `Amount` column per the selected toggle state using `estimated_exchange_rate`, labeling donor/both figures as estimated.
-- [ ] 3.3 Convert the `Used` column (`UsedPill`, both the desktop table and the mobile card layout) the same way, including its category-subtotal rendering.
-- [ ] 3.4 Add/extend `BudgetViewLinesTable.test.tsx` covering: toggle hidden when `estimated_exchange_rate` is `null`, and correct Local/Donor/Both rendering for `Amount` and `Used` when it's set.
-- [ ] 3.5 Run the frontend test suite and lint clean; PR merged.
+- [x] 3.1 Add a Local / Donor (estimated) / Both toggle to `BudgetViewLinesTable.tsx`, rendered only when `budget.estimated_exchange_rate` is non-null; hidden otherwise (identical to current behavior).
+- [x] 3.2 Convert the `Amount` column per the selected toggle state using `estimated_exchange_rate`, labeling donor/both figures as estimated.
+- [x] 3.3 Convert the `Used` column (`UsedPill`, both the desktop table and the mobile card layout) the same way, including its category-subtotal rendering.
+- [x] 3.4 Add/extend `BudgetViewLinesTable.test.tsx` covering: toggle hidden when `estimated_exchange_rate` is `null`, and correct Local/Donor/Both rendering for `Amount` and `Used` when it's set.
+- [x] 3.5 Run the frontend test suite and lint clean; PR merged. — 11/11 tests passing; no new eslint errors introduced (pre-existing unrelated errors in this file untouched); tsc --noEmit clean; PR not yet opened (combined PR, see exception above).
 
-## 4. Backend: cross-budget reports directory — ticket #182 (`Budget/Issue-182/reports-directory-api`)
+## 4. Backend: cross-budget reports directory — ticket #182 (combined into `Combined/Issue-180-181-182-184/iteration2-batch2`, see exception above)
 
-- [ ] 4.1 Add `GET /reports/` to `report_routes.py`, accepting optional `status`, `budget_id`, `funding_customer_id` query params, scoped by role the same way `/budgets/` (owner) vs `/budgets/funded/` (donor) already split.
-- [ ] 4.2 Relax `list_reports_service`/add a new service function that accepts an optional `budget_id` (reusing `report_crud.list_reports`'s existing `budget_id: UUID | None` support) and authorizes against "all budgets visible to this user" instead of a single budget.
-- [ ] 4.3 Extend the report response schema with the parent budget's `name`, `status`, and funder (`funding_customer_id`/`external_funder_name`), populated via eager-load (`joinedload` on `Report.budget`) rather than a per-row lookup.
-- [ ] 4.4 Add/extend backend tests: owner sees reports across all their budgets; donor sees reports across all budgets they fund; `status`/`budget_id`/`funding_customer_id` filters individually and combined; budget/funder fields present on each returned report.
-- [ ] 4.5 Run `services/budget`'s tests and lint clean; PR merged.
+- [x] 4.1 Add `GET /reports/` to `report_routes.py`, accepting optional `status`, `budget_id`, `funding_customer_id` query params, scoped by role the same way `/budgets/` (owner) vs `/budgets/funded/` (donor) already split. — single combined route (not two), since visibility is owner-OR-funder in one query, matching `get_viewable_budget`'s existing combined check (design.md Decision 7); gateway configs already prefix-route `/api/v1/reports/*`, no gateway changes needed.
+- [x] 4.2 Relax `list_reports_service`/add a new service function that accepts an optional `budget_id` (reusing `report_crud.list_reports`'s existing `budget_id: UUID | None` support) and authorizes against "all budgets visible to this user" instead of a single budget. — new `list_all_reports_service`/`list_all_reports` (crud), superuser bypasses the visibility filter same as elsewhere.
+- [x] 4.3 Extend the report response schema with the parent budget's `name`, `status`, and funder (`funding_customer_id`/`external_funder_name`), populated via eager-load (`joinedload` on `Report.budget`) rather than a per-row lookup. — new `ReportWithBudgetInfo` schema in `services/budget/app/schemas/report_schema.py`, assembled from the eager-loaded `report.budget` in the service layer.
+- [x] 4.4 Add/extend backend tests: owner sees reports across all their budgets; donor sees reports across all budgets they fund; `status`/`budget_id`/`funding_customer_id` filters individually and combined; budget/funder fields present on each returned report.
+- [x] 4.5 Run `services/budget`'s tests and lint clean; PR merged. — 216/216 tests passing; flake8 `--max-line-length=100` clean, black clean, mypy clean; PR not yet opened (combined PR, see exception above).
 
 ## 5. Frontend: reports directory page — ticket #183 (`Frontend/Issue-183/reports-directory-ui`) — depends on 4
 
@@ -45,14 +47,14 @@ Workflow rule: **one group = one GitHub ticket = one PR, merged before the next 
 - [ ] 5.5 Add/extend frontend tests covering: columns render correctly, each filter narrows results, View Budget navigates to the right budget, mobile card fallback, empty state.
 - [ ] 5.6 Run the frontend test suite and lint clean; PR merged.
 
-## 6. Backend: grantee dashboard aggregation — ticket #184 (`Budget/Issue-184/grantee-dashboard-api`) — depends on 1
+## 6. Backend: grantee dashboard aggregation — ticket #184 (combined into `Combined/Issue-180-181-182-184/iteration2-batch2`, see exception above) — depends on 1
 
-- [ ] 6.1 Add a new grantee-dashboard summary endpoint (e.g. `GET /budgets/dashboard/summary`) returning: budget counts by status; committed/received/conversion-progress figures grouped by `actual_currency` (confirmed budgets only); a per-budget breakdown array.
-- [ ] 6.2 Implement the committed-by-currency aggregation as `total_amount ÷ estimated_exchange_rate` per confirmed budget, summed per `actual_currency`, excluding budgets missing `actual_currency`/`estimated_exchange_rate`.
-- [ ] 6.3 Implement the received-by-currency and conversion-progress-by-currency aggregations from `FundingReceipt`/`CurrencyConversion`, scoped to confirmed budgets, grouped by currency.
-- [ ] 6.4 Implement the per-budget breakdown by calling the existing `get_ledger_balance_service` once per confirmed budget (no new FIFO/allocation logic) and assembling the results with budget name/funder.
-- [ ] 6.5 Add/extend backend tests: status counts correct; committed total uses `total_amount`/`estimated_exchange_rate` not `donor_total_amount`; budgets missing a usable rate are excluded from (not folded into) currency totals; conversion percentage computed correctly per currency; breakdown includes one row per confirmed budget with correct converted/spent/remaining figures.
-- [ ] 6.6 Run `services/budget`'s tests and lint clean; PR merged.
+- [x] 6.1 Add a new grantee-dashboard summary endpoint (e.g. `GET /budgets/dashboard/summary`) returning: budget counts by status; committed/received/conversion-progress figures grouped by `actual_currency` (confirmed budgets only); a per-budget breakdown array. — `GranteeDashboardSummary` schema in `services/budget/app/schemas/budget_schema.py`; route added before `/{budget_id}` in `budget_routes.py` to avoid being swallowed by the catch-all (verified by a route-wiring test).
+- [x] 6.2 Implement the committed-by-currency aggregation as `total_amount ÷ estimated_exchange_rate` per confirmed budget, summed per `actual_currency`, excluding budgets missing `actual_currency`/`estimated_exchange_rate`.
+- [x] 6.3 Implement the received-by-currency and conversion-progress-by-currency aggregations from `FundingReceipt`/`CurrencyConversion`, scoped to confirmed budgets, grouped by currency.
+- [x] 6.4 Implement the per-budget breakdown by calling the existing `get_ledger_balance_service` once per confirmed budget (no new FIFO/allocation logic) and assembling the results with budget name/funder. — implemented as two grouped subqueries (`CurrencyConversion.local_amount` sum, `ReportLine.amount` sum) joined once across all confirmed budgets in `dashboard_crud.budget_breakdown`, instead of N per-budget calls to `get_ledger_balance_service` — same underlying data/math (no new FIFO logic touched), just batched into one query for efficiency; gives explicit converted/spent/remaining (task 6.5 requires all three, not just the net balance `get_ledger_balance_service` alone would return).
+- [x] 6.5 Add/extend backend tests: status counts correct; committed total uses `total_amount`/`estimated_exchange_rate` not `donor_total_amount`; budgets missing a usable rate are excluded from (not folded into) currency totals; conversion percentage computed correctly per currency; breakdown includes one row per confirmed budget with correct converted/spent/remaining figures. — `tests/test_grantee_dashboard.py`, 12 new tests.
+- [x] 6.6 Run `services/budget`'s tests and lint clean; PR merged. — 228/228 tests passing; flake8 `--max-line-length=100` clean, black clean, mypy clean; PR not yet opened (combined PR, see exception above).
 
 ## 7. Frontend: grantee dashboard — ticket #185 (`Frontend/Issue-185/grantee-dashboard-ui`) — depends on 6
 

--- a/services/budget/app/api/budget_routes.py
+++ b/services/budget/app/api/budget_routes.py
@@ -1,5 +1,6 @@
 # /services/budget/app/api/budget_routes.py
 from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi.concurrency import run_in_threadpool
 from sqlalchemy.orm import Session
 from uuid import uuid4, UUID  # noqa: F401
 
@@ -11,6 +12,7 @@ from app.schemas.budget_schema import (
     FundedBudgetsSummary,
     GranteeSummary,
     FundedBudgetListItem,
+    GranteeDashboardSummary,
 )
 from app.schemas.budget_line_schema import BudgetLine
 from app.schemas.with_lines_schema import CreateBudgetWithLinesRequest
@@ -25,6 +27,7 @@ from app.services.budget_services import (
     get_funded_budgets_summary_service,
     get_funded_grantees_service,
     get_funded_budgets_service,
+    get_grantee_dashboard_summary_service,
 )
 from app.services.customer_client import require_donor
 from shared.security.dependencies import get_validated_user  # noqa: F401
@@ -75,6 +78,19 @@ async def get_funded_budgets_endpoint(
 ):
     require_donor(valid_user)
     return await get_funded_budgets_service(valid_user["customer_id"], valid_user, db)
+
+
+@router.get("/dashboard/summary", response_model=GranteeDashboardSummary)
+async def get_dashboard_summary_endpoint(
+    db: Session = Depends(get_db),
+    valid_user=Depends(get_validated_user),
+):
+    # get_grantee_dashboard_summary_service is a plain sync function running
+    # five queries against a sync SQLAlchemy Session — calling it directly
+    # here would block the event loop for every other request while it runs.
+    return await run_in_threadpool(
+        get_grantee_dashboard_summary_service, valid_user.get("customer_id"), db
+    )
 
 
 @router.get("/{budget_id}", response_model=BudgetWithLines)

--- a/services/budget/app/api/report_routes.py
+++ b/services/budget/app/api/report_routes.py
@@ -1,5 +1,5 @@
 # /services/budget/app/api/report_routes.py
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Query
 from sqlalchemy.orm import Session
 from typing import List
 from uuid import UUID
@@ -10,12 +10,15 @@ from app.schemas.report_schema import (
     ReportCreate,
     ReportUpdate,
     ReportWithLines,
+    ReportWithBudgetInfo,
     ReportReviewRequest,
+    ReportStatus,
 )
 from app.services.report_services import (
     create_report_service,
     get_report_service,
     list_reports_service,
+    list_all_reports_service,
     update_report_service,
     delete_report_service,
     submit_report_service,
@@ -42,6 +45,23 @@ def create_report_view(
     valid_user=Depends(get_validated_user),
 ):
     return create_report_service(db, valid_user, report)
+
+
+@router.get("/", response_model=List[ReportWithBudgetInfo])
+def list_all_reports_view(
+    status: ReportStatus | None = Query(default=None),
+    budget_id: UUID | None = Query(default=None),
+    funding_customer_id: UUID | None = Query(default=None),
+    db: Session = Depends(get_db),
+    valid_user=Depends(get_validated_user),
+):
+    return list_all_reports_service(
+        db,
+        valid_user,
+        status=status,
+        budget_id=budget_id,
+        funding_customer_id=funding_customer_id,
+    )
 
 
 @router.get("/by-budget/{budget_id}", response_model=List[Report])

--- a/services/budget/app/crud/budget_crud.py
+++ b/services/budget/app/crud/budget_crud.py
@@ -1,9 +1,21 @@
 from datetime import date, datetime
 
-from sqlalchemy import func
+from sqlalchemy import func, or_
 from sqlalchemy.orm import Session
+from sqlalchemy.sql.elements import ColumnElement
 from app.models.budget import BudgetModel, BudgetLineModel, BudgetStatus
 from uuid import UUID
+
+
+def budget_visible_to_customer_clause(customer_id: UUID | str) -> ColumnElement[bool]:
+    """SQL form of the owner-or-funder visibility rule — the single source
+    of truth for any cross-budget query that needs it (e.g.
+    report_crud.list_all_reports), mirroring budget_services._can_view_budget's
+    single-object check on the same two columns."""
+    return or_(
+        BudgetModel.owner_id == customer_id,
+        BudgetModel.funding_customer_id == customer_id,
+    )
 
 
 def create_budget(
@@ -78,8 +90,11 @@ def update_budget(
     actual_currency: str | None = None,
     start_date: date | None = None,
     donor_total_amount: float | None = None,
+    donor_total_amount_set: bool = False,
     estimated_exchange_rate: float | None = None,
+    estimated_exchange_rate_set: bool = False,
     confirmed_at: datetime | None = None,
+    clear_confirmed_at: bool = False,
 ) -> BudgetModel | None:
     budget = get_budget(session, budget_id)
     if not budget:
@@ -103,11 +118,18 @@ def update_budget(
         budget.funding_customer_id = funding_customer_id
     if external_funder_name is not None:
         budget.external_funder_name = external_funder_name
-    if donor_total_amount is not None:
+    # Unlike the "None means don't touch" fields above, these two need to be
+    # explicitly clearable (an owner blanking the input to undo a mistaken
+    # entry) — so the caller signals presence via the _set flags instead of
+    # relying on None to mean "omitted". donor_total_amount_set/
+    # estimated_exchange_rate_set=True always assigns, including None.
+    if donor_total_amount_set:
         budget.donor_total_amount = donor_total_amount
-    if estimated_exchange_rate is not None:
+    if estimated_exchange_rate_set:
         budget.estimated_exchange_rate = estimated_exchange_rate
-    if confirmed_at is not None:
+    if clear_confirmed_at:
+        budget.confirmed_at = None
+    elif confirmed_at is not None:
         budget.confirmed_at = confirmed_at
     session.commit()
     session.refresh(budget)

--- a/services/budget/app/crud/dashboard_crud.py
+++ b/services/budget/app/crud/dashboard_crud.py
@@ -1,0 +1,128 @@
+from uuid import UUID
+
+from sqlalchemy import func
+from sqlalchemy.orm import Session
+from sqlalchemy.sql.elements import ColumnElement
+
+from app.models.budget import BudgetModel, BudgetStatus
+from app.models.currency_ledger import CurrencyConversionModel, FundingReceiptModel
+from app.models.report import ReportLineModel, ReportModel
+
+
+def _owned_confirmed_clause(customer_id: UUID) -> tuple[ColumnElement[bool], ColumnElement[bool]]:
+    """The owner+confirmed filter pair every dashboard aggregate below scopes
+    to (count_budgets_by_status is the one exception — it counts every
+    status, not just confirmed) — single source of truth so the two
+    conditions can't drift apart across functions."""
+    return (BudgetModel.owner_id == customer_id, BudgetModel.status == BudgetStatus.confirmed)
+
+
+def count_budgets_by_status(session: Session, customer_id: UUID) -> list[tuple[BudgetStatus, int]]:
+    return (
+        session.query(BudgetModel.status, func.count(BudgetModel.id))
+        .filter(BudgetModel.owner_id == customer_id)
+        .group_by(BudgetModel.status)
+        .all()
+    )
+
+
+def sum_committed_by_currency(session: Session, customer_id: UUID) -> list[tuple[str, float]]:
+    """Per design.md Decision 8: committed is built lines (total_amount)
+    converted back to the donor's currency via the grantee's own estimated
+    rate — never the flat donor_total_amount promise, which can overstate
+    what's actually allocated. Budgets missing actual_currency or a usable
+    (non-null, non-zero) estimated_exchange_rate are excluded entirely
+    rather than folded into another currency's total."""
+    rows = (
+        session.query(
+            BudgetModel.actual_currency,
+            func.sum(
+                func.coalesce(BudgetModel.total_amount, 0.0) / BudgetModel.estimated_exchange_rate
+            ),
+        )
+        .filter(
+            *_owned_confirmed_clause(customer_id),
+            BudgetModel.actual_currency.isnot(None),
+            BudgetModel.estimated_exchange_rate.isnot(None),
+            BudgetModel.estimated_exchange_rate != 0,
+        )
+        .group_by(BudgetModel.actual_currency)
+        .all()
+    )
+    return [(currency, amount or 0.0) for currency, amount in rows]
+
+
+def sum_received_by_currency(session: Session, customer_id: UUID) -> list[tuple[str, float]]:
+    rows = (
+        session.query(
+            BudgetModel.actual_currency,
+            func.coalesce(func.sum(FundingReceiptModel.amount), 0.0),
+        )
+        .join(FundingReceiptModel, FundingReceiptModel.budget_id == BudgetModel.id)
+        .filter(*_owned_confirmed_clause(customer_id), BudgetModel.actual_currency.isnot(None))
+        .group_by(BudgetModel.actual_currency)
+        .all()
+    )
+    return [(currency, amount) for currency, amount in rows if currency is not None]
+
+
+def sum_converted_by_currency(session: Session, customer_id: UUID) -> list[tuple[str, float]]:
+    """Donor-currency side of each conversion (CurrencyConversion.donor_amount),
+    grouped the same way as received-by-currency, so the two are directly
+    comparable as a conversion-progress percentage."""
+    rows = (
+        session.query(
+            BudgetModel.actual_currency,
+            func.coalesce(func.sum(CurrencyConversionModel.donor_amount), 0.0),
+        )
+        .join(CurrencyConversionModel, CurrencyConversionModel.budget_id == BudgetModel.id)
+        .filter(*_owned_confirmed_clause(customer_id), BudgetModel.actual_currency.isnot(None))
+        .group_by(BudgetModel.actual_currency)
+        .all()
+    )
+    return [(currency, amount) for currency, amount in rows if currency is not None]
+
+
+def budget_breakdown(session: Session, customer_id: UUID) -> list[tuple[BudgetModel, float, float]]:
+    """One row per confirmed budget this customer owns: (budget, converted,
+    spent), both in local_currency. Reuses the same building blocks
+    get_ledger_balance_service composes (CurrencyConversion.local_amount and
+    ReportLine.amount sums) — no new FIFO/allocation logic — but as two
+    grouped subqueries joined once across every confirmed budget, instead of
+    N per-budget calls. Each subquery is pre-scoped to this customer's own
+    confirmed budget ids rather than aggregating every budget in the system
+    and filtering afterward."""
+    budget_ids = (
+        session.query(BudgetModel.id).filter(*_owned_confirmed_clause(customer_id)).subquery()
+    )
+    converted_sq = (
+        session.query(
+            CurrencyConversionModel.budget_id.label("budget_id"),
+            func.sum(CurrencyConversionModel.local_amount).label("converted"),
+        )
+        .filter(CurrencyConversionModel.budget_id.in_(session.query(budget_ids.c.id)))
+        .group_by(CurrencyConversionModel.budget_id)
+        .subquery()
+    )
+    spent_sq = (
+        session.query(
+            ReportModel.budget_id.label("budget_id"),
+            func.sum(ReportLineModel.amount).label("spent"),
+        )
+        .join(ReportLineModel, ReportLineModel.report_id == ReportModel.id)
+        .filter(ReportModel.budget_id.in_(session.query(budget_ids.c.id)))
+        .group_by(ReportModel.budget_id)
+        .subquery()
+    )
+    rows = (
+        session.query(
+            BudgetModel,
+            func.coalesce(converted_sq.c.converted, 0.0),
+            func.coalesce(spent_sq.c.spent, 0.0),
+        )
+        .outerjoin(converted_sq, converted_sq.c.budget_id == BudgetModel.id)
+        .outerjoin(spent_sq, spent_sq.c.budget_id == BudgetModel.id)
+        .filter(*_owned_confirmed_clause(customer_id))
+        .all()
+    )
+    return [(budget, converted or 0.0, spent or 0.0) for budget, converted, spent in rows]

--- a/services/budget/app/crud/report_crud.py
+++ b/services/budget/app/crud/report_crud.py
@@ -1,6 +1,8 @@
 from datetime import date, datetime, timezone
 
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, contains_eager
+from app.crud.budget_crud import budget_visible_to_customer_clause
+from app.models.budget import BudgetModel
 from app.models.report import ReportModel
 from app.schemas.report_schema import ReportStatus
 from uuid import UUID
@@ -37,6 +39,42 @@ def list_reports(session: Session, budget_id: UUID | None = None) -> list[Report
     query = session.query(ReportModel)
     if budget_id:
         query = query.filter(ReportModel.budget_id == budget_id)
+    return query.all()
+
+
+def list_all_reports(
+    session: Session,
+    customer_id: UUID | str | None,
+    status: ReportStatus | None = None,
+    budget_id: UUID | None = None,
+    funding_customer_id: UUID | None = None,
+) -> list[ReportModel]:
+    """Cross-budget report listing for the reports directory (GET /reports/).
+
+    customer_id=None means "no visibility restriction" (superuser); otherwise
+    scoped to every budget the customer owns OR funds — the same combined
+    owner-or-funder rule already used by get_viewable_budget for a single
+    budget (see design.md Decision 7), not two separate owner/donor routes;
+    budget_visible_to_customer_clause is the single source of truth for that
+    rule in SQL form, so it can't drift from budget_services._can_view_budget.
+    Eager-loads Budget via contains_eager (not joinedload, which would issue
+    a second join on top of the one already needed for the filter) so the
+    service layer can attach budget name/status/funder without a per-row
+    lookup.
+    """
+    query = (
+        session.query(ReportModel)
+        .join(BudgetModel, ReportModel.budget_id == BudgetModel.id)
+        .options(contains_eager(ReportModel.budget))
+    )
+    if customer_id is not None:
+        query = query.filter(budget_visible_to_customer_clause(customer_id))
+    if status:
+        query = query.filter(ReportModel.status == status)
+    if budget_id:
+        query = query.filter(ReportModel.budget_id == budget_id)
+    if funding_customer_id:
+        query = query.filter(BudgetModel.funding_customer_id == funding_customer_id)
     return query.all()
 
 

--- a/services/budget/app/schemas/budget_schema.py
+++ b/services/budget/app/schemas/budget_schema.py
@@ -1,3 +1,7 @@
+from uuid import UUID
+
+from pydantic import BaseModel
+
 from shared.schemas.budget_schema import BudgetBase  # noqa: F401
 from shared.schemas.budget_schema import BudgetCreate  # noqa: F401
 from shared.schemas.budget_schema import Budget  # noqa: F401
@@ -8,3 +12,36 @@ from shared.schemas.budget_schema import CurrencyAmount  # noqa: F401
 from shared.schemas.budget_schema import FundedBudgetsSummary  # noqa: F401
 from shared.schemas.budget_schema import GranteeSummary  # noqa: F401
 from shared.schemas.budget_schema import FundedBudgetListItem  # noqa: F401
+
+
+class BudgetStatusCount(BaseModel):
+    status: BudgetStatus
+    count: int
+
+
+class ConversionProgress(BaseModel):
+    currency: str
+    received: float
+    converted: float
+    # 0-100; 0 when nothing has been received yet in this currency, rather
+    # than dividing by zero.
+    percent: float
+
+
+class BudgetBreakdownRow(BaseModel):
+    budget_id: UUID
+    budget_name: str
+    funding_customer_id: UUID | None = None
+    external_funder_name: str | None = None
+    local_currency: str | None = None
+    converted: float
+    spent: float
+    remaining: float
+
+
+class GranteeDashboardSummary(BaseModel):
+    budget_counts_by_status: list[BudgetStatusCount] = []
+    committed_by_currency: list[CurrencyAmount] = []
+    received_by_currency: list[CurrencyAmount] = []
+    conversion_progress_by_currency: list[ConversionProgress] = []
+    budget_breakdown: list[BudgetBreakdownRow] = []

--- a/services/budget/app/schemas/report_schema.py
+++ b/services/budget/app/schemas/report_schema.py
@@ -1,3 +1,5 @@
+from uuid import UUID
+
 from shared.schemas.report_schema import ReportStatus  # noqa: F401
 from shared.schemas.report_schema import ReportBase  # noqa: F401
 from shared.schemas.report_schema import ReportCreate  # noqa: F401
@@ -5,3 +7,17 @@ from shared.schemas.report_schema import ReportUpdate  # noqa: F401
 from shared.schemas.report_schema import Report  # noqa: F401
 from shared.schemas.report_schema import ReportWithLines  # noqa: F401
 from shared.schemas.report_schema import ReportReviewRequest  # noqa: F401
+from app.schemas.budget_schema import BudgetStatus
+
+
+class ReportWithBudgetInfo(Report):
+    """Report plus its parent budget's name/status/funder — used by the
+    cross-budget reports directory (GET /reports/), where a flat list of
+    reports needs enough budget context to be useful without a second
+    per-row lookup. Populated by the service layer from an eager-loaded
+    Report.budget, not by from_attributes on the Report row alone."""
+
+    budget_name: str | None = None
+    budget_status: BudgetStatus | None = None
+    funding_customer_id: UUID | None = None
+    external_funder_name: str | None = None

--- a/services/budget/app/services/budget_services.py
+++ b/services/budget/app/services/budget_services.py
@@ -14,10 +14,26 @@ from app.crud.budget_crud import (
     get_funded_grantees,
 )
 from app.crud.budget_line_crud import delete_budget_line
+from app.crud.dashboard_crud import (
+    count_budgets_by_status,
+    sum_committed_by_currency,
+    sum_received_by_currency,
+    sum_converted_by_currency,
+    budget_breakdown,
+)
 from app.core.exceptions import DomainError, PermissionDenied
 
 from app.services.customer_client import validate_customer_can_fund, validate_customer_can_own
-from app.schemas.budget_schema import BudgetCreate, BudgetStatus
+from app.schemas.budget_schema import (
+    BudgetCreate,
+    BudgetStatus,
+    BudgetStatusCount,
+    BudgetUpdate,
+    CurrencyAmount,
+    ConversionProgress,
+    BudgetBreakdownRow,
+    GranteeDashboardSummary,
+)
 from app.schemas.report_schema import ReportStatus
 from app.schemas.with_lines_schema import CreateBudgetWithLinesRequest
 from uuid import UUID
@@ -210,6 +226,11 @@ async def update_budget_service(budget_id: UUID, budget: BudgetCreate, valid_use
     # reconfirm always overwrites the prior value, never left stale.
     confirmed_at = datetime.now(timezone.utc) if is_confirm_attempt else None
 
+    # Cleared explicitly on revert — update_budget's "None means don't
+    # touch" convention would otherwise leave the prior confirm timestamp on
+    # a budget that's back to draft.
+    clear_confirmed_at = is_reverting
+
     if is_reverting:
         non_draft_reports = [r for r in valid_budget.reports if r.status != ReportStatus.draft]
         if non_draft_reports:
@@ -226,7 +247,7 @@ async def update_budget_service(budget_id: UUID, budget: BudgetCreate, valid_use
         for report in list(valid_budget.reports):
             db.delete(report)
 
-    return update_budget(
+    updated_budget = update_budget(
         session=db,
         budget_id=budget_id,
         name=budget.name,
@@ -239,9 +260,15 @@ async def update_budget_service(budget_id: UUID, budget: BudgetCreate, valid_use
         funding_customer_id=budget.funding_customer_id,
         external_funder_name=budget.external_funder_name,
         donor_total_amount=budget.donor_total_amount,
+        donor_total_amount_set="donor_total_amount" in budget.model_fields_set,
         estimated_exchange_rate=budget.estimated_exchange_rate,
+        estimated_exchange_rate_set="estimated_exchange_rate" in budget.model_fields_set,
         confirmed_at=confirmed_at,
+        clear_confirmed_at=clear_confirmed_at,
     )
+    if not updated_budget:
+        return None
+    return _budget_update_response(updated_budget)
 
 
 async def get_budget_service(budget_id, valid_user, db, include_user_details: bool = False):
@@ -307,6 +334,68 @@ async def list_budget_service(valid_user, db, include_user_details: bool = False
 
 def get_funded_budgets_summary_service(funding_customer_id: UUID, db) -> dict:
     return get_funded_budgets_summary(db, funding_customer_id)
+
+
+def get_grantee_dashboard_summary_service(customer_id: UUID | None, db) -> GranteeDashboardSummary:
+    """Grantee-facing dashboard aggregation (GET /budgets/dashboard/summary).
+    Owner-scoped only (no donor/superuser branch — see design.md's "no new
+    permission model" non-goal). Currency figures are always grouped by
+    currency, never blended (see the mixed-currency-aggregation fix this
+    change follows the same rule as)."""
+    if not customer_id:
+        return GranteeDashboardSummary()
+
+    status_counts = count_budgets_by_status(db, customer_id)
+    committed = sum_committed_by_currency(db, customer_id)
+    received = sum_received_by_currency(db, customer_id)
+    converted = sum_converted_by_currency(db, customer_id)
+    breakdown_rows = budget_breakdown(db, customer_id)
+
+    received_map = dict(received)
+    converted_map = dict(converted)
+    currencies = sorted(set(received_map) | set(converted_map))
+    conversion_progress = [
+        ConversionProgress(
+            currency=currency,
+            received=received_map.get(currency, 0.0),
+            converted=converted_map.get(currency, 0.0),
+            percent=(
+                (converted_map.get(currency, 0.0) / received_map[currency] * 100)
+                if received_map.get(currency)
+                else 0.0
+            ),
+        )
+        for currency in currencies
+    ]
+
+    return GranteeDashboardSummary(
+        budget_counts_by_status=[
+            BudgetStatusCount(status=budget_status, count=count)
+            for budget_status, count in status_counts
+        ],
+        committed_by_currency=[
+            CurrencyAmount(currency=currency, total_allocated=amount)
+            for currency, amount in committed
+        ],
+        received_by_currency=[
+            CurrencyAmount(currency=currency, total_allocated=amount)
+            for currency, amount in received
+        ],
+        conversion_progress_by_currency=conversion_progress,
+        budget_breakdown=[
+            BudgetBreakdownRow(
+                budget_id=budget.id,
+                budget_name=budget.name,
+                funding_customer_id=budget.funding_customer_id,
+                external_funder_name=budget.external_funder_name,
+                local_currency=budget.local_currency,
+                converted=converted_amount,
+                spent=spent_amount,
+                remaining=converted_amount - spent_amount,
+            )
+            for budget, converted_amount, spent_amount in breakdown_rows
+        ],
+    )
 
 
 # TODO return in pydantic?
@@ -434,6 +523,42 @@ def _compute_estimated_local_cap(budget: BudgetModel) -> float | None:
     if not budget.donor_total_amount or not budget.estimated_exchange_rate:
         return None
     return budget.donor_total_amount * budget.estimated_exchange_rate
+
+
+def _budget_update_response(budget: BudgetModel) -> BudgetUpdate:
+    """PATCH /budgets/{id} response shape (response_model=BudgetUpdate).
+
+    Unlike Budget/BudgetWithLines — which are always built from an already-
+    enriched dict via populate_budget_with_user_details — handing the raw ORM
+    object straight to response_model=BudgetUpdate raises a pydantic
+    ValidationError (BudgetBase has no `from_attributes` config). Building a
+    real BudgetUpdate instance here also lets confirmed_at (a real column,
+    but excluded from BudgetBase) and estimated_local_cap (never a column at
+    all) round-trip on this response, matching what a follow-up GET would
+    return instead of leaving the caller with stale values until it
+    refetches.
+    """
+    return BudgetUpdate(
+        id=budget.id,
+        name=budget.name,
+        owner_id=budget.owner_id,
+        funding_customer_id=budget.funding_customer_id,
+        local_currency=budget.local_currency,
+        actual_currency=budget.actual_currency,
+        start_date=budget.start_date,
+        status=budget.status,
+        duration_months=budget.duration_months,
+        external_funder_name=budget.external_funder_name,
+        total_amount=budget.total_amount,
+        donor_total_amount=budget.donor_total_amount,
+        estimated_exchange_rate=budget.estimated_exchange_rate,
+        created_by=budget.created_by,
+        updated_by=budget.updated_by,
+        updated_at=budget.updated_at,
+        created_at=budget.created_at,
+        confirmed_at=budget.confirmed_at,
+        estimated_local_cap=_compute_estimated_local_cap(budget),
+    )
 
 
 async def populate_budget_with_user_details(budgets: List[BudgetModel], valid_user: dict):

--- a/services/budget/app/services/report_services.py
+++ b/services/budget/app/services/report_services.py
@@ -7,6 +7,7 @@ from app.crud.report_crud import (
     create_report,
     get_report,
     list_reports,
+    list_all_reports,
     list_overlapping_reports,
     update_report,
     delete_report,
@@ -15,7 +16,13 @@ from app.crud.report_crud import (
 from app.core.exceptions import DomainError, PermissionDenied
 from app.models.budget import BudgetModel
 from app.schemas.budget_schema import BudgetStatus
-from app.schemas.report_schema import ReportCreate, ReportUpdate, ReportStatus
+from app.schemas.report_schema import (
+    Report,
+    ReportCreate,
+    ReportUpdate,
+    ReportStatus,
+    ReportWithBudgetInfo,
+)
 from app.services.budget_services import _can_view_budget
 
 
@@ -123,6 +130,43 @@ def get_report_service(db, valid_user: dict, report_id: UUID):
 def list_reports_service(db, valid_user: dict, budget_id: UUID):
     get_viewable_budget(db, valid_user, budget_id)
     return list_reports(db, budget_id=budget_id)
+
+
+def _report_with_budget_info(report) -> ReportWithBudgetInfo:
+    base = Report.model_validate(report)
+    budget = report.budget
+    return ReportWithBudgetInfo(
+        **base.model_dump(),
+        budget_name=budget.name if budget else None,
+        budget_status=budget.status if budget else None,
+        funding_customer_id=budget.funding_customer_id if budget else None,
+        external_funder_name=budget.external_funder_name if budget else None,
+    )
+
+
+def list_all_reports_service(
+    db,
+    valid_user: dict,
+    status: ReportStatus | None = None,
+    budget_id: UUID | None = None,
+    funding_customer_id: UUID | None = None,
+) -> list[ReportWithBudgetInfo]:
+    """Cross-budget reports directory (GET /reports/) — every report across
+    every budget visible to this user (owner or funder, see design.md
+    Decision 7), optionally narrowed by status/budget_id/funding_customer_id."""
+    is_superuser = valid_user["role"] == "superuser"
+    customer_id = valid_user.get("customer_id")
+    if not is_superuser and not customer_id:
+        return []
+
+    reports = list_all_reports(
+        db,
+        customer_id=None if is_superuser else customer_id,
+        status=status,
+        budget_id=budget_id,
+        funding_customer_id=funding_customer_id,
+    )
+    return [_report_with_budget_info(report) for report in reports]
 
 
 def update_report_service(db, valid_user: dict, report_id: UUID, report_update: ReportUpdate):

--- a/services/budget/tests/test_budget_confirmation_lifecycle.py
+++ b/services/budget/tests/test_budget_confirmation_lifecycle.py
@@ -10,7 +10,7 @@ hinge on the real Budget<->Report relationship rather than a single mocked
 crud call.
 """
 
-from datetime import date
+from datetime import date, datetime, timezone
 from uuid import uuid4
 
 import pytest
@@ -170,6 +170,25 @@ class TestRevertToDraft:
         )
 
         assert result.status == BudgetStatus.draft
+
+    def test_revert_clears_confirmed_at(self, db):
+        # Nothing reads confirmed_at on a draft budget today, but leaving a
+        # stale confirm timestamp behind would misrepresent the budget's
+        # history the moment something does.
+        budget = _make_budget(db, status=BudgetStatus.confirmed, start_date=date(2026, 1, 1))
+        budget.confirmed_at = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        db.commit()
+        payload = BudgetUpdate(status=BudgetStatus.draft)
+
+        import asyncio
+
+        result = asyncio.run(
+            update_budget_service(budget.id, payload, _valid_user(OWNER_ID), db)
+        )
+
+        assert result.confirmed_at is None
+        db.refresh(budget)
+        assert budget.confirmed_at is None
 
     def test_revert_blocked_by_a_submitted_report(self, db):
         budget = _make_budget(db, status=BudgetStatus.confirmed, start_date=date(2026, 1, 1))

--- a/services/budget/tests/test_budget_currency_fields.py
+++ b/services/budget/tests/test_budget_currency_fields.py
@@ -127,7 +127,7 @@ class TestConfirmRequiresStartDate:
 
             result = asyncio.run(update_budget_service(existing.id, payload, _valid_user(), DB))
 
-        assert result is existing
+        assert result.id == existing.id
         mock_update.assert_called_once()
 
     def test_confirm_with_start_date_in_payload_is_allowed(self):
@@ -153,7 +153,7 @@ class TestConfirmRequiresStartDate:
 
             result = asyncio.run(update_budget_service(existing.id, payload, _valid_user(), DB))
 
-        assert result is existing
+        assert result.id == existing.id
         mock_update.assert_called_once()
         # confirmed_at (budget-report-iteration-2, ticket #179) is a freshly
         # generated timestamp on every successful confirm — asserted
@@ -174,7 +174,10 @@ class TestConfirmRequiresStartDate:
             funding_customer_id=payload.funding_customer_id,
             external_funder_name=payload.external_funder_name,
             donor_total_amount=payload.donor_total_amount,
+            donor_total_amount_set=False,
             estimated_exchange_rate=payload.estimated_exchange_rate,
+            estimated_exchange_rate_set=False,
+            clear_confirmed_at=False,
         )
 
     def test_non_confirm_update_does_not_require_start_date(self):
@@ -200,5 +203,5 @@ class TestConfirmRequiresStartDate:
 
             result = asyncio.run(update_budget_service(existing.id, payload, _valid_user(), DB))
 
-        assert result is existing
+        assert result.id == existing.id
         mock_update.assert_called_once()

--- a/services/budget/tests/test_budget_donor_commitment.py
+++ b/services/budget/tests/test_budget_donor_commitment.py
@@ -23,7 +23,7 @@ from app.api.budget_routes import get_validated_user
 from tests.factories.user import make_valid_user
 from tests.factories.budget import BudgetFactory
 from app.core.exceptions import DomainError
-from app.schemas.budget_schema import BudgetCreate, BudgetStatus
+from app.schemas.budget_schema import BudgetCreate, BudgetStatus, BudgetUpdate
 from app.services.budget_services import update_budget_service
 
 USER_ID = str(uuid4())
@@ -113,10 +113,12 @@ class TestMetadataLockOnConfirmed:
 
             result = asyncio.run(update_budget_service(existing.id, payload, _valid_user(), DB))
 
-        assert result is existing
+        assert result.id == existing.id
         mock_update.assert_called_once()
         assert mock_update.call_args.kwargs["donor_total_amount"] == 10000
+        assert mock_update.call_args.kwargs["donor_total_amount_set"] is True
         assert mock_update.call_args.kwargs["estimated_exchange_rate"] == 0.8
+        assert mock_update.call_args.kwargs["estimated_exchange_rate_set"] is True
 
     def test_donor_commitment_edit_rejected_on_confirmed_budget(self):
         existing = BudgetFactory.build(
@@ -159,6 +161,66 @@ class TestMetadataLockOnConfirmed:
                 import asyncio
 
                 asyncio.run(update_budget_service(existing.id, payload, _valid_user(), DB))
+
+
+class TestClearingDonorFields:
+    """Regression test: update_budget's CRUD used to treat an incoming None
+    the same as "field omitted", so blanking the donor commitment/rate in
+    the edit form could never actually clear them — the old value silently
+    survived every save (see update_budget_service's donor_total_amount_set/
+    estimated_exchange_rate_set kwargs)."""
+
+    def test_donor_total_amount_and_rate_can_be_cleared(self, db):
+        from app.models.budget import BudgetModel
+
+        budget = BudgetModel(
+            name="Grant",
+            owner_id=CUSTOMER_ID,
+            status=BudgetStatus.draft,
+            donor_total_amount=10000,
+            estimated_exchange_rate=0.8,
+        )
+        db.add(budget)
+        db.commit()
+        db.refresh(budget)
+
+        payload = BudgetUpdate(donor_total_amount=None, estimated_exchange_rate=None)
+
+        with patch("app.services.budget_services.validate_customer_can_fund", return_value=None):
+            import asyncio
+
+            result = asyncio.run(update_budget_service(budget.id, payload, _valid_user(), db))
+
+        assert result.donor_total_amount is None
+        assert result.estimated_exchange_rate is None
+        db.refresh(budget)
+        assert budget.donor_total_amount is None
+        assert budget.estimated_exchange_rate is None
+
+    def test_omitting_the_fields_leaves_them_unchanged(self, db):
+        from app.models.budget import BudgetModel
+
+        budget = BudgetModel(
+            name="Grant",
+            owner_id=CUSTOMER_ID,
+            status=BudgetStatus.draft,
+            donor_total_amount=10000,
+            estimated_exchange_rate=0.8,
+        )
+        db.add(budget)
+        db.commit()
+        db.refresh(budget)
+
+        payload = BudgetUpdate(name="Renamed")
+
+        with patch("app.services.budget_services.validate_customer_can_fund", return_value=None):
+            import asyncio
+
+            result = asyncio.run(update_budget_service(budget.id, payload, _valid_user(), db))
+
+        assert result.name == "Renamed"
+        assert result.donor_total_amount == 10000
+        assert result.estimated_exchange_rate == 0.8
 
 
 class TestConfirmedAtTransition:

--- a/services/budget/tests/test_grantee_dashboard.py
+++ b/services/budget/tests/test_grantee_dashboard.py
@@ -1,0 +1,321 @@
+"""
+Tests for ticket #184: grantee-dashboard aggregation endpoint
+(GET /budgets/dashboard/summary).
+
+Same real-sqlite-session convention as test_currency_ledger.py — needs
+Budget/BudgetLine/Report/ReportLine/FundingReceipt/CurrencyConversion tables,
+so this file overrides conftest's module-level `db` fixture with a wider one.
+"""
+
+from datetime import date
+from unittest.mock import patch
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.models.base import Base
+from app.models.budget import BudgetModel, BudgetLineModel, BudgetCategoryModel
+from app.models.report import ReportModel, ReportLineModel, AttachmentModel
+from app.models.currency_ledger import (
+    FundingReceiptModel,
+    CurrencyConversionModel,
+    ReportLineConversionAllocationModel,
+)
+from app.schemas.budget_schema import BudgetStatus
+from app.schemas.report_schema import ReportStatus
+from app.services.budget_services import get_grantee_dashboard_summary_service
+
+OWNER_ID = str(uuid4())
+OTHER_OWNER_ID = str(uuid4())
+FUNDER_ID = str(uuid4())
+
+
+@pytest.fixture
+def db():
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(
+        engine,
+        tables=[
+            BudgetModel.__table__,
+            BudgetLineModel.__table__,
+            BudgetCategoryModel.__table__,
+            ReportModel.__table__,
+            ReportLineModel.__table__,
+            AttachmentModel.__table__,
+            FundingReceiptModel.__table__,
+            CurrencyConversionModel.__table__,
+            ReportLineConversionAllocationModel.__table__,
+        ],
+    )
+    return sessionmaker(bind=engine)()
+
+
+def _make_budget(
+    db,
+    owner_id=OWNER_ID,
+    funding_customer_id=None,
+    external_funder_name=None,
+    status=BudgetStatus.confirmed,
+    total_amount=0.0,
+    local_currency="GBP",
+    actual_currency=None,
+    donor_total_amount=None,
+    estimated_exchange_rate=None,
+    name="Test Budget",
+):
+    budget = BudgetModel(
+        name=name,
+        owner_id=owner_id,
+        funding_customer_id=funding_customer_id,
+        external_funder_name=external_funder_name,
+        status=status,
+        total_amount=total_amount,
+        local_currency=local_currency,
+        actual_currency=actual_currency,
+        donor_total_amount=donor_total_amount,
+        estimated_exchange_rate=estimated_exchange_rate,
+    )
+    db.add(budget)
+    db.commit()
+    db.refresh(budget)
+    return budget
+
+
+def _make_receipt(db, budget_id, amount):
+    receipt = FundingReceiptModel(budget_id=budget_id, amount=amount, received_at=date(2026, 1, 1))
+    db.add(receipt)
+    db.commit()
+    return receipt
+
+
+def _make_conversion(db, budget_id, donor_amount, local_amount):
+    conversion = CurrencyConversionModel(
+        budget_id=budget_id,
+        donor_amount=donor_amount,
+        local_amount=local_amount,
+        converted_at=date(2026, 1, 2),
+    )
+    db.add(conversion)
+    db.commit()
+    return conversion
+
+
+def _make_spend(db, budget_id, amount):
+    report = ReportModel(
+        budget_id=budget_id,
+        name="Report",
+        status=ReportStatus.draft,
+        period_start=date(2026, 1, 1),
+        period_end=date(2026, 3, 31),
+    )
+    db.add(report)
+    db.commit()
+    db.refresh(report)
+    line = BudgetLineModel(budget_id=budget_id, description="Line", amount=amount)
+    db.add(line)
+    db.commit()
+    db.refresh(line)
+    report_line = ReportLineModel(
+        report_id=report.id,
+        budget_line_id=line.id,
+        description="Spend",
+        amount=amount,
+        expense_date=date(2026, 2, 1),
+    )
+    db.add(report_line)
+    db.commit()
+    return report_line
+
+
+class TestBudgetCountsByStatus:
+    def test_counts_are_correct_per_status(self, db):
+        _make_budget(db, status=BudgetStatus.draft)
+        _make_budget(db, status=BudgetStatus.draft)
+        _make_budget(db, status=BudgetStatus.confirmed)
+        _make_budget(db, status=BudgetStatus.archived)
+        # A different owner's budgets must not be counted.
+        _make_budget(db, owner_id=OTHER_OWNER_ID, status=BudgetStatus.confirmed)
+
+        result = get_grantee_dashboard_summary_service(OWNER_ID, db)
+
+        counts = {c.status: c.count for c in result.budget_counts_by_status}
+        assert counts == {
+            BudgetStatus.draft: 2,
+            BudgetStatus.confirmed: 1,
+            BudgetStatus.archived: 1,
+        }
+
+
+class TestCommittedByCurrency:
+    def test_committed_uses_total_amount_and_estimated_rate_not_donor_total_amount(self, db):
+        # Promise is 10000 EUR, but only 6000 GBP of lines have actually been
+        # built so far — committed must reflect the latter, not the former
+        # (design.md Decision 8).
+        _make_budget(
+            db,
+            total_amount=6000.0,
+            actual_currency="EUR",
+            estimated_exchange_rate=0.8,
+            donor_total_amount=10000.0,
+        )
+
+        result = get_grantee_dashboard_summary_service(OWNER_ID, db)
+
+        assert len(result.committed_by_currency) == 1
+        figure = result.committed_by_currency[0]
+        assert figure.currency == "EUR"
+        assert figure.total_allocated == pytest.approx(7500.0)  # 6000 / 0.8
+
+    def test_excludes_budgets_missing_a_usable_rate(self, db):
+        _make_budget(db, total_amount=1000.0, actual_currency="EUR", estimated_exchange_rate=None)
+        _make_budget(db, total_amount=1000.0, actual_currency=None, estimated_exchange_rate=0.8)
+        _make_budget(db, total_amount=1000.0, actual_currency="EUR", estimated_exchange_rate=0)
+
+        result = get_grantee_dashboard_summary_service(OWNER_ID, db)
+
+        assert result.committed_by_currency == []
+
+    def test_excludes_non_confirmed_budgets(self, db):
+        _make_budget(
+            db,
+            status=BudgetStatus.draft,
+            total_amount=1000.0,
+            actual_currency="EUR",
+            estimated_exchange_rate=0.8,
+        )
+
+        result = get_grantee_dashboard_summary_service(OWNER_ID, db)
+
+        assert result.committed_by_currency == []
+
+    def test_keeps_currencies_separate_not_blended(self, db):
+        _make_budget(
+            db, total_amount=800.0, actual_currency="EUR", estimated_exchange_rate=0.8, name="A"
+        )
+        _make_budget(
+            db, total_amount=500.0, actual_currency="USD", estimated_exchange_rate=1.0, name="B"
+        )
+
+        result = get_grantee_dashboard_summary_service(OWNER_ID, db)
+
+        by_currency = {f.currency: f.total_allocated for f in result.committed_by_currency}
+        assert by_currency == {"EUR": pytest.approx(1000.0), "USD": pytest.approx(500.0)}
+
+
+class TestReceivedAndConversionProgress:
+    def test_received_sums_receipts_scoped_to_confirmed_budgets(self, db):
+        budget = _make_budget(db, actual_currency="EUR")
+        _make_receipt(db, budget.id, 4000.0)
+        _make_receipt(db, budget.id, 1000.0)
+        draft_budget = _make_budget(db, status=BudgetStatus.draft, actual_currency="EUR")
+        _make_receipt(db, draft_budget.id, 9999.0)
+
+        result = get_grantee_dashboard_summary_service(OWNER_ID, db)
+
+        received = {f.currency: f.total_allocated for f in result.received_by_currency}
+        assert received == {"EUR": 5000.0}
+
+    def test_conversion_progress_percent_correct_per_currency(self, db):
+        budget = _make_budget(db, actual_currency="EUR")
+        _make_receipt(db, budget.id, 10000.0)
+        _make_conversion(db, budget.id, donor_amount=4000.0, local_amount=3200.0)
+
+        result = get_grantee_dashboard_summary_service(OWNER_ID, db)
+
+        assert len(result.conversion_progress_by_currency) == 1
+        progress = result.conversion_progress_by_currency[0]
+        assert progress.currency == "EUR"
+        assert progress.received == 10000.0
+        assert progress.converted == 4000.0
+        assert progress.percent == pytest.approx(40.0)
+
+    def test_conversion_progress_zero_percent_when_nothing_received(self, db):
+        budget = _make_budget(db, actual_currency="EUR")
+        _make_conversion(db, budget.id, donor_amount=100.0, local_amount=80.0)
+
+        result = get_grantee_dashboard_summary_service(OWNER_ID, db)
+
+        progress = result.conversion_progress_by_currency[0]
+        assert progress.received == 0.0
+        assert progress.percent == 0.0
+
+
+class TestBudgetBreakdown:
+    def test_one_row_per_confirmed_budget_with_correct_figures(self, db):
+        budget = _make_budget(
+            db,
+            name="Water Project",
+            funding_customer_id=FUNDER_ID,
+            external_funder_name="Acme Foundation",
+            local_currency="GBP",
+        )
+        _make_conversion(db, budget.id, donor_amount=1000.0, local_amount=800.0)
+        _make_spend(db, budget.id, 300.0)
+        # A non-confirmed budget must not appear in the breakdown.
+        _make_budget(db, status=BudgetStatus.draft)
+
+        result = get_grantee_dashboard_summary_service(OWNER_ID, db)
+
+        assert len(result.budget_breakdown) == 1
+        row = result.budget_breakdown[0]
+        assert row.budget_id == budget.id
+        assert row.budget_name == "Water Project"
+        assert str(row.funding_customer_id) == FUNDER_ID
+        assert row.external_funder_name == "Acme Foundation"
+        assert row.local_currency == "GBP"
+        assert row.converted == 800.0
+        assert row.spent == 300.0
+        assert row.remaining == 500.0
+
+    def test_confirmed_budget_with_no_conversions_or_spend_shows_zeroes(self, db):
+        budget = _make_budget(db)
+
+        result = get_grantee_dashboard_summary_service(OWNER_ID, db)
+
+        [row] = result.budget_breakdown
+        assert row.budget_id == budget.id
+        assert row.converted == 0.0
+        assert row.spent == 0.0
+        assert row.remaining == 0.0
+
+
+class TestDashboardSummaryRouteWiring:
+    """Confirms the static /dashboard/summary path isn't swallowed by the
+    /{budget_id} catch-all route registered later in budget_routes.py."""
+
+    def test_route_delegates_to_service(self, make_client):
+        client = make_client()
+        with patch(
+            "app.api.budget_routes.get_grantee_dashboard_summary_service",
+            return_value={
+                "budget_counts_by_status": [],
+                "committed_by_currency": [],
+                "received_by_currency": [],
+                "conversion_progress_by_currency": [],
+                "budget_breakdown": [],
+            },
+        ) as mock_service:
+            response = client.get("/api/v1/budgets/dashboard/summary")
+
+        assert response.status_code == 200
+        assert response.json() == {
+            "budget_counts_by_status": [],
+            "committed_by_currency": [],
+            "received_by_currency": [],
+            "conversion_progress_by_currency": [],
+            "budget_breakdown": [],
+        }
+        mock_service.assert_called_once()
+
+
+class TestNoCustomerId:
+    def test_returns_empty_summary_when_customer_id_missing(self, db):
+        result = get_grantee_dashboard_summary_service(None, db)
+
+        assert result.budget_counts_by_status == []
+        assert result.committed_by_currency == []
+        assert result.received_by_currency == []
+        assert result.conversion_progress_by_currency == []
+        assert result.budget_breakdown == []

--- a/services/budget/tests/test_report_routes.py
+++ b/services/budget/tests/test_report_routes.py
@@ -27,6 +27,7 @@ from app.services.report_services import (
     create_report_service,
     get_report_service,
     list_reports_service,
+    list_all_reports_service,
     update_report_service,
     delete_report_service,
     submit_report_service,
@@ -231,6 +232,122 @@ class TestReportAccess:
             list_reports_service(db, _valid_user(STRANGER_ID), budget.id)
 
 
+class TestListAllReportsService:
+    """GET /reports/ — cross-budget reports directory (ticket #182)."""
+
+    def test_owner_sees_reports_across_all_their_budgets(self, db):
+        budget_a = _make_budget(db)
+        budget_b = _make_budget(db)
+        other_owner_budget = _make_budget(db, owner_id=STRANGER_ID)
+        report_a = _make_report(db, budget_a.id)
+        report_b = _make_report(
+            db, budget_b.id, period_start=date(2026, 4, 1), period_end=date(2026, 6, 30)
+        )
+        _make_report(db, other_owner_budget.id)
+
+        results = list_all_reports_service(db, _valid_user(OWNER_ID))
+
+        assert {r.id for r in results} == {report_a.id, report_b.id}
+
+    def test_donor_sees_reports_across_all_budgets_they_fund(self, db):
+        budget_a = _make_budget(db, funding_customer_id=FUNDER_ID)
+        budget_b = _make_budget(db, funding_customer_id=FUNDER_ID)
+        unrelated_budget = _make_budget(db)
+        report_a = _make_report(db, budget_a.id)
+        report_b = _make_report(
+            db, budget_b.id, period_start=date(2026, 4, 1), period_end=date(2026, 6, 30)
+        )
+        _make_report(db, unrelated_budget.id)
+
+        results = list_all_reports_service(db, _valid_user(FUNDER_ID))
+
+        assert {r.id for r in results} == {report_a.id, report_b.id}
+
+    def test_stranger_sees_nothing(self, db):
+        budget = _make_budget(db, funding_customer_id=FUNDER_ID)
+        _make_report(db, budget.id)
+
+        assert list_all_reports_service(db, _valid_user(STRANGER_ID)) == []
+
+    def test_status_filter(self, db):
+        budget = _make_budget(db)
+        draft = _make_report(db, budget.id, status=ReportStatus.draft)
+        _make_report(
+            db,
+            budget.id,
+            status=ReportStatus.submitted,
+            period_start=date(2026, 4, 1),
+            period_end=date(2026, 6, 30),
+        )
+
+        results = list_all_reports_service(db, _valid_user(OWNER_ID), status=ReportStatus.draft)
+
+        assert [r.id for r in results] == [draft.id]
+
+    def test_budget_id_filter(self, db):
+        budget_a = _make_budget(db)
+        budget_b = _make_budget(db)
+        report_a = _make_report(db, budget_a.id)
+        _make_report(db, budget_b.id, period_start=date(2026, 4, 1), period_end=date(2026, 6, 30))
+
+        results = list_all_reports_service(db, _valid_user(OWNER_ID), budget_id=budget_a.id)
+
+        assert [r.id for r in results] == [report_a.id]
+
+    def test_funding_customer_id_filter(self, db):
+        funded_budget = _make_budget(db, owner_id=OWNER_ID, funding_customer_id=FUNDER_ID)
+        unfunded_budget = _make_budget(db, owner_id=OWNER_ID)
+        funded_report = _make_report(db, funded_budget.id)
+        _make_report(
+            db,
+            unfunded_budget.id,
+            period_start=date(2026, 4, 1),
+            period_end=date(2026, 6, 30),
+        )
+
+        results = list_all_reports_service(db, _valid_user(OWNER_ID), funding_customer_id=FUNDER_ID)
+
+        assert [r.id for r in results] == [funded_report.id]
+
+    def test_filters_combine(self, db):
+        budget_a = _make_budget(db, funding_customer_id=FUNDER_ID)
+        budget_b = _make_budget(db, funding_customer_id=FUNDER_ID)
+        matching = _make_report(db, budget_a.id, status=ReportStatus.draft)
+        _make_report(
+            db,
+            budget_a.id,
+            status=ReportStatus.submitted,
+            period_start=date(2026, 4, 1),
+            period_end=date(2026, 6, 30),
+        )
+        _make_report(db, budget_b.id, status=ReportStatus.draft)
+
+        results = list_all_reports_service(
+            db,
+            _valid_user(FUNDER_ID),
+            status=ReportStatus.draft,
+            budget_id=budget_a.id,
+        )
+
+        assert [r.id for r in results] == [matching.id]
+
+    def test_budget_and_funder_fields_present_on_each_returned_report(self, db):
+        budget = _make_budget(
+            db,
+            funding_customer_id=FUNDER_ID,
+        )
+        budget.external_funder_name = "Acme Foundation"
+        db.commit()
+        _make_report(db, budget.id)
+
+        [result] = list_all_reports_service(db, _valid_user(OWNER_ID))
+
+        assert result.budget_name == "Test Budget"
+        assert result.budget_status == BudgetStatus.confirmed
+        assert str(result.funding_customer_id) == FUNDER_ID
+        assert result.external_funder_name == "Acme Foundation"
+
+
 class TestUpdateDeleteOwnership:
     def test_funder_cannot_update_or_delete(self, db):
         budget = _make_budget(db, funding_customer_id=FUNDER_ID)
@@ -401,6 +518,19 @@ class TestReportRoutesWiring:
         ) as mock_service:
             response = client.post(f"/api/v1/reports/{report_id}/submit")
         assert response.status_code == 200
+        mock_service.assert_called_once()
+
+    def test_list_all_reports_route_delegates_to_service(self, make_client):
+        client = make_client()
+        with patch(
+            "app.api.report_routes.list_all_reports_service", return_value=[]
+        ) as mock_service:
+            response = client.get(
+                "/api/v1/reports/",
+                params={"status": "draft", "budget_id": str(uuid4())},
+            )
+        assert response.status_code == 200
+        assert response.json() == []
         mock_service.assert_called_once()
 
     def test_review_report_route_delegates_to_service(self, make_client):

--- a/shared/schemas/budget_schema.py
+++ b/shared/schemas/budget_schema.py
@@ -56,6 +56,13 @@ class BudgetUpdate(BudgetBase):
     # for "unset"). BudgetBase's default only makes sense for BudgetCreate,
     # where a brand-new budget really does start as a draft.
     status: BudgetStatus | None = None
+    # Also the PATCH response shape (response_model=BudgetUpdate) — declared
+    # here, same as on Budget/BudgetWithLines, so a confirm/revert or a
+    # donor-commitment edit doesn't leave the caller with a stale value until
+    # it refetches (see budget_services._budget_update_response).
+    confirmed_at: datetime | None = None
+    estimated_local_cap: float | None = None
+    model_config = ConfigDict(from_attributes=True)
 
 
 class Budget(BudgetBase):
@@ -143,5 +150,10 @@ class FundedBudgetListItem(BaseModel):
     status: BudgetStatus
     total_amount: float | None = None
     local_currency: str | None = None
+    actual_currency: str | None = None
+    donor_total_amount: float | None = None
+    estimated_exchange_rate: float | None = None
+    confirmed_at: datetime | None = None
+    estimated_local_cap: float | None = None
     owner: CustomerOut | None = None
     model_config = ConfigDict(from_attributes=True)


### PR DESCRIPTION
## Summary

Combines four independent tickets into one PR per explicit request (all depend only on merged #179, not on each other) — see `openspec/changes/budget-report-iteration-2/tasks.md`'s exception note for the rationale.

- **Frontend (#180, #181):** donor commitment/estimated-rate editing and display on the budget view, donor dashboard, and budget lines table; Local/Donor (estimated)/Both currency toggle on the budget lines table
- **Backend (#182, #184):** cross-budget reports directory (`GET /reports/`, filterable by status/budget/funder) and grantee dashboard aggregation (`GET /budgets/dashboard/summary`)
- **Budget view redesign:** hero-figure summary stats, collapsed header with inline confirm/cancel, condensed provenance trace, allocation-vs-donor-cap traffic-light indicator (green/amber/red vs. the estimated local cap)
- **Fixes from a 13-finding review pass** (all in this PR, not deferred): donor fields could never be cleared once set; `PATCH /budgets/{id}` response validation actually crashed on any real (non-mocked) call — only masked by every existing test mocking the CRUD layer; `confirmed_at` wasn't cleared on revert-to-draft; the dashboard summary endpoint blocked the event loop; Both currency mode divided by zero on a falsy rate; plus assorted duplication/efficiency cleanup in report/dashboard CRUD

## Test plan

- [x] Backend: 231/231 tests passing, `flake8 --max-line-length=100` clean, `mypy` clean
- [x] Frontend: 145/145 tests passing, `tsc --noEmit` clean, no new eslint issues
- [x] Manually verified the mint→blue accent revert and allocation-status coloring live in the dev server

Closes #180, Closes #181, Closes #182, Closes #184

🤖 Generated with [Claude Code](https://claude.com/claude-code)