### PR TITLE
Customer discovery filters, auth hardening, and donor-grantee/customers gateway routes

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -48,6 +48,18 @@ api.opengrantflow.com {
 		reverse_proxy users:8000
 	}
 
+	# ---- DONOR-GRANTEE RELATIONSHIPS ----
+	handle_path /api/v1/donor-grantees/* {
+		rewrite * /api/donor-grantees{uri}
+		reverse_proxy users:8000
+	}
+
+	# ---- CUSTOMERS ----
+	handle_path /api/v1/customers/* {
+		rewrite * /api/customers{uri}
+		reverse_proxy users:8000
+	}
+
 	# ---- BUDGET SERVICE ----
 	handle /api/v1/budgets/* {
 		reverse_proxy budget:8000

--- a/nginx/nginx-dev.conf
+++ b/nginx/nginx-dev.conf
@@ -59,6 +59,24 @@ http {
             proxy_set_header X-Forwarded-Proto $scheme;
         }
 
+        # ---- DONOR-GRANTEE RELATIONSHIPS ----
+        location /api/v1/donor-grantees/ {
+            proxy_pass http://users/api/donor-grantees/;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
+        # ---- CUSTOMERS ----
+        location /api/v1/customers/ {
+            proxy_pass http://users/api/customers/;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
         # ---- AUTH SERVICE ----
         location /api/v1/auth/ {
             proxy_pass http://users/api/auth/;

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -49,6 +49,28 @@ http {
             proxy_set_header X-Forwarded-Proto $scheme;
         }
 
+        # ---- DONOR-GRANTEE RELATIONSHIPS ----
+        location /api/v1/donor-grantees/ {
+            set $users_service "http://users:8000";
+            rewrite ^/api/v1/donor-grantees/(.*)$ /api/donor-grantees/$1 break;
+            proxy_pass $users_service;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
+        # ---- CUSTOMERS ----
+        location /api/v1/customers/ {
+            set $users_service "http://users:8000";
+            rewrite ^/api/v1/customers/(.*)$ /api/customers/$1 break;
+            proxy_pass $users_service;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
         # ---- AUTH SERVICE ----
         location /api/v1/auth/ {
             set $users_service "http://users:8000";

--- a/openspec/changes/donor-grantee-relationship-backend/specs/donor-grantee-relationship/spec.md
+++ b/openspec/changes/donor-grantee-relationship-backend/specs/donor-grantee-relationship/spec.md
@@ -50,7 +50,7 @@ The system SHALL allow a donor to list all `donor_grantees` records where they a
 - **THEN** the system rejects the request and the record is not removed
 
 #### Scenario: Superuser lists any customer's relationships
-- **WHEN** an authenticated user with the `superuser` role requests a relationship list with an explicit `customer_id` and `role`
+- **WHEN** an authenticated user with the `superuser` role requests a relationship list with an explicit `customer_id` and `request_type`
 - **THEN** the system returns the matching `donor_grantees` records for that `customer_id`, regardless of who the superuser is
 
 #### Scenario: Superuser deletes any relationship

--- a/openspec/changes/donor-grantee-relationship-backend/tasks.md
+++ b/openspec/changes/donor-grantee-relationship-backend/tasks.md
@@ -9,7 +9,7 @@ One task group = one GitHub ticket = one PR, merged before the next group starts
 - [x] 1.5 Add `services/users/app/crud/donor_grantee_crud.py`: `create_donor_grantee`, `list_donor_grantees(*, donor_id=None, grantee_id=None)`, `get_donor_grantee`, `delete_donor_grantee`, `donor_grantee_exists`. `create_donor_grantee` fetches both the real donor and grantee `CustomerModel` rows in a single `get_customers_by_ids` query (keyed by `str(id)` to sidestep `GUID`'s dialect-dependent str/UUID round-trip) so the model's `@validates` hooks fire, and raises a 404-appropriate error if either customer doesn't exist.
 - [x] 1.6 Add `services/users/app/api/donor_grantee_routes.py` following `customer_routes.py` conventions:
   - `POST /donor-grantees/` — donor-only (`require_donor` check on `valid_user`), `donor_id` always taken from `valid_user["customer_id"]`, never from the request body — **except for a `superuser` caller, who must supply `donor_id` explicitly in the body (rejected with 400 if omitted)**, since a superuser has no donor customer of their own to derive it from; 400 on duplicate (unique-constraint `IntegrityError`) or invalid grantee.
-  - `GET /donor-grantees/?role=donor|grantee` — returns the caller's own relationships, scoped by their `customer_id`; 400 on missing/invalid `role`. A `superuser` caller must instead pass `customer_id` explicitly (rejected with 400 if omitted) and gets that customer's relationships.
+  - `GET /donor-grantees/?request_type=donor|grantee` — returns the caller's own relationships, scoped by their `customer_id`; 400 on missing/invalid `request_type`. A `superuser` caller must instead pass `customer_id` explicitly (rejected with 400 if omitted) and gets that customer's relationships.
   - `DELETE /donor-grantees/{id}` — donor-only; 404 if missing, 403 if `donor_id` doesn't match the caller. A `superuser` caller bypasses the ownership check and may delete any record.
   - `GET /donor-grantees/exists?donor_id=&grantee_id=` — no auth, matching the existing `POST /customers/by_ids/` internal-endpoint convention; returns `{"exists": bool}`.
 - [x] 1.7 Register the router in `services/users/main.py` at prefix `/api`.
@@ -28,8 +28,8 @@ One task group = one GitHub ticket = one PR, merged before the next group starts
 
 ## 3. Customer discovery + gateway routes — depends on 1 — ticket #191 (`Platform/Issue-191/customer-discovery-gateway-routes`)
 
-- [ ] 3.1 Extend `get_customers`/`list_customers` (`services/users/app/crud/customer_crud.py`, `services/users/app/api/customer_routes.py`) with optional `is_ngo` and `search` (name `ilike`) query params.
-- [ ] 3.2 Add `Depends(get_current_user)` to `list_customers` and `get_customer_endpoint` in `customer_routes.py` (currently unauthenticated; hardening ahead of exposing these through the public gateway for the first time).
-- [ ] 3.3 Add gateway routes for `/api/v1/donor-grantees/` and `/api/v1/customers/` in `nginx/nginx-dev.conf`, `nginx/nginx.conf`, and `Caddyfile`, mirroring the existing `/api/v1/users/` block.
-- [ ] 3.4 Manually verify (per design.md's migration plan) end-to-end against the dev stack: donor approves a grantee, grantee's budget-funding attempt succeeds; donor revokes, a new funding attempt fails while the earlier budget is unaffected; non-donor/grantee-side write attempts are rejected.
+- [x] 3.1 Extend `get_customers`/`list_customers` (`services/users/app/crud/customer_crud.py`, `services/users/app/api/customer_routes.py`) with optional `is_ngo` and `search` (name `ilike`) query params.
+- [x] 3.2 Add `Depends(get_current_user)` to `list_customers` and `get_customer_endpoint` in `customer_routes.py` (currently unauthenticated; hardening ahead of exposing these through the public gateway for the first time).
+- [x] 3.3 Add gateway routes for `/api/v1/donor-grantees/` and `/api/v1/customers/` in `nginx/nginx-dev.conf`, `nginx/nginx.conf`, and `Caddyfile`, mirroring the existing `/api/v1/users/` block.
+- [x] 3.4 Manually verify (per design.md's migration plan) end-to-end against the dev stack: donor approves a grantee, grantee's budget-funding attempt succeeds; donor revokes, a new funding attempt fails while the earlier budget is unaffected; non-donor/grantee-side write attempts are rejected.
 - [ ] 3.5 Run users-service tests and lint clean; PR merged (`Closes` the ticket for this group).

--- a/openspec/changes/donor-grantee-relationship-frontend/design.md
+++ b/openspec/changes/donor-grantee-relationship-frontend/design.md
@@ -19,7 +19,7 @@ This depends entirely on `donor-grantee-relationship-backend`: the `/api/v1/dono
 
 ## Decisions
 
-**1. Grantee's donor picker is a plain `<select>`, not a search box.** A grantee's own approved-donor list (`GET /donor-grantees/?role=grantee`) is expected to be small (a handful of donors at most), fetched once via `useQuery`, no search needed. This matches `AddBudgetModal`'s existing plain-input style — no new component.
+**1. Grantee's donor picker is a plain `<select>`, not a search box.** A grantee's own approved-donor list (`GET /donor-grantees/?request_type=grantee`) is expected to be small (a handful of donors at most), fetched once via `useQuery`, no search needed. This matches `AddBudgetModal`'s existing plain-input style — no new component.
 
 **2. Donor's "add grantee" is a manual-trigger search, not live filtering.** Text input for an NGO name + a search action (button or Enter-to-submit) fires `useQuery` with the search string as part of the query key (or a `useMutation`/manual `refetch`), calling `GET /customers/?is_ngo=true&search=...`. Chosen over live-as-you-type to avoid needing a debounce utility that doesn't exist in this codebase, for a low-frequency action.
 

--- a/openspec/changes/donor-grantee-relationship-frontend/tasks.md
+++ b/openspec/changes/donor-grantee-relationship-frontend/tasks.md
@@ -2,7 +2,7 @@ One task group = one GitHub ticket = one PR, merged before the next group starts
 
 ## 1. API client layer
 
-- [ ] 1.1 Add `frontend-typescript/src/api/donorGranteeApi.ts`: `listDonorGrantees(role: "donor" | "grantee")`, `createDonorGrantee(granteeId: string)`, `deleteDonorGrantee(id: string)`, typed response interfaces, wrapping `gatewayApi` against `/api/v1/donor-grantees/`, mirroring `donorDashboardApi.ts`'s style.
+- [ ] 1.1 Add `frontend-typescript/src/api/donorGranteeApi.ts`: `listDonorGrantees(requestType: "donor" | "grantee")`, `createDonorGrantee(granteeId: string)`, `deleteDonorGrantee(id: string)`, typed response interfaces, wrapping `gatewayApi` against `/api/v1/donor-grantees/`, mirroring `donorDashboardApi.ts`'s style.
 - [ ] 1.2 Extend the customer-facing API client with `searchCustomers({ is_ngo, search })` against `/api/v1/customers/` (new file `customerApi.ts`, or extend an existing users-api client if one already wraps `/api/v1/customers/` or `/api/v1/users/` — check `frontend-typescript/src/api/` before adding a new file).
 - [ ] 1.3 Manually verify both clients against the live dev stack once `donor-grantee-relationship-backend` is merged (list/create/delete relationship; search customers by name and `is_ngo`).
 - [ ] 1.4 Run frontend lint/typecheck clean; PR merged (`Closes` the ticket for this group).

--- a/services/budget/app/services/budget_services.py
+++ b/services/budget/app/services/budget_services.py
@@ -178,11 +178,6 @@ async def update_budget_service(budget_id: UUID, budget: BudgetCreate, valid_use
         budget_id, valid_user, is_confirm_attempt, db
     )
 
-    if budget.funding_customer_id:
-        validate_donor_grantee_relationship(
-            budget.funding_customer_id, valid_budget.owner_id, raise_domain_error=True
-        )
-
     if is_funder_confirm and _is_metadata_edit(budget):
         raise DomainError(
             "A funder can only confirm a budget, not edit its metadata",
@@ -223,6 +218,16 @@ async def update_budget_service(budget_id: UUID, budget: BudgetCreate, valid_use
             str(valid_user["customer_id"]) != str(valid_budget.owner_id)
         ):
             raise PermissionDenied()
+
+    if budget.funding_customer_id:
+        # Checked against the *final* owner (post-reassignment), not
+        # valid_budget.owner_id — a superuser changing owner_id and
+        # funding_customer_id in the same request must be validated against
+        # the new owner, otherwise the gate could be bypassed by reassigning
+        # to an unapproved grantee after the check.
+        validate_donor_grantee_relationship(
+            budget.funding_customer_id, owner_id or valid_budget.owner_id, raise_domain_error=True
+        )
 
     if budget.status == BudgetStatus.confirmed:
         effective_start_date = budget.start_date or valid_budget.start_date

--- a/services/budget/app/services/budget_services.py
+++ b/services/budget/app/services/budget_services.py
@@ -76,6 +76,11 @@ async def create_budget_service(
         owner_id = budget.owner_id
 
     if budget.funding_customer_id:
+        # owner_id is always set by this point: either the caller's own
+        # customer_id claim (always present in a valid JWT) or, for a
+        # superuser, budget.owner_id (either client-supplied or the
+        # FIXME fallback above) — never None in practice.
+        assert owner_id is not None
         validate_donor_grantee_relationship(
             budget.funding_customer_id, owner_id, raise_domain_error=True
         )

--- a/services/budget/app/services/customer_client.py
+++ b/services/budget/app/services/customer_client.py
@@ -13,12 +13,19 @@ class CustomerServiceError(Exception):
 
 
 def get_customer(customer_id: str | uuid.UUID) -> dict:
+    """Uses the no-auth by_ids/ internal endpoint (not GET /customers/{id},
+    which now requires a JWT) since this is a service-to-service call with
+    no user token to forward."""
     try:
-        resp = requests.get(f"{CUSTOMER_SERVICE_URL}{customer_id}")
+        resp = requests.post(f"{CUSTOMER_SERVICE_URL}by_ids/", json=[str(customer_id)])
         resp.raise_for_status()
-        return resp.json()
+        items = resp.json()
     except requests.RequestException as e:
         raise CustomerServiceError(f"Failed to fetch customer {customer_id}") from e
+
+    if not items:
+        raise CustomerServiceError(f"Failed to fetch customer {customer_id}")
+    return items[0]
 
 
 @lru_cache(maxsize=128)

--- a/services/budget/app/services/donor_grantee_client.py
+++ b/services/budget/app/services/donor_grantee_client.py
@@ -44,6 +44,4 @@ def validate_donor_grantee_relationship(
         raise Error(str(e))
 
     if not exists:
-        raise Error(
-            f"Donor {donor_id} has not approved grantee {grantee_id} to fund their budgets"
-        )
+        raise Error(f"Donor {donor_id} has not approved grantee {grantee_id} to fund their budgets")

--- a/services/users/app/api/customer_routes.py
+++ b/services/users/app/api/customer_routes.py
@@ -1,33 +1,35 @@
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 from app.schemas.customer_schema import Customer
-from app.db.session import SessionLocal
+from app.db.session import get_db
 from app.crud.customer_crud import (
     create_customer,
     get_customers,
     get_customer,
     get_customers_by_ids,
 )
+from app.utils.security import get_current_user
 from uuid import UUID
 
 router = APIRouter()
 
 
-def get_db():
-    db = SessionLocal()
-    try:
-        yield db
-    finally:
-        db.close()
-
-
 @router.get("/customers/", response_model=list[Customer])
-def list_customers(db: Session = Depends(get_db)):
-    return get_customers(session=db)
+def list_customers(
+    is_ngo: bool | None = None,
+    search: str | None = None,
+    db: Session = Depends(get_db),
+    current_user: dict = Depends(get_current_user),
+):
+    return get_customers(session=db, is_ngo=is_ngo, search=search)
 
 
 @router.post("/customers/", response_model=Customer)
-def create_customer_endpoint(customer: Customer, db: Session = Depends(get_db)):
+def create_customer_endpoint(
+    customer: Customer,
+    db: Session = Depends(get_db),
+    current_user: dict = Depends(get_current_user),
+):
     db_customer = create_customer(
         session=db,
         name=customer.name,
@@ -40,7 +42,11 @@ def create_customer_endpoint(customer: Customer, db: Session = Depends(get_db)):
 
 
 @router.get("/customers/{customer_id}", response_model=Customer)
-def get_customer_endpoint(customer_id: UUID, db: Session = Depends(get_db)):
+def get_customer_endpoint(
+    customer_id: UUID,
+    db: Session = Depends(get_db),
+    current_user: dict = Depends(get_current_user),
+):
     customer = get_customer(session=db, customer_id=customer_id)
     if not customer:
         raise HTTPException(status_code=404, detail="Customer not found")

--- a/services/users/app/api/donor_grantee_routes.py
+++ b/services/users/app/api/donor_grantee_routes.py
@@ -32,7 +32,7 @@ def create_donor_grantee_endpoint(
 
 @router.get("/donor-grantees/", response_model=list[DonorGrantee])
 def list_donor_grantees_endpoint(
-    role: str,
+    request_type: str | None = None,
     customer_id: UUID | None = None,
     db: Session = Depends(get_db),
     valid_user: dict = Depends(get_validated_user),
@@ -40,7 +40,9 @@ def list_donor_grantees_endpoint(
     # customer_id is only honored for a superuser caller (see
     # list_donor_grantees_service) — a regular caller is always scoped to
     # their own customer_id regardless of what they pass here.
-    return list_donor_grantees_service(db, valid_user, role=role, customer_id=customer_id)
+    return list_donor_grantees_service(
+        db, valid_user, request_type=request_type, customer_id=customer_id
+    )
 
 
 @router.delete("/donor-grantees/{donor_grantee_id}", status_code=204)

--- a/services/users/app/crud/customer_crud.py
+++ b/services/users/app/crud/customer_crud.py
@@ -8,8 +8,21 @@ def get_customer(session: Session, customer_id: UUID):
     return session.query(CustomerModel).filter(CustomerModel.id == customer_id).first()
 
 
-def get_customers(session: Session, limit: int = 100):
-    return session.query(CustomerModel).limit(limit).all()
+def get_customers(
+    session: Session,
+    limit: int = 100,
+    is_ngo: bool | None = None,
+    search: str | None = None,
+):
+    query = session.query(CustomerModel)
+    if is_ngo is not None:
+        query = query.filter(CustomerModel.is_ngo == is_ngo)
+    if search:
+        # Escape ilike wildcards (% and _) in user input so they're matched
+        # literally rather than acting as pattern metacharacters.
+        escaped = search.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+        query = query.filter(CustomerModel.name.ilike(f"%{escaped}%", escape="\\"))
+    return query.limit(limit).all()
 
 
 def create_customer(

--- a/services/users/app/services/donor_grantees_services.py
+++ b/services/users/app/services/donor_grantees_services.py
@@ -15,6 +15,10 @@ from app.crud.donor_grantee_crud import (
 logger = get_logger(__name__)
 
 
+def is_superuser(valid_user: dict) -> bool:
+    return valid_user.get("role") == "superuser"
+
+
 def require_donor(valid_user: dict) -> None:
     """Assert the caller's customer has is_donor=True.
 
@@ -26,39 +30,48 @@ def require_donor(valid_user: dict) -> None:
         raise DomainError("Customer is not a donor", status.HTTP_403_FORBIDDEN)
 
 
+def _resolve_scoped_customer_id(
+    valid_user: dict,
+    explicit_id: UUID | None,
+    *,
+    field_name: str,
+    require_donor_role: bool = False,
+) -> UUID:
+    """Resolve which customer_id a request acts as/on.
+
+    A superuser has no donor/grantee customer of their own to derive from,
+    so they must supply `explicit_id` (rejected if omitted). A regular
+    caller is always scoped to their own `customer_id` JWT claim — anything
+    they submit for `explicit_id` is ignored.
+    """
+    if is_superuser(valid_user):
+        if explicit_id is None:
+            raise DomainError(f"Superuser must specify {field_name}", status.HTTP_400_BAD_REQUEST)
+        return explicit_id
+    if require_donor_role:
+        require_donor(valid_user)
+    return UUID(str(valid_user["customer_id"]))
+
+
 def create_donor_grantee_service(
     session: Session, valid_user: dict, grantee_id: UUID, donor_id: UUID | None = None
 ):
-    if valid_user.get("role") == "superuser":
-        # Superusers aren't necessarily attached to a donor customer
-        # themselves (see the analogous owner_id override in
-        # budget_services.create_budget_service), so there's no JWT claim to
-        # derive donor_id from — the caller must say which donor they mean.
-        if donor_id is None:
-            raise DomainError("Superuser must specify donor_id", status.HTTP_400_BAD_REQUEST)
-    else:
-        require_donor(valid_user)
-        donor_id = UUID(str(valid_user["customer_id"]))
-
+    donor_id = _resolve_scoped_customer_id(
+        valid_user, donor_id, field_name="donor_id", require_donor_role=True
+    )
     return create_donor_grantee(session, donor_id=donor_id, grantee_id=grantee_id)
 
 
 def list_donor_grantees_service(
-    session: Session, valid_user: dict, role: str, customer_id: UUID | None = None
+    session: Session, valid_user: dict, request_type: str | None, customer_id: UUID | None = None
 ):
-    if valid_user.get("role") == "superuser":
-        # A superuser has no customer_id claim of their own to scope by —
-        # they're asking on behalf of whichever customer they specify.
-        if customer_id is None:
-            raise DomainError("Superuser must specify customer_id", status.HTTP_400_BAD_REQUEST)
-    else:
-        customer_id = UUID(str(valid_user["customer_id"]))
+    customer_id = _resolve_scoped_customer_id(valid_user, customer_id, field_name="customer_id")
 
-    if role == "donor":
+    if request_type == "donor":
         return list_donor_grantees(session, donor_id=customer_id)
-    if role == "grantee":
+    if request_type == "grantee":
         return list_donor_grantees(session, grantee_id=customer_id)
-    raise DomainError("role must be 'donor' or 'grantee'", status.HTTP_400_BAD_REQUEST)
+    raise DomainError("request_type must be 'donor' or 'grantee'", status.HTTP_400_BAD_REQUEST)
 
 
 def delete_donor_grantee_service(session: Session, valid_user: dict, donor_grantee_id: UUID):
@@ -68,7 +81,7 @@ def delete_donor_grantee_service(session: Session, valid_user: dict, donor_grant
 
     # A superuser may delete any relationship; a regular caller must be the
     # donor on the row itself (checked below), not merely *a* donor.
-    if valid_user.get("role") != "superuser":
+    if not is_superuser(valid_user):
         require_donor(valid_user)
         if str(donor_grantee.donor_id) != str(valid_user["customer_id"]):
             raise DomainError(

--- a/services/users/tests/test_customer_routes.py
+++ b/services/users/tests/test_customer_routes.py
@@ -1,0 +1,91 @@
+"""Route tests for /api/customers/ covering the auth + search-filter changes
+made alongside ticket #191 (customer discovery filters, auth hardening).
+"""
+
+from tests.factories.user import CustomerFactory
+
+
+def _persist(db, obj):
+    db.add(obj)
+    db.commit()
+    db.refresh(obj)
+    return obj
+
+
+class TestListCustomers:
+    def test_requires_auth(self, make_client, db):
+        client = make_client(db=db)
+        app = client.app
+        from app.utils.security import get_current_user
+
+        del app.dependency_overrides[get_current_user]
+
+        response = client.get("/api/customers/")
+
+        assert response.status_code == 401
+
+    def test_search_escapes_ilike_wildcards(self, make_client, db):
+        _persist(db, CustomerFactory.build(name="100% Match Org"))
+        _persist(db, CustomerFactory.build(name="Unrelated Org"))
+        client = make_client(db=db)
+
+        response = client.get("/api/customers/", params={"search": "100%"})
+
+        assert response.status_code == 200
+        body = response.json()
+        assert len(body) == 1
+        assert body[0]["name"] == "100% Match Org"
+
+    def test_search_underscore_is_literal(self, make_client, db):
+        _persist(db, CustomerFactory.build(name="a_b Org"))
+        _persist(db, CustomerFactory.build(name="axb Org"))
+        client = make_client(db=db)
+
+        response = client.get("/api/customers/", params={"search": "a_b"})
+
+        assert response.status_code == 200
+        body = response.json()
+        assert len(body) == 1
+        assert body[0]["name"] == "a_b Org"
+
+    def test_is_ngo_filter(self, make_client, db):
+        _persist(db, CustomerFactory.build(name="NGO Org", is_ngo=True))
+        _persist(db, CustomerFactory.build(name="Donor Org", is_ngo=False))
+        client = make_client(db=db)
+
+        response = client.get("/api/customers/", params={"is_ngo": True})
+
+        assert response.status_code == 200
+        body = response.json()
+        assert len(body) == 1
+        assert body[0]["name"] == "NGO Org"
+
+
+class TestCreateCustomer:
+    def test_requires_auth(self, make_client, db):
+        client = make_client(db=db)
+        app = client.app
+        from app.utils.security import get_current_user
+
+        del app.dependency_overrides[get_current_user]
+
+        response = client.post(
+            "/api/customers/",
+            json={"name": "New Org", "country": "GB", "currency": "GBP"},
+        )
+
+        assert response.status_code == 401
+
+
+class TestGetCustomer:
+    def test_requires_auth(self, make_client, db):
+        customer = _persist(db, CustomerFactory.build())
+        client = make_client(db=db)
+        app = client.app
+        from app.utils.security import get_current_user
+
+        del app.dependency_overrides[get_current_user]
+
+        response = client.get(f"/api/customers/{customer.id}")
+
+        assert response.status_code == 401

--- a/services/users/tests/test_donor_grantee_routes.py
+++ b/services/users/tests/test_donor_grantee_routes.py
@@ -111,7 +111,7 @@ class TestListDonorGrantees:
         create_donor_grantee(db, donor_id=other_donor.id, grantee_id=other_grantee.id)
         client = make_client(db=db, customer_id=str(donor.id), is_donor=True)
 
-        response = client.get("/api/donor-grantees/", params={"role": "donor"})
+        response = client.get("/api/donor-grantees/", params={"request_type": "donor"})
 
         assert response.status_code == 200
         body = response.json()
@@ -126,17 +126,24 @@ class TestListDonorGrantees:
         create_donor_grantee(db, donor_id=donor.id, grantee_id=other_grantee.id)
         client = make_client(db=db, customer_id=str(grantee.id), is_donor=False)
 
-        response = client.get("/api/donor-grantees/", params={"role": "grantee"})
+        response = client.get("/api/donor-grantees/", params={"request_type": "grantee"})
 
         assert response.status_code == 200
         body = response.json()
         assert len(body) == 1
         assert body[0]["grantee_id"] == str(grantee.id)
 
-    def test_invalid_role_is_rejected(self, make_client, db):
+    def test_invalid_request_type_is_rejected(self, make_client, db):
         client = make_client(db=db, is_donor=True)
 
-        response = client.get("/api/donor-grantees/", params={"role": "nope"})
+        response = client.get("/api/donor-grantees/", params={"request_type": "nope"})
+
+        assert response.status_code == 400
+
+    def test_missing_request_type_is_400_not_422(self, make_client, db):
+        client = make_client(db=db, is_donor=True)
+
+        response = client.get("/api/donor-grantees/")
 
         assert response.status_code == 400
 
@@ -150,7 +157,7 @@ class TestListDonorGrantees:
         client = make_client(db=db, role="superuser")
 
         response = client.get(
-            "/api/donor-grantees/", params={"role": "donor", "customer_id": str(donor.id)}
+            "/api/donor-grantees/", params={"request_type": "donor", "customer_id": str(donor.id)}
         )
 
         assert response.status_code == 200
@@ -161,7 +168,7 @@ class TestListDonorGrantees:
     def test_superuser_without_customer_id_is_rejected(self, make_client, db):
         client = make_client(db=db, role="superuser")
 
-        response = client.get("/api/donor-grantees/", params={"role": "donor"})
+        response = client.get("/api/donor-grantees/", params={"request_type": "donor"})
 
         assert response.status_code == 400
 


### PR DESCRIPTION
## Summary
- Extends `GET /customers/` with optional `is_ngo` and `search` (name `ilike`, wildcard-escaped) filters
- Adds `Depends(get_current_user)` to `list_customers`, `get_customer_endpoint`, and `create_customer_endpoint` (previously unauthenticated)
- Adds gateway routes for `/api/v1/donor-grantees/` and `/api/v1/customers/` in `nginx-dev.conf`, `nginx.conf`, and `Caddyfile`
- Fixes review findings surfaced while implementing this ticket:
  - `services/budget/app/services/customer_client.py`'s internal customer lookup now uses the no-auth `by_ids/` endpoint instead of the now-authed `GET /customers/{id}` (was 401ing every funded budget create/update)
  - `update_budget_service`'s donor-grantee gate now runs after owner reassignment, checking the *final* owner (closes a superuser bypass)
  - Removed a locally-shadowed `get_db()` in `customer_routes.py` that the test fixture's override couldn't reach
  - `list_donor_grantees`'s query param renamed `role` → `request_type` (was confusable with the JWT's own `role` claim); missing param now 400s instead of 422
  - Deduped the superuser-bypass-else-JWT-claim pattern in `donor_grantees_services.py` into `_resolve_scoped_customer_id`/`is_superuser` helpers

Manually verified end-to-end against the dev stack per design.md's migration plan (donor approve → funding succeeds; revoke → new funding attempt fails, existing budget unaffected).

Closes #191

## Test plan
- [x] `services/users/tests/` — 45/45 passing (incl. new `test_customer_routes.py`)
- [x] `services/budget/tests/` — 258/258 passing
- [x] flake8 (`--max-line-length=100`) and black clean on all touched files
- [x] Manual e2e verification against dev stack

🤖 Generated with [Claude Code](https://claude.com/claude-code)