### PR TITLE
Playwright API-chain e2e suite (Phase 1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,11 @@ coverage.xml
 .pytest_cache/
 cover/
 
+# Playwright
+test-results/
+playwright-report/
+blob-report/
+
 # Translations
 *.mo
 *.pot

--- a/README.md
+++ b/README.md
@@ -1,12 +1,10 @@
 # GrantFlow
 
-**Version:** 0.1.0 · **Last updated:** 2026-07-19
+**Version:** 0.1.0 · **Last updated:** 2026-08-07
 
 GrantFlow is an open-source platform for budget management and financial reporting in NGOs and donor organizations. It was born from 20 years of watching organizations manage grant budgets in incompatible Excel files — and a belief that modern software engineering can fix that.
 
 > **Status:** Active development — not yet production-ready.
-
-> **In-progress migration:** the AI chat stack is moving to a dedicated `chat-service` ("agent host") that owns conversation history and tool dispatch, so `ai-service` becomes pure stateless reasoning. This document describes the target architecture. Merged so far: #87–#90 (safety-net tests, frontend URL context, `shared/ai_client`, ai's `POST /ai/decide`). Next up: **#95 — retire ai's legacy chat stack** (`chat_routes.py`, `chat_orchestrator.py`, `chat_agent.py`, session tables). See [`openspec/changes/ai-chat-agent-host-migration/`](openspec/changes/ai-chat-agent-host-migration/) for the full proposal, design, and live task status.
 
 → **[Product Overview](docs/PRODUCT.md)** — what GrantFlow does, who it's for, and why it exists.
 
@@ -279,10 +277,13 @@ GrantFlow/
 ├── shared/                 # Shared Python library
 │   ├── ai_client/          # In-process client for ai-service's /ai/decide (retries, timeouts, decision parsing)
 │   ├── db/                 # Audit mixin, custom column types
+│   ├── exceptions/         # Shared exception types
 │   ├── observability/      # OpenTelemetry setup
 │   ├── schemas/            # Pydantic schemas (cross-service)
 │   ├── security/           # JWT utils, FastAPI auth dependencies
-│   └── utils/              # HTTP client wrapper, currency service
+│   ├── services/           # Currency service
+│   ├── storage/            # S3-compatible storage service (report attachments)
+│   └── utils/              # HTTP client wrapper
 └── services/
     ├── users/              # FastAPI: users, customers, auth
     ├── budget/             # FastAPI: budgets, budget lines
@@ -322,6 +323,8 @@ GitHub Actions runs on every push/PR touching a service or `shared/`:
 | `worker.yml` | `services/worker/**` | black · flake8 · pytest |
 | `shared.yml` | `shared/**` | black · flake8 · pytest (`shared/ai_client`, `shared/tests`) |
 | `frontend.yml` | `frontend-typescript/**` | vitest (with coverage) |
+| `compose.yml` | compose files, `.env*` (changed paths) | Docker Compose Validation — config lint |
+| `deploy.yml` | push to `main` | Deploy to VPS over SSH (`workflow_dispatch` also) |
 
 ---
 

--- a/frontend-typescript/e2e/playwright.config.ts
+++ b/frontend-typescript/e2e/playwright.config.ts
@@ -1,0 +1,26 @@
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./specs",
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  reporter: "list",
+  projects: [
+    {
+      name: "api",
+      testDir: "./specs/api",
+      use: {
+        baseURL: process.env.E2E_GATEWAY_URL ?? "http://localhost:9082",
+      },
+    },
+    {
+      name: "browser",
+      testDir: "./specs/browser",
+      use: {
+        ...devices["Desktop Chrome"],
+        baseURL: process.env.E2E_FRONTEND_URL ?? "http://localhost:4000",
+      },
+    },
+  ],
+});

