### PR TITLE
Improve budgets list cards: status badges, actions, mobile filters

### DIFF
--- a/frontend-typescript/src/pages/Budgets/SingleBudgetView.tsx
+++ b/frontend-typescript/src/pages/Budgets/SingleBudgetView.tsx
@@ -1,5 +1,5 @@
-import React, { useState } from "react";
-import { useParams } from "react-router-dom";
+import React, { useEffect, useState } from "react";
+import { useParams, useSearchParams } from "react-router-dom";
 import { useQueryClient } from "@tanstack/react-query";
 import { BudgetViewHeader } from "./components/BudgetViewHeader";
 import { BudgetViewLinesTable } from "./components/BudgetViewLinesTable";
@@ -33,12 +33,26 @@ function SingleBudgetView({ id }: { id: string | undefined }) {
   const [isEditLineOpen, setIsEditLineOpen] = useState<BudgetLine | undefined>(
     undefined
   );
-  // Bumped by CurrencyLedgerPanel's "set actual currency first" prompt to
-  // open BudgetViewHeader's edit mode from outside it (see that prop's
-  // comment) — undefined until first bumped, so it never fires on mount.
+  // Bumped by CurrencyLedgerPanel's "set actual currency first" prompt (or
+  // the `?edit=1` URL param below) to open BudgetViewHeader's edit mode from
+  // outside it (see that prop's comment) — undefined until first bumped, so
+  // it never fires on mount by itself.
   const [headerEditTrigger, setHeaderEditTrigger] = useState<number>();
   const { budget, setBudget } = useDetailedBudget();
   const queryClient = useQueryClient();
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  // Landed here from the budgets list's Edit action (?edit=1) — open edit
+  // mode immediately, then strip the param so a refresh/back-nav doesn't
+  // re-trigger it.
+  useEffect(() => {
+    if (!searchParams.get("edit")) return;
+    setHeaderEditTrigger((v) => (v ?? 0) + 1);
+    const next = new URLSearchParams(searchParams);
+    next.delete("edit");
+    setSearchParams(next, { replace: true });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   // Metadata/lines lock as soon as the budget is confirmed — a report can
   // only ever be created against an already-confirmed budget, so this is a

--- a/frontend-typescript/src/pages/Budgets/budgets.tsx
+++ b/frontend-typescript/src/pages/Budgets/budgets.tsx
@@ -10,7 +10,11 @@ import {
 import { fetchAllBudgets } from "@/api/gatewayApi";
 import { utcToLocal } from "@/utils/datetime";
 import { HiPlus } from "react-icons/hi";
-import { HiXMark, HiMagnifyingGlass } from "react-icons/hi2";
+import {
+  HiXMark,
+  HiMagnifyingGlass,
+  HiAdjustmentsHorizontal,
+} from "react-icons/hi2";
 import { TableView } from "./components/TableView";
 import { CardsView } from "./components/CardsView";
 
@@ -19,6 +23,7 @@ import { Budget, BudgetPatched } from "./types/budget";
 import { archiveBudget, deleteBudget } from "@/api/budgetApi";
 import { AddBudgetModal } from "./components/AddBudget";
 import { EditBudgetModal } from "./components/EditBudget";
+import { STATUS_STYLES } from "./constants/budgetStatus";
 
 const BudgetsPage: React.FC = () => {
   const [view, setView] = useState<"cards" | "table">();
@@ -35,6 +40,28 @@ const BudgetsPage: React.FC = () => {
   const [showCurrencyDropdown, setShowCurrencyDropdown] = useState(false);
   const [filterDuration, setFilterDuration] = useState<string>("");
   const [showDurationDropdown, setShowDurationDropdown] = useState(false);
+  const [showFilterSheet, setShowFilterSheet] = useState(false);
+
+  const toggleStatusFilter = (status: string, checked: boolean) => {
+    setFilterStatuses(
+      checked
+        ? [...filterStatuses, status]
+        : filterStatuses.filter((s) => s !== status),
+    );
+  };
+
+  const toggleCurrencyFilter = (currency: string, checked: boolean) => {
+    setFilterCurrencies(
+      checked
+        ? [...filterCurrencies, currency]
+        : filterCurrencies.filter((c) => c !== currency),
+    );
+  };
+
+  const activeFilterCount =
+    filterStatuses.length +
+    filterCurrencies.length +
+    (filterDuration ? 1 : 0);
 
   useEffect(() => {
     const handleResize = () => {
@@ -229,13 +256,7 @@ const BudgetsPage: React.FC = () => {
                   <div
                     key={`status-${status}`}
                     className={`flex items-center gap-2 px-4 py-2 rounded-full text-sm font-semibold capitalize ${
-                      status === "draft"
-                        ? "bg-yellow-100 text-yellow-800"
-                        : status === "approved"
-                          ? "bg-green-100 text-green-800"
-                          : status === "rejected"
-                            ? "bg-red-100 text-red-800"
-                            : "bg-slate-100 text-slate-800"
+                      STATUS_STYLES[status] ?? STATUS_STYLES.draft
                     }`}
                   >
                     {status}
@@ -301,6 +322,24 @@ const BudgetsPage: React.FC = () => {
                 />
               </div>
 
+              {/* Mobile: single Filters trigger replacing the three dropdowns below lg */}
+              <button
+                onClick={() => setShowFilterSheet(true)}
+                className="lg:hidden w-full px-3 py-2 border border-slate-300 rounded-lg text-sm bg-white hover:bg-slate-50 flex items-center justify-between gap-2 focus:outline-none focus:ring-2 focus:ring-slate-400"
+              >
+                <span className="flex items-center gap-2 text-slate-700">
+                  <HiAdjustmentsHorizontal size={16} />
+                  Filters
+                </span>
+                {activeFilterCount > 0 && (
+                  <span className="inline-flex items-center justify-center min-w-5 h-5 px-1 rounded-full bg-slate-700 text-white text-xs font-semibold">
+                    {activeFilterCount}
+                  </span>
+                )}
+              </button>
+
+              {/* Desktop (lg+): existing Status/Currency/Duration dropdowns + Clear, unchanged */}
+              <div className="hidden lg:contents">
               {/* Status Filter - Multi-select with Dropdown */}
               <div className="relative flex-shrink-0 w-full lg:w-auto">
                 <button
@@ -339,15 +378,9 @@ const BudgetsPage: React.FC = () => {
                           <input
                             type="checkbox"
                             checked={filterStatuses.includes(status)}
-                            onChange={(e) => {
-                              if (e.target.checked) {
-                                setFilterStatuses([...filterStatuses, status]);
-                              } else {
-                                setFilterStatuses(
-                                  filterStatuses.filter((s) => s !== status),
-                                );
-                              }
-                            }}
+                            onChange={(e) =>
+                              toggleStatusFilter(status, e.target.checked)
+                            }
                             className="w-4 h-4 rounded border-slate-300 text-slate-700 focus:ring-slate-400"
                           />
                           <span className="text-sm text-slate-700 capitalize">
@@ -398,20 +431,9 @@ const BudgetsPage: React.FC = () => {
                           <input
                             type="checkbox"
                             checked={filterCurrencies.includes(currency)}
-                            onChange={(e) => {
-                              if (e.target.checked) {
-                                setFilterCurrencies([
-                                  ...filterCurrencies,
-                                  currency,
-                                ]);
-                              } else {
-                                setFilterCurrencies(
-                                  filterCurrencies.filter(
-                                    (c) => c !== currency,
-                                  ),
-                                );
-                              }
-                            }}
+                            onChange={(e) =>
+                              toggleCurrencyFilter(currency, e.target.checked)
+                            }
                             className="w-4 h-4 rounded border-slate-300 text-slate-700 focus:ring-slate-400"
                           />
                           <span className="text-sm text-slate-700">
@@ -501,7 +523,135 @@ const BudgetsPage: React.FC = () => {
                   <HiXMark size={14} /> Clear All
                 </Button>
               )}
+              </div>
             </div>
+
+            {/* Mobile filter sheet */}
+            {showFilterSheet && (
+              <div className="lg:hidden fixed inset-0 z-50">
+                <div
+                  className="absolute inset-0 bg-black/40"
+                  onClick={() => setShowFilterSheet(false)}
+                />
+                <div className="absolute bottom-0 inset-x-0 max-h-[85vh] overflow-y-auto bg-white rounded-t-2xl p-4">
+                  <div className="flex items-center justify-between mb-4">
+                    <h2 className="text-lg font-bold text-slate-900">
+                      Filters
+                    </h2>
+                    <button
+                      onClick={() => setShowFilterSheet(false)}
+                      className="p-1 text-slate-500 hover:text-slate-800 hover:bg-slate-100 rounded"
+                    >
+                      <HiXMark size={20} />
+                    </button>
+                  </div>
+
+                  {/* Status group */}
+                  <div className="mb-4">
+                    <p className="text-sm font-semibold text-slate-700 mb-2">
+                      Status
+                    </p>
+                    <div className="space-y-1">
+                      {uniqueStatuses.map((status: string) => (
+                        <label
+                          key={status}
+                          className="flex items-center gap-2 px-3 py-2 rounded hover:bg-slate-50 cursor-pointer"
+                        >
+                          <input
+                            type="checkbox"
+                            checked={filterStatuses.includes(status)}
+                            onChange={(e) =>
+                              toggleStatusFilter(status, e.target.checked)
+                            }
+                            className="w-4 h-4 rounded border-slate-300 text-slate-700 focus:ring-slate-400"
+                          />
+                          <span className="text-sm text-slate-700 capitalize">
+                            {status}
+                          </span>
+                        </label>
+                      ))}
+                    </div>
+                  </div>
+
+                  {/* Currency group */}
+                  <div className="mb-4">
+                    <p className="text-sm font-semibold text-slate-700 mb-2">
+                      Currency
+                    </p>
+                    <div className="space-y-1">
+                      {uniqueCurrencies.map((currency: string) => (
+                        <label
+                          key={currency}
+                          className="flex items-center gap-2 px-3 py-2 rounded hover:bg-slate-50 cursor-pointer"
+                        >
+                          <input
+                            type="checkbox"
+                            checked={filterCurrencies.includes(currency)}
+                            onChange={(e) =>
+                              toggleCurrencyFilter(currency, e.target.checked)
+                            }
+                            className="w-4 h-4 rounded border-slate-300 text-slate-700 focus:ring-slate-400"
+                          />
+                          <span className="text-sm text-slate-700">
+                            {currency}
+                          </span>
+                        </label>
+                      ))}
+                    </div>
+                  </div>
+
+                  {/* Duration group */}
+                  <div className="mb-6">
+                    <p className="text-sm font-semibold text-slate-700 mb-2">
+                      Duration
+                    </p>
+                    <div className="space-y-1">
+                      {[
+                        { value: "short", label: "Short (≤ 6 mo)" },
+                        { value: "medium", label: "Medium (7-12 mo)" },
+                        { value: "long", label: "Long (> 12 mo)" },
+                      ].map((option) => (
+                        <label
+                          key={option.value}
+                          className="flex items-center gap-2 px-3 py-2 rounded hover:bg-slate-50 cursor-pointer"
+                        >
+                          <input
+                            type="radio"
+                            name="duration-sheet"
+                            value={option.value}
+                            checked={filterDuration === option.value}
+                            onChange={(e) =>
+                              setFilterDuration(e.target.value)
+                            }
+                            className="w-4 h-4 border-slate-300 text-slate-700 focus:ring-slate-400"
+                          />
+                          <span className="text-sm text-slate-700">
+                            {option.label}
+                          </span>
+                        </label>
+                      ))}
+                    </div>
+                  </div>
+
+                  <div className="flex gap-3">
+                    <Button
+                      onClick={clearFilters}
+                      variant="outline"
+                      className="flex-1 flex items-center justify-center"
+                    >
+                      Clear
+                    </Button>
+                    <Button
+                      onClick={() => setShowFilterSheet(false)}
+                      variant="primary"
+                      className="flex-1 flex items-center justify-center"
+                    >
+                      Apply
+                    </Button>
+                  </div>
+                </div>
+              </div>
+            )}
 
             {/* Results counter */}
             <div className="text-xs text-slate-600 mt-3">
@@ -515,7 +665,6 @@ const BudgetsPage: React.FC = () => {
               {view === "cards" ? (
                 <CardsView
                   data={filteredData}
-                  onEdit={openEditModal}
                   onDelete={deleteBudgetMutation.mutate}
                 />
               ) : view === "table" ? (

--- a/frontend-typescript/src/pages/Budgets/components/BudgetViewHeader.tsx
+++ b/frontend-typescript/src/pages/Budgets/components/BudgetViewHeader.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { Archive } from "lucide-react";
 import { Card, CardContent, CardHeader } from "@/components/ui/Card";
 import Button, { ConfirmDeleteButton } from "@/components/ui/Button";
 import Input from "@/components/ui/Input";
@@ -30,7 +31,11 @@ export function StatusBadge({ status }: { status: string }) {
     <span
       className={`inline-flex items-center gap-1.5 text-xs font-semibold uppercase tracking-wide px-2.5 py-1 rounded-full mb-2 ${cls}`}
     >
-      <span className="w-1.5 h-1.5 rounded-full bg-current" />
+      {status === "archived" ? (
+        <Archive className="w-3 h-3" />
+      ) : (
+        <span className="w-1.5 h-1.5 rounded-full bg-current" />
+      )}
       {label}
     </span>
   );

--- a/frontend-typescript/src/pages/Budgets/components/CardsView.tsx
+++ b/frontend-typescript/src/pages/Budgets/components/CardsView.tsx
@@ -1,30 +1,37 @@
-import Button from "@/components/ui/Button";
+import { useNavigate } from "react-router-dom";
+import Button, { ConfirmDeleteButton } from "@/components/ui/Button";
 import { StatusBadge } from "@/pages/Budgets/components/BudgetViewHeader";
 import { utcToLocal } from "@/utils/datetime";
 import { formatCurrency } from "@/utils/currency";
 import { Budget } from "../types/budget";
 import { Edit2, Trash2, DollarSign, Calendar, User } from "lucide-react";
 
+const CONFIRMED_DELETE_DISABLED_TITLE =
+  "Confirmed budgets can't be deleted while they may have reports, funding receipts, or currency conversions attached.";
+
 export function CardsView({
   data,
-  onEdit,
   onDelete,
 }: {
   data: Budget[];
-  onEdit: (budget: Budget) => void;
   onDelete: (budget_id: string) => void;
 }) {
+  const navigate = useNavigate();
   return (
     <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 w-full">
       {data.map((budget: Budget) => (
         <div
           key={budget.id}
-          className="bg-white rounded-lg border border-slate-200 shadow-sm hover:shadow-md transition-all duration-200 overflow-hidden group"
+          onClick={() => navigate(`/budgets/${budget.id}`)}
+          className="bg-white rounded-lg border border-slate-200 shadow-sm hover:shadow-md transition-all duration-200 overflow-hidden group cursor-pointer"
         >
           {/* Card Header with Status */}
           <div className="px-4 py-3 border-b border-slate-100 bg-gradient-to-r from-slate-50 to-white">
             <div className="flex items-start justify-between gap-3 mb-2">
-              <h2 className="text-lg font-bold text-slate-900 flex-1">
+              <h2
+                className="text-lg font-bold text-slate-900 flex-1 min-w-0 truncate"
+                title={budget.name}
+              >
                 {budget.name}
               </h2>
               <StatusBadge status={budget.status} />
@@ -84,21 +91,30 @@ export function CardsView({
           </div>
 
           {/* Card Actions */}
-          <div className="px-4 py-3 bg-slate-50 border-t border-slate-100 flex gap-2 justify-end">
+          <div
+            className="grid grid-cols-2 border-t border-slate-100"
+            onClick={(e) => e.stopPropagation()}
+          >
             <Button
-              variant="secondary"
-              onClick={() => onEdit(budget)}
-              className="flex items-center justify-center gap-1 py-1 px-3 text-sm"
+              variant="ghost"
+              onClick={() => navigate(`/budgets/${budget.id}?edit=1`)}
+              className="flex items-center justify-center gap-1.5 min-h-[44px] rounded-none text-sm"
             >
-              <Edit2 size={14} /> Edit
+              <Edit2 size={16} /> Edit
             </Button>
-            <Button
-              variant="danger"
-              onClick={() => onDelete(budget.id)}
-              className="flex items-center justify-center gap-1 py-1 px-3 text-sm"
+            <ConfirmDeleteButton
+              variant="icon-danger"
+              onConfirm={() => onDelete(budget.id)}
+              disabled={budget.status === "confirmed"}
+              title={
+                budget.status === "confirmed"
+                  ? CONFIRMED_DELETE_DISABLED_TITLE
+                  : undefined
+              }
+              className="flex items-center justify-center gap-1.5 min-h-[44px] rounded-none text-sm border-l border-slate-100"
             >
-              <Trash2 size={14} /> Delete
-            </Button>
+              <Trash2 size={16} /> Delete
+            </ConfirmDeleteButton>
           </div>
         </div>
       ))}

--- a/frontend-typescript/src/pages/Budgets/components/TableView.tsx
+++ b/frontend-typescript/src/pages/Budgets/components/TableView.tsx
@@ -8,6 +8,9 @@ import { Edit2, Trash2 } from "lucide-react";
 
 const columnHelper = createColumnHelper<any>();
 
+const CONFIRMED_DELETE_DISABLED_TITLE =
+  "Confirmed budgets can't be deleted while they may have reports, funding receipts, or currency conversions attached.";
+
 export function TableView({
   data,
   onEdit,
@@ -77,7 +80,12 @@ export function TableView({
           <Button
             variant="icon-danger"
             onClick={() => onDelete(info.row.original.id)}
-            title="Delete budget"
+            disabled={info.row.original.status === "confirmed"}
+            title={
+              info.row.original.status === "confirmed"
+                ? CONFIRMED_DELETE_DISABLED_TITLE
+                : "Delete budget"
+            }
           >
             <Trash2 size={18} />
           </Button>

--- a/frontend-typescript/src/pages/Budgets/constants/budgetStatus.ts
+++ b/frontend-typescript/src/pages/Budgets/constants/budgetStatus.ts
@@ -18,7 +18,7 @@ export const STATUS_STYLES: Record<string, string> = {
   draft: "bg-slate-100 text-slate-600",
   ai_draft: "bg-amber-100 text-amber-700",
   confirmed: "bg-teal-100 text-teal-700",
-  archived: "bg-gray-200 text-gray-600",
+  archived: "bg-transparent text-gray-500 border border-dashed border-gray-400",
 };
 
 // Solid-fill counterpart of STATUS_STYLES's pill tints, for chart-like uses

--- a/openspec/changes/budget-cards-improvement/tasks.md
+++ b/openspec/changes/budget-cards-improvement/tasks.md
@@ -1,29 +1,42 @@
 Workflow rule: one task group = one GitHub ticket = one PR, merged before the next group starts.
 
+Deviation (2026-08-12): all three groups implemented together on one branch
+(`Frontend/Issue-213/archived-badge-style`) under the single ticket #213,
+landing as one combined PR instead of three sequential ones.
+
 ## 1. Archived status badge treatment — no dependency on other groups
 
-- [ ] 1.1 Create a GitHub ticket for this group (`scripts/new-issue.sh`), branch on creation, move to In Progress.
-- [ ] 1.2 In `constants/budgetStatus.ts`, change `STATUS_STYLES.archived` from a solid fill to a dashed-outline style (transparent/white background, dashed border, muted text color); leave `draft`, `ai_draft`, `confirmed` unchanged.
-- [ ] 1.3 In `BudgetViewHeader.tsx`'s `StatusBadge`, add an optional icon slot rendered instead of the dot for `archived` (small archive-box icon), keeping the dot for the other three statuses.
-- [ ] 1.4 Verify the badge renders correctly everywhere `StatusBadge` is used (budget detail header, `CardsView`, `TableView` if applicable) — archived should look distinctly different from draft in each location.
-- [ ] 1.5 Run frontend lint/typecheck and the relevant component tests clean; open PR with `Closes #<n>`; PR merged.
+- [x] 1.1 Create a GitHub ticket for this group (`scripts/new-issue.sh`), branch on creation, move to In Progress.
+- [x] 1.2 In `constants/budgetStatus.ts`, change `STATUS_STYLES.archived` from a solid fill to a dashed-outline style (transparent/white background, dashed border, muted text color); leave `draft`, `ai_draft`, `confirmed` unchanged.
+- [x] 1.3 In `BudgetViewHeader.tsx`'s `StatusBadge`, add an optional icon slot rendered instead of the dot for `archived` (small archive-box icon), keeping the dot for the other three statuses.
+- [x] 1.4 Verify the badge renders correctly everywhere `StatusBadge` is used (budget detail header, `CardsView`, `TableView` if applicable) — archived should look distinctly different from draft in each location.
+- [x] 1.5 Run frontend lint/typecheck and the relevant component tests clean; open PR with `Closes #<n>`; PR merged.
+  - [x] eslint clean on touched files, tsc -b clean
+  - [x] Budgets test suite clean (151 passed)
+  - [ ] PR opened and merged (combined PR, Closes #213)
 
 ## 2. Budget card actions: confirm delete + touch targets — no dependency on other groups
 
-- [ ] 2.1 Create a GitHub ticket for this group, branch on creation, move to In Progress.
-- [ ] 2.2 In `CardsView.tsx`, replace the `bg-slate-50` footer strip and `secondary`/`danger` `Button` pair with a 2-column grid footer (Edit | Delete), each cell a minimum 44px tall.
-- [ ] 2.3 Give Edit a quiet/ghost style (no heavy border) and Delete a text/icon-only red style that only fills on hover/press.
-- [ ] 2.4 Replace the direct `onDelete(budget.id)` wiring with the existing `ConfirmDeleteButton` component so Delete requires an inline Yes/No confirmation before the delete request fires.
-- [ ] 2.5 Confirm cancelling the inline confirmation (tapping No) returns the card to its normal state without issuing a delete request.
-- [ ] 2.6 Run frontend lint/typecheck and the relevant component tests clean; open PR with `Closes #<n>`; PR merged.
+- [x] 2.1 Create a GitHub ticket for this group, branch on creation, move to In Progress. (folded into #213, same branch)
+- [x] 2.2 In `CardsView.tsx`, replace the `bg-slate-50` footer strip and `secondary`/`danger` `Button` pair with a 2-column grid footer (Edit | Delete), each cell a minimum 44px tall.
+- [x] 2.3 Give Edit a quiet/ghost style (no heavy border) and Delete a text/icon-only red style that only fills on hover/press.
+- [x] 2.4 Replace the direct `onDelete(budget.id)` wiring with the existing `ConfirmDeleteButton` component so Delete requires an inline Yes/No confirmation before the delete request fires.
+- [x] 2.5 Confirm cancelling the inline confirmation (tapping No) returns the card to its normal state without issuing a delete request.
+- [x] 2.6 Run frontend lint/typecheck and the relevant component tests clean; open PR with `Closes #<n>`; PR merged.
+  - [x] eslint clean on touched files, tsc -b clean
+  - [x] Budgets test suite clean (151 passed)
+  - [ ] PR opened and merged (combined PR, Closes #213)
 
 ## 3. Mobile filter collapse and shared chip colors — no dependency on other groups
 
-- [ ] 3.1 Create a GitHub ticket for this group, branch on creation, move to In Progress.
-- [ ] 3.2 In `budgets.tsx`, below the `lg` breakpoint, replace the three full-width Status/Currency/Duration dropdown buttons with a single "Filters" trigger button.
-- [ ] 3.3 Add an active-filter-count badge to the "Filters" trigger, computed from `filterStatuses.length + filterCurrencies.length + (filterDuration ? 1 : 0)`.
-- [ ] 3.4 Implement the filter sheet: opens on tapping "Filters", contains the Status/Currency/Duration groups (reusing existing selection state and handlers) plus Clear and Apply controls, and closes on Apply, backdrop tap, or dismissal.
-- [ ] 3.5 Confirm the `lg`-and-above layout is unchanged (existing single-row Status/Currency/Duration controls, no "Filters" trigger).
-- [ ] 3.6 Update the removable status filter chips to read their colors from `STATUS_STYLES`/`STATUS_ACCENT` (`constants/budgetStatus.ts`) instead of the hardcoded yellow/green/red/slate classes.
-- [ ] 3.7 Manually verify on a mobile viewport (or emulated width `<1024px`) that budget cards are visible without scrolling past the filter bar.
-- [ ] 3.8 Run frontend lint/typecheck and the relevant component tests clean; open PR with `Closes #<n>`; PR merged.
+- [x] 3.1 Create a GitHub ticket for this group, branch on creation, move to In Progress. (folded into #213, same branch)
+- [x] 3.2 In `budgets.tsx`, below the `lg` breakpoint, replace the three full-width Status/Currency/Duration dropdown buttons with a single "Filters" trigger button.
+- [x] 3.3 Add an active-filter-count badge to the "Filters" trigger, computed from `filterStatuses.length + filterCurrencies.length + (filterDuration ? 1 : 0)`.
+- [x] 3.4 Implement the filter sheet: opens on tapping "Filters", contains the Status/Currency/Duration groups (reusing existing selection state and handlers) plus Clear and Apply controls, and closes on Apply, backdrop tap, or dismissal.
+- [x] 3.5 Confirm the `lg`-and-above layout is unchanged (existing single-row Status/Currency/Duration controls, no "Filters" trigger).
+- [x] 3.6 Update the removable status filter chips to read their colors from `STATUS_STYLES`/`STATUS_ACCENT` (`constants/budgetStatus.ts`) instead of the hardcoded yellow/green/red/slate classes.
+- [x] 3.7 Manually verify on a mobile viewport (or emulated width `<1024px`) that budget cards are visible without scrolling past the filter bar.
+- [x] 3.8 Run frontend lint/typecheck and the relevant component tests clean; open PR with `Closes #<n>`; PR merged.
+  - [x] eslint clean on touched files, tsc -b clean
+  - [x] Budgets test suite clean (151 passed)
+  - [ ] PR opened and merged (combined PR, Closes #213)


### PR DESCRIPTION
## Summary
- Archived status badge gets a dashed-outline + icon treatment, structurally distinct from `draft` instead of relying on a similar grey hue.
- Budget card footer reworked into an even, 44px-tall two-button split (quiet Edit / icon-only Delete), wired through `ConfirmDeleteButton` for an inline Yes/No confirm before delete.
- Status/Currency/Duration filter dropdowns collapse into a single "Filters" trigger + bottom sheet below `lg`, so budget cards are visible above the fold on mobile; desktop layout unchanged.
- Removable status filter chips now read colors from `STATUS_STYLES` (the same source the badges use) instead of a hardcoded palette that no longer matched real status values.
- Long budget card titles truncate to one line so mismatched card heights don't misalign the action row across a grid.
- Card click and Edit now navigate to the budget detail page (Edit opens it in edit mode via `?edit=1`) instead of the old list-page modal.
- Delete is disabled for confirmed budgets in both card and table views — the backend already rejects deleting a budget that still has reports, funding receipts, or currency conversions attached (400, not a cascade), so this avoids a wasted click into that error.

All three original openspec groups (`budget-cards-improvement`) plus follow-up polish requested during review landed together on one branch/PR per user direction.

## Test plan
- [x] `npx tsc -b --noEmit` clean
- [x] `npx eslint` clean on all touched files (pre-existing unrelated lint debt elsewhere untouched)
- [x] Full Budgets vitest suite: 151/151 passing
- [x] Manual browser verification (Playwright-driven, screenshots reviewed): archived badge in TableView/CardsView/detail header, CardsView footer + confirm-delete Yes/No + cancel flow, mobile Filters sheet + active-count badge + chip colors, desktop filter layout unchanged, long-name truncation, card-click/Edit navigation, Delete disabled on confirmed budgets in both views

Closes #213

🤖 Generated with [Claude Code](https://claude.com/claude-code)