### PR TITLE
Throwaway: e2e.yml negative-trigger check (services/ai/** only)

### DIFF
--- a/services/ai/E2E_TRIGGER_CHECK.md
+++ b/services/ai/E2E_TRIGGER_CHECK.md
@@ -1,0 +1,4 @@
+Throwaway file for task 4.5 of the e2e-test-suite OpenSpec change — verifying
+that `.github/workflows/e2e.yml`'s path-filter does NOT trigger on a change
+scoped to `services/ai/**` alone. Safe to delete; this PR will be closed
+without merging.


### PR DESCRIPTION
Task 4.5 verification for the e2e-test-suite OpenSpec change. Confirms `.github/workflows/e2e.yml`'s path-filter does NOT trigger on a change scoped to `services/ai/**` alone. Will be closed without merging once confirmed.