--- a/frontend-typescript/e2e/specs/api/auth-budget-chain.spec.ts
+++ b/frontend-typescript/e2e/specs/api/auth-budget-chain.spec.ts
@@ -1,0 +1,111 @@
+import { test, expect, request as pwRequest } from "@playwright/test";
+import { jwtDecode } from "jwt-decode";
+
+interface TokenResponse {
+  access_token: string;
+  token_type: string;
+  refresh_token: string;
+  status: string;
+}
+
+interface JwtPayload {
+  user_id: string;
+}
+
+// Register issues a token for a "pending" user with no org attached yet;
+// budgets require an owner_id (customer_id), so the chain onboards the user
+// (creating an org) before logging back in to pick up a token whose claims
+// actually carry that customer_id — mirrors the real Register -> Onboarding
+// -> Dashboard flow in the frontend (see src/pages/OnBoarding.tsx).
+test("register, onboard, login, then drive the budget CRUD chain", async ({
+  request,
+  baseURL,
+}) => {
+  const unique = crypto.randomUUID();
+  const email = `e2e-${unique}@example.com`;
+  const password = "Passw0rd!23";
+
+  const registerRes = await request.post("/api/v1/register", {
+    data: { email, password, first_name: "E2E", last_name: "Tester" },
+  });
+  expect(registerRes.status()).toBe(200);
+  const registerBody: TokenResponse = await registerRes.json();
+  expect(registerBody.access_token).toBeTruthy();
+
+  const userId = jwtDecode<JwtPayload>(registerBody.access_token).user_id;
+  expect(userId).toBeTruthy();
+
+  const registerContext = await pwRequest.newContext({
+    baseURL,
+    extraHTTPHeaders: { Authorization: `Bearer ${registerBody.access_token}` },
+  });
+  const onboardRes = await registerContext.patch(`/api/v1/users/${userId}/`, {
+    data: { new_customer_name: `E2E Org ${unique}` },
+  });
+  expect(onboardRes.status()).toBe(200);
+  await registerContext.dispose();
+
+  const loginRes = await request.post("/api/v1/auth/login", {
+    data: { email, password },
+  });
+  expect(loginRes.status()).toBe(200);
+  const loginBody: TokenResponse = await loginRes.json();
+  expect(loginBody.access_token).toBeTruthy();
+
+  const authed = await pwRequest.newContext({
+    baseURL,
+    extraHTTPHeaders: { Authorization: `Bearer ${loginBody.access_token}` },
+  });
+
+  try {
+    const createBudgetRes = await authed.post("/api/v1/budgets/", {
+      data: {
+        name: `E2E Budget ${unique}`,
+        external_funder_name: "E2E Funder",
+        local_currency: "USD",
+        actual_currency: "USD",
+      },
+    });
+    expect(createBudgetRes.status()).toBe(200);
+    const budget = await createBudgetRes.json();
+    expect(budget.id).toBeTruthy();
+    const budgetId: string = budget.id;
+
+    const addLineRes = await authed.post("/api/v1/budget-lines/", {
+      data: { budget_id: budgetId, description: "Initial line", amount: 100 },
+    });
+    expect(addLineRes.status()).toBe(200);
+    const line = await addLineRes.json();
+    expect(line.id).toBeTruthy();
+    const lineId: string = line.id;
+
+    const updateLineRes = await authed.patch(`/api/v1/budget-lines/${lineId}/`, {
+      data: { budget_id: budgetId, amount: 150 },
+    });
+    expect(updateLineRes.status()).toBe(200);
+    const updatedLine = await updateLineRes.json();
+    expect(updatedLine.amount).toBe(150);
+
+    const getBudgetRes = await authed.get(`/api/v1/budgets/${budgetId}`);
+    expect(getBudgetRes.status()).toBe(200);
+    const budgetWithLines = await getBudgetRes.json();
+    expect(budgetWithLines.total_amount).toBe(150);
+    expect(budgetWithLines.lines).toHaveLength(1);
+
+    const deleteLineRes = await authed.delete(`/api/v1/budget-lines/${lineId}/`);
+    expect(deleteLineRes.status()).toBe(200);
+
+    const getAfterDeleteRes = await authed.get(`/api/v1/budgets/${budgetId}`);
+    expect(getAfterDeleteRes.status()).toBe(200);
+    const budgetAfterDelete = await getAfterDeleteRes.json();
+    expect(budgetAfterDelete.total_amount).toBe(0);
+    expect(budgetAfterDelete.lines).toHaveLength(0);
+
+    const deleteBudgetRes = await authed.delete(`/api/v1/budgets/${budgetId}`);
+    expect(deleteBudgetRes.status()).toBe(200);
+    const deleteBudgetBody = await deleteBudgetRes.json();
+    expect(deleteBudgetBody.success).toBe(true);
+  } finally {
+    await authed.dispose();
+  }
+});

--- a/frontend-typescript/package-lock.json
+++ b/frontend-typescript/package-lock.json
@@ -27,6 +27,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.33.0",
+        "@playwright/test": "^1.62.1",
         "@testing-library/jest-dom": "^6.8.0",
         "@testing-library/react": "^16.3.0",
         "@types/node": "^24.5.1",
@@ -1301,6 +1302,22 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.1.tgz",
+      "integrity": "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@rolldown/pluginutils": {
@@ -4988,6 +5005,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/frontend-typescript/package.json
+++ b/frontend-typescript/package.json
@@ -31,6 +31,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.33.0",
+    "@playwright/test": "^1.62.1",
     "@testing-library/jest-dom": "^6.8.0",
     "@testing-library/react": "^16.3.0",
     "@types/node": "^24.5.1",

--- a/frontend-typescript/vite.config.ts
+++ b/frontend-typescript/vite.config.ts
@@ -1,5 +1,5 @@
 
-import { defineConfig } from "vite";
+import { defineConfig, configDefaults } from "vitest/config";
 import react from "@vitejs/plugin-react";
 import path from "path";
 import tailwindcss from '@tailwindcss/vite'
@@ -20,6 +20,7 @@ export default defineConfig({
     globals: true, // so you can use describe/it/expect without imports
     environment: "jsdom", // so React can render
     setupFiles: ["./src/setupTests.ts"], // optional, for global setup
+    exclude: [...configDefaults.exclude, "e2e/**"],
   },
 
 })

--- a/openspec/changes/async-sqlalchemy-migration/.openspec.yaml
+++ b/openspec/changes/async-sqlalchemy-migration/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-07

--- a/openspec/changes/async-sqlalchemy-migration/design.md
+++ b/openspec/changes/async-sqlalchemy-migration/design.md
@@ -1,0 +1,58 @@
+## Context
+
+`services/budget/app/db/session.py` and `services/users/app/db/session.py` both use `create_engine(SQLALCHEMY_DATABASE_URL)` + `sessionmaker(...)` (psycopg2 driver), with route-level `get_db()` generators yielding a sync `Session`. Every CRUD module (`budget_crud.py`, `budget_line_crud.py`, etc.) uses `.query(Model).filter(...)` and calls `session.commit()`/`session.refresh()` directly inside each function — there is no `commit=False` escape hatch.
+
+`services/ai/app/db/session.py` is the reference: `create_async_engine` with the URL's driver forced to `postgresql+asyncpg` regardless of what's configured in the env file (psycopg2-binary stays only for the Alembic CLI), plus `async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)`. Its `get_db()` (currently defined locally in `settings_routes.py`) is `async def` and yields the `AsyncSession` directly, no try/finally close needed since `async with` isn't even used there — the session is closed by FastAPI's dependency teardown.
+
+The concrete pain point motivating this now (not just architectural tidiness): `create_budget_with_lines_service` (`services/budget/app/services/budget_services.py:503-566`) creates a budget, then loops creating lines, and on *any* exception — including a mid-loop DB failure — manually deletes every line already created plus the budget itself ("compensating transaction"). This is not atomic: a crash between the last `delete_budget_line` call and `delete_budget` leaves orphaned rows, and it does real extra DB round-trips on every failure path.
+
+Relationship audit (`grep relationship(` across both services) found ~15 relationships in budget's 6 model files, all default lazy-loaded (`lazy="select"`, SQLAlchemy's default), and users has `customer = relationship("CustomerModel", lazy="joined")` (already eager, safe) alongside several default-lazy ones (`sessions`, `users`, `donor`, `grantee`). Every default-lazy relationship accessed outside an already-awaited context will raise `MissingGreenlet` once the session is async.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Both services run fully async DB access end-to-end, matching ai-service's pattern exactly (same driver-forcing trick, same `async_sessionmaker` config).
+- Zero `MissingGreenlet` risk: every relationship a route/service actually reads is either explicitly eager-loaded (`selectinload`/`joinedload`) at the query site or never accessed lazily.
+- `create_budget_with_lines_service` (and any other multi-step writer) uses one real DB transaction — `flush()` inside, single `commit()` at the end — instead of compensating deletes.
+- CRUD write functions gain `commit: bool = True`; existing callers are unaffected (default preserves current commit-per-call behavior).
+
+**Non-Goals:**
+- No API contract, schema, or request/response shape changes.
+- No change to Alembic — migrations keep running sync (psycopg2), same as ai-service.
+- Not migrating chat-service (already async from the start) or touching `shared/db/`'s audit mixin behavior beyond what's needed to keep it working under `AsyncSession`.
+- Not a performance-tuning pass (connection pool sizing, query optimization) — purely the sync→async mechanical swap plus the atomicity fix already scoped for #59.
+
+## Decisions
+
+**1. Users-service first, then budget-service.** Users has 3 models, budget has 6+ with the with-lines atomicity work layered on top. A clean async dry run on the smaller service surfaces driver/fixture/relationship issues cheaply before the harder service.
+
+**2. Reuse ai-service's exact session-setup pattern, don't invent a new one.** `make_url(...).set(drivername="postgresql+asyncpg")` plus `async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)`. Rationale: it's already proven in this repo, keeps all four services' persistence layer consistent, and `expire_on_commit=False` avoids a second class of lazy-load-after-commit surprises (attribute access after `commit()` would otherwise trigger a refresh query).
+
+**3. Centralize `get_db()` per service instead of leaving it duplicated per route file.** Budget currently defines `get_db()` locally in `budget_routes.py`; it's duplicated implicitly if other route files construct their own `Session()`. Move to one `get_db()` in each service's `app/db/session.py` (matching users-service's existing pattern, which already centralizes it) — mechanical cleanup that falls out of touching every route file's import anyway.
+
+**4. Eager-load audit is per-callsite, not "make everything eager by default."** Rather than blanket-setting `lazy="selectin"` on every relationship (which would over-fetch on paths that never touch the relationship), each route/service function that currently accesses a relationship attribute gets an explicit `selectinload()`/`joinedload()` added to its query. This keeps the fetch shape matching actual usage, same discipline the codebase already applies (`users.customer` is already `lazy="joined"` because it's read on nearly every request).
+
+**5. `commit=False` is additive, not a rewrite of CRUD signatures.** Every CRUD write function keeps its current default behavior (`commit=True` → commits immediately, unchanged for 100% of existing callers) and gains one new optional kwarg. Only `create_budget_with_lines_service` (and its inner calls to `create_budget_service`/`create_budget_line_service`) is rewired to pass `commit=False` and drive one shared `db.commit()` at the end — no other caller needs to change.
+
+**6. Alternative considered and rejected: migrate both services simultaneously in one PR.** Rejected — larger blast radius, harder to bisect a regression to "the async swap" vs. "the atomicity change," and the proposal's own ordering (users first as a dry run) only pays off if it lands and is validated before budget starts.
+
+## Risks / Trade-offs
+
+- [Missed lazy-load site slips through review, surfaces as a runtime `MissingGreenlet` in an untested code path] → Mitigation: run the full existing test suite (converted to async fixtures) plus a manual smoke pass through every route in both services before merging each service's migration.
+- [`expire_on_commit=False` masks a stale-attribute bug if code assumes post-commit attributes reflect DB-computed defaults (e.g. server-side timestamps)] → Mitigation: audit for any `session.refresh()` calls being removed and confirm no route depends on a DB-generated value it doesn't already explicitly refresh.
+- [Test infra: budget/users tests currently use sync fixtures/sessions; switching to async requires new fixtures, following `services/ai/tests`' existing async pattern (already validated in this repo) rather than inventing one] → Mitigation covered by reusing that pattern directly.
+- [Threadpool removal changes concurrency characteristics under load — theoretically better, but unverified under this repo's actual traffic shape] → Accepted; no production traffic exists yet to validate against, and this is explicitly the cheapest time to take that risk (see proposal's "Why now").
+
+## Migration Plan
+
+1. Users-service: swap session/engine, centralize `get_db()`, convert `app/crud/*.py` to `select()`-style async, add `selectinload`/`joinedload` at each relationship-accessing callsite, convert test fixtures to async, full test pass + manual smoke test.
+2. Budget-service: same mechanical steps across its larger CRUD/route surface.
+3. Budget-service, layered on top of step 2: add `commit: bool = True` to CRUD write functions, rewire `create_budget_with_lines_service` to `flush()`-then-single-`commit()`, delete the compensating-transaction delete calls.
+4. Each service ships as its own PR/ticket chain (per this repo's one-chunk-one-ticket-one-PR workflow) — no shared PR.
+
+**Rollback:** each service's migration is independently revertable (git revert the service's PR) since neither touches the other service, the API contract, or the DB schema — no data migration to unwind.
+
+## Open Questions
+
+- Whether Alembic's `env.py` in each service needs any change given the driver-forcing happens in `db/session.py`, not the URL in `alembic.ini` — likely no, since ai-service's Alembic already runs sync against the same psycopg2 URL unmodified, but worth confirming per-service during implementation.
+- Whether `shared/db/`'s audit mixin (if it issues its own queries/session calls, e.g. an `after_flush` hook) needs any adjustment for `AsyncSession` — needs a read during implementation, not resolved here.

--- a/openspec/changes/async-sqlalchemy-migration/proposal.md
+++ b/openspec/changes/async-sqlalchemy-migration/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+`services/budget` and `services/users` still use sync SQLAlchemy (`create_engine`/`SessionLocal`/psycopg2) injected into `async def` FastAPI endpoints; `services/ai` already runs fully async (`create_async_engine`/asyncpg). FastAPI silently threadpools the sync calls, which works today but creates architectural inconsistency and thread-pool pressure under load. There's no production database yet — this is the cheapest point in the project's life to fix it, using the ai-service migration as the reference implementation. Bundled in: the CRUD layer's `commit=False`/`session.flush()` support (GitHub #59), deferred from the `/budgets/with-lines` endpoint, whose current compensating-transaction workaround (deleting already-committed rows on partial failure) this migration is the natural point to replace with real transactional atomicity.
+
+## What Changes
+
+- Both services: `create_engine` → `create_async_engine` (asyncpg driver), `SessionLocal` → `async_sessionmaker`/`AsyncSession`, `db: Session = Depends(get_db)` → `db: AsyncSession = Depends(get_db)`.
+- All CRUD `.query()` calls → `select()`-style async queries (`await db.execute(...)`, `await db.commit()`).
+- Pre-work: audit every lazily-loaded relationship in both services' models and convert to explicit `selectinload`/`joinedload`, since lazy loading raises `MissingGreenlet` under an async session.
+- CRUD write functions gain an optional `commit: bool = True` parameter; `commit=False` calls `session.flush()` instead of `session.commit()`, letting multi-step callers (e.g. `create_budget_with_lines_service`) manage one real transaction instead of compensating deletes.
+- **BREAKING**: internal only — every route/service function that depends on `Session`/`SessionLocal` in these two services changes signature to `AsyncSession`. No external API contract changes.
+- Order: users-service first (smaller surface, dry run), then budget-service (larger surface, including the with-lines atomic-write path).
+
+## Capabilities
+
+### New Capabilities
+- `async-persistence`: the architectural requirement that budget-service and users-service perform all database access asynchronously end-to-end (async engine, async session, non-blocking queries), with no lazy-loaded relationships that could raise `MissingGreenlet`, and that multi-step writes use real DB-level transactions (`flush`-then-`commit`) rather than compensating transactions.
+
+### Modified Capabilities
+- None — no product-facing request/response contract changes; existing capability specs describe behavior, not persistence implementation.
+
+## Impact
+
+- Code: `services/budget/app/**` and `services/users/app/**` — engine/session setup, all CRUD modules, all route handlers, all service-layer functions with DB calls, model relationship definitions.
+- Tests: both services' test suites need async fixtures (see `services/ai/tests` for the existing pattern) and DB-session mocking updates.
+- Dependencies: both services need `asyncpg` added; psycopg2 can be dropped once Alembic (which can stay sync) no longer needs it, or kept solely for Alembic migrations if simpler.
+- No schema changes, no API contract changes, no infra/deploy changes.

--- a/openspec/changes/async-sqlalchemy-migration/specs/async-persistence/spec.md
+++ b/openspec/changes/async-sqlalchemy-migration/specs/async-persistence/spec.md
@@ -1,0 +1,38 @@
+## ADDED Requirements
+
+### Requirement: End-to-end async database access
+Budget-service and users-service SHALL perform all database reads and writes through an async SQLAlchemy engine and session (`create_async_engine` + `AsyncSession` via `async_sessionmaker`), with no route or service-layer function depending on a sync `Session`/`SessionLocal`. Alembic migrations MAY continue to run synchronously against the same database.
+
+#### Scenario: Route handler receives an async session
+- **WHEN** any request hits a budget-service or users-service route that reads or writes the database
+- **THEN** the route's `db` dependency is a `AsyncSession` obtained via `Depends(get_db)`, and every DB call in the request path is awaited (`await db.execute(...)`, `await db.commit()`, `await db.flush()`)
+
+#### Scenario: No sync engine remains reachable from application code
+- **WHEN** the codebase is searched for `create_engine(` or `sessionmaker(` (sync forms) in `services/budget/app` or `services/users/app`
+- **THEN** no application code path (routes, services, CRUD) references them; only Alembic's own migration runner may still use a sync connection
+
+### Requirement: No lazy-load MissingGreenlet risk
+Every SQLAlchemy relationship that a route or service function reads SHALL be either explicitly eager-loaded at the query site (`selectinload`/`joinedload`) or never accessed outside an awaited context. No request path SHALL trigger an implicit lazy-load under the async session.
+
+#### Scenario: Relationship access on an already-loaded object
+- **WHEN** a route or service function accesses a model's relationship attribute (e.g. `budget.lines`, `user.customer`) after fetching that model
+- **THEN** the query that fetched the model explicitly eager-loaded that relationship, so the attribute access does not trigger a lazy SQL query
+
+#### Scenario: Full test and manual smoke pass surfaces no MissingGreenlet
+- **WHEN** the full test suite for a migrated service runs, and every route is manually exercised once
+- **THEN** no `MissingGreenlet` (or equivalent lazy-load-under-async) error occurs
+
+### Requirement: Atomic multi-step writes via commit=False
+CRUD write functions SHALL accept an optional `commit: bool = True` parameter. When `commit=False`, the function SHALL call `session.flush()` instead of `session.commit()`, leaving the caller responsible for the final commit. The default (`commit=True`) SHALL preserve every existing caller's current commit-per-call behavior unchanged.
+
+#### Scenario: Default caller behavior is unchanged
+- **WHEN** an existing caller invokes a CRUD write function without passing `commit`
+- **THEN** the function commits immediately, exactly as it did before this change
+
+#### Scenario: Multi-step write commits once
+- **WHEN** `create_budget_with_lines_service` creates a budget and its lines
+- **THEN** each inner CRUD call is invoked with `commit=False` (flushing only), and a single `db.commit()` is issued once after all lines are created, making the whole operation atomic in one DB transaction
+
+#### Scenario: Failure mid-transaction rolls back, not compensating-deletes
+- **WHEN** `create_budget_with_lines_service` encounters an error after the budget and some lines have been flushed but before the final commit
+- **THEN** the transaction is rolled back (no committed rows for the budget or any of its lines) instead of issuing explicit `delete_budget_line`/`delete_budget` calls to undo already-committed rows

--- a/openspec/changes/async-sqlalchemy-migration/tasks.md
+++ b/openspec/changes/async-sqlalchemy-migration/tasks.md
@@ -1,0 +1,30 @@
+Workflow rule: **one task group = one GitHub ticket = one PR, merged before the next group starts.** This change supersedes backlog issues #70 (migrate budget+users to async SQLAlchemy) and #59 (CRUD `commit=False`/`flush()` support); file a fresh ticket per group below via `scripts/new-issue.sh` at implementation time and close #70/#59 from the groups noted, rather than reusing their numbers directly. Every PR: `flake8 --max-line-length=100` clean; commits/pushes only with explicit user approval.
+
+## 1. Users-service async migration (dry run) — closes #70 (users half)
+
+- [ ] 1.1 Swap `services/users/app/db/session.py` to `create_async_engine`/`async_sessionmaker`/`AsyncSession`, mirroring `services/ai/app/db/session.py`'s driver-forcing (`make_url(...).set(drivername="postgresql+asyncpg")`); keep psycopg2 available for Alembic only
+- [ ] 1.2 Update `get_db()` in `services/users/app/db/session.py` to `async def`, yielding the `AsyncSession`
+- [ ] 1.3 Convert every `services/users/app/crud/*.py` function from `.query(...)`/`session.commit()` to `select(...)`/`await db.execute(...)`/`await db.commit()`
+- [ ] 1.4 Update every route in `services/users/app/api/*.py` to depend on `AsyncSession` and `await` all CRUD calls
+- [ ] 1.5 Audit `services/users/app/models/*.py` relationships (`customer` already `lazy="joined"`; `sessions`, `users`, `donor`, `grantee` are default-lazy) and add `selectinload`/`joinedload` at each query site that actually reads one of them
+- [ ] 1.6 Convert `services/users/tests/` fixtures/sessions to async, following `services/ai/tests`' existing async pattern
+- [ ] 1.7 Run the full users-service test suite plus a manual smoke pass through every route; confirm no `MissingGreenlet` errors
+- [ ] 1.8 Run `black`/`mypy`/`flake8 --max-line-length=100` clean; PR merged (`Closes #70` for the users-service portion)
+
+## 2. Budget-service async migration — depends on 1, closes #70 (budget half)
+
+- [ ] 2.1 Swap `services/budget/app/db/session.py` to `create_async_engine`/`async_sessionmaker`/`AsyncSession`, same pattern validated in group 1
+- [ ] 2.2 Centralize `get_db()` in `services/budget/app/db/session.py` as `async def` (currently defined locally in `budget_routes.py`); remove the duplicate
+- [ ] 2.3 Convert every `services/budget/app/crud/*.py` function from `.query(...)`/`session.commit()` to `select(...)`/`await db.execute(...)`/`await db.commit()`
+- [ ] 2.4 Update every route in `services/budget/app/api/*.py` to depend on `AsyncSession` and `await` all CRUD/service calls
+- [ ] 2.5 Audit `services/budget/app/models/*.py` relationships (~15 across `budget.py`, `report.py`, `mapping.py`, `budget_templates.py`, `currency_ledger.py`, all default-lazy) and add `selectinload`/`joinedload` at each query site that actually reads one of them
+- [ ] 2.6 Convert `services/budget/tests/` fixtures/sessions to async
+- [ ] 2.7 Run the full budget-service test suite plus a manual smoke pass through every route (including `/budgets/with-lines`); confirm no `MissingGreenlet` errors
+- [ ] 2.8 Run `black`/`mypy`/`flake8 --max-line-length=100` clean; PR merged (`Closes #70` for the budget-service portion)
+
+## 3. Atomic multi-step writes (commit=False/flush) — depends on 2, closes #59
+
+- [ ] 3.1 Add `commit: bool = True` to budget-service CRUD write functions (`create_budget`, `create_budget_line`, `delete_budget`, `delete_budget_line`, etc.); when `False`, call `await db.flush()` instead of `await db.commit()`; confirm no existing caller's behavior changes when the argument is omitted
+- [ ] 3.2 Rewire `create_budget_with_lines_service` (`services/budget/app/services/budget_services.py:503-566`) to call `create_budget_service`/`create_budget_line_service` with `commit=False`, issue a single `await db.commit()` after all lines are created, and delete the compensating `delete_budget_line`/`delete_budget` rollback calls in the `except` blocks (rely on transaction rollback instead)
+- [ ] 3.3 Add tests: default-`commit=True` callers behave exactly as before; `create_budget_with_lines_service` issues exactly one commit across the whole operation; a forced mid-loop failure (e.g. a bad line triggering a DB constraint error) leaves zero rows committed for the budget and its lines, verified by querying the DB after the failed call
+- [ ] 3.4 Run `black`/`mypy`/`flake8 --max-line-length=100` clean; PR merged (`Closes #59`)

--- a/openspec/changes/e2e-test-suite/tasks.md
+++ b/openspec/changes/e2e-test-suite/tasks.md
@@ -10,10 +10,10 @@ Workflow rule: **one group = one GitHub ticket = one PR, merged before the next 
 
 ## 2. Playwright API-chain suite (Phase 1)
 
-- [ ] 2.1 Add `@playwright/test` to `frontend-typescript/devDependencies`; scaffold `frontend-typescript/e2e/playwright.config.ts` with two `projects`: `api` (no browser, `request` fixture, `baseURL` pointed at the nginx gateway) and `browser` (chromium, `baseURL: 'http://localhost:4000'`)
-- [ ] 2.2 Create `frontend-typescript/e2e/specs/api/auth-budget-chain.spec.ts` with the chain: register → login (capture JWT from the response body) → create budget → add budget line → update budget line → get budget (assert totals reflect lines) → delete budget line → delete budget, using an authenticated `request` context for each authenticated step
-- [ ] 2.3 Add unique-fixture-data generation (e.g. `crypto.randomUUID()` in the register step) so repeated runs never collide
-- [ ] 2.4 Run the `api` project locally against a `local.sh up` stack and confirm all assertions pass twice in a row with no manual cleanup between runs
+- [x] 2.1 Add `@playwright/test` to `frontend-typescript/devDependencies`; scaffold `frontend-typescript/e2e/playwright.config.ts` with two `projects`: `api` (no browser, `request` fixture, `baseURL` pointed at the nginx gateway) and `browser` (chromium, `baseURL: 'http://localhost:4000'`)
+- [x] 2.2 Create `frontend-typescript/e2e/specs/api/auth-budget-chain.spec.ts` with the chain: register → login (capture JWT from the response body) → create budget → add budget line → update budget line → get budget (assert totals reflect lines) → delete budget line → delete budget, using an authenticated `request` context for each authenticated step *(chain also inserts an onboarding step between register and login — `PATCH /api/v1/users/{id}/` with `new_customer_name` — discovered to be required: `BudgetModel.owner_id` is `NOT NULL` and is set from the JWT's `customer_id` claim, which a freshly-registered user doesn't have until an org/customer is attached; the immediately-following login re-issues a token whose claims carry the new `customer_id`, matching the real Register→Onboarding→Dashboard frontend flow (`src/pages/OnBoarding.tsx`))*
+- [x] 2.3 Add unique-fixture-data generation (e.g. `crypto.randomUUID()` in the register step) so repeated runs never collide
+- [x] 2.4 Run the `api` project locally against a `local.sh up` stack and confirm all assertions pass twice in a row with no manual cleanup between runs *(ran 3x consecutively against the already-running `local.sh up` stack, all green, zero manual cleanup)*
 
 ## 3. Playwright browser suite (Phase 2)
 


### PR DESCRIPTION
## Summary
- Implements group 2 (tasks 2.1-2.4) of the `e2e-test-suite` OpenSpec change: `frontend-typescript/e2e/playwright.config.ts` (`api` + `browser` projects) and `e2e/specs/api/auth-budget-chain.spec.ts`, covering register -> onboard -> login -> create budget -> add/update/delete budget line -> get budget (assert totals) -> delete budget, through the nginx gateway with unique fixture data per run.
- Chain includes an onboarding step (`PATCH /api/v1/users/{id}/` with `new_customer_name`) between register and login that wasn't spelled out in the original design — needed because `BudgetModel.owner_id` is NOT NULL and comes from the JWT's `customer_id` claim, which a freshly-registered user doesn't have until an org is attached. Mirrors the real frontend Register -> Onboarding -> Dashboard flow.
- Bundled in (already staged, not part of this ticket's implementation): a new OpenSpec proposal for migrating `budget`/`users` services to async SQLAlchemy (planning docs only), and a README refresh reflecting recently landed `shared/` modules and CI workflows.
- Adds `.gitignore` entries for Playwright's local output dirs (`test-results/`, `playwright-report/`, `blob-report/`).

## Test plan
- [x] `npx playwright test --config=frontend-typescript/e2e/playwright.config.ts --project=api` against a `local.sh up` stack, run 3x consecutively — all green, no manual cleanup between runs
- [x] `npm run lint` — no new errors introduced by the e2e files (91 pre-existing errors elsewhere, unrelated)

Closes #198

🤖 Generated with [Claude Code](https://claude.com/claude-code)