### PR TITLE
Fix Used column stuck at 0% on cold load

### DIFF
--- a/frontend-typescript/src/main.tsx
+++ b/frontend-typescript/src/main.tsx
@@ -4,6 +4,7 @@ import App from "./App";
 // import "./index.css";
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import { SpeedInsights } from "@vercel/speed-insights/react";
 import { Analytics } from "@vercel/analytics/react";
 const queryClient = new QueryClient();
@@ -14,6 +15,7 @@ ReactDOM.createRoot(document.getElementById("root")!).render(
       <App />
       <SpeedInsights />
       <Analytics />
+      <ReactQueryDevtools initialIsOpen={false} />
     </QueryClientProvider>
   </React.StrictMode>
 );

--- a/frontend-typescript/src/pages/Budgets/SingleBudgetView.tsx
+++ b/frontend-typescript/src/pages/Budgets/SingleBudgetView.tsx
@@ -31,7 +31,7 @@ export function SingleBudgetViewContainer() {
 function SingleBudgetView({ id }: { id: string | undefined }) {
   const [isAddOpen, setIsAddOpen] = useState(false);
   const [isEditLineOpen, setIsEditLineOpen] = useState<BudgetLine | undefined>(
-    undefined
+    undefined,
   );
   // Bumped by CurrencyLedgerPanel's "set actual currency first" prompt (or
   // the `?edit=1` URL param below) to open BudgetViewHeader's edit mode from

--- a/frontend-typescript/src/pages/Budgets/SingleBudgetViewContext.tsx
+++ b/frontend-typescript/src/pages/Budgets/SingleBudgetViewContext.tsx
@@ -35,6 +35,8 @@ interface SingleBudgetViewContextType {
   // exists yet, so this is an N+1 fetch-and-sum client-side, fine for the
   // usual handful of reports per budget.
   spendByLineId: Record<string, number>;
+  // True while reports/report-lines are still fetching (#216).
+  isSpendPending: boolean;
   totalReported: number;
   // Whether any report has ever been submitted against this budget — gates
   // whether "Total Reported" is worth showing at all. A draft report with
@@ -117,20 +119,34 @@ export const SingleBudgetViewContextProvider: React.FC<{
     queryClient.setQueryData(budgetDetailsQueryKey(id), updated);
   };
 
-  const { data: reports } = useQuery({
+  const { data: reports, isPending: isReportsPending } = useQuery({
     queryKey: reportsByBudgetQueryKey(id),
     queryFn: () => (id ? listReportsByBudget(id) : Promise.resolve([])),
     enabled: !!id,
   });
 
+  // The `queries` array itself must stay referentially stable across
+  // renders (memoized on `reports`, whose reference React Query already
+  // holds stable via structural sharing) — otherwise it's a new array of
+  // new object literals every render, which re-fires useQueries' internal
+  // `observer.setQueries()` effect on every render (including the ones
+  // triggered by report-line data itself resolving), fighting the in-flight
+  // fetch instead of just waiting for it (#216).
+  //
   // combine's result is only recomputed when useQueries' structurally-shared
   // output actually changes, unlike a useMemo keyed on the queries array
   // (which is a new reference every render regardless of data changes).
-  const spendByLineId = useQueries({
-    queries: (reports ?? []).map((report) => ({
-      queryKey: reportLinesQueryKey(report.id),
-      queryFn: () => listReportLinesByReport(report.id),
-    })),
+  const reportLineQueries = useMemo(
+    () =>
+      (reports ?? []).map((report) => ({
+        queryKey: reportLinesQueryKey(report.id),
+        queryFn: () => listReportLinesByReport(report.id),
+      })),
+    [reports],
+  );
+
+  const { spendByLineId, isSpendPending: isSpendQueriesPending } = useQueries({
+    queries: reportLineQueries,
     combine: (queries) => {
       const totals: Record<string, number> = {};
       queries.forEach((query) => {
@@ -139,9 +155,15 @@ export const SingleBudgetViewContextProvider: React.FC<{
           totals[line.budget_line_id] = (totals[line.budget_line_id] ?? 0) + (line.amount ?? 0);
         });
       });
-      return totals;
+      return {
+        spendByLineId: totals,
+        isSpendPending: queries.some((query) => query.isPending),
+      };
     },
   });
+
+  // Also pending while `reports` itself hasn't loaded yet.
+  const isSpendPending = isReportsPending || isSpendQueriesPending;
 
   const totalReported = useMemo(
     () => Object.values(spendByLineId).reduce((sum, value) => sum + value, 0),
@@ -158,6 +180,7 @@ export const SingleBudgetViewContextProvider: React.FC<{
         totalAmount,
         existingExtraKeys,
         spendByLineId,
+        isSpendPending,
         totalReported,
         hasReports: (reports ?? []).some((r) => r.status !== "draft"),
       }}

--- a/frontend-typescript/src/pages/Budgets/components/BudgetViewLinesTable.test.tsx
+++ b/frontend-typescript/src/pages/Budgets/components/BudgetViewLinesTable.test.tsx
@@ -25,6 +25,7 @@ function renderTable(
   lines: BudgetLine[],
   spendByLineId: Record<string, number>,
   budgetOverrides: Partial<Budget> = {},
+  isSpendPending = false,
 ) {
   useDetailedBudgetMock.mockReturnValue({
     budget: makeBudget(budgetOverrides),
@@ -33,6 +34,7 @@ function renderTable(
     budgetCategoryNames: [],
     existingExtraKeys: [],
     spendByLineId,
+    isSpendPending,
   });
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
@@ -98,6 +100,20 @@ describe("BudgetViewLinesTable Used column", () => {
     const pills = screen.getAllByText("0%");
     expect(pills[0].className).toContain("bg-slate-100");
     expect(screen.getAllByText("£0 / £300").length).toBeGreaterThan(0);
+  });
+
+  it("shows a loading pill instead of 0% while spend is still being fetched (#216)", () => {
+    renderTable(
+      [makeLine({ id: "bl5", amount: 300, category: { id: "c5", name: "Misc", code: "MISC" } })],
+      {},
+      {},
+      true,
+    );
+
+    expect(screen.queryByText("0%")).not.toBeInTheDocument();
+    const pills = screen.getAllByText("…");
+    expect(pills.length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Loading…").length).toBeGreaterThan(0);
   });
 });
 

--- a/frontend-typescript/src/pages/Budgets/components/BudgetViewLinesTable.tsx
+++ b/frontend-typescript/src/pages/Budgets/components/BudgetViewLinesTable.tsx
@@ -80,6 +80,7 @@ function UsedPill({
   actualCurrency,
   rate,
   labelInline = true,
+  loading = false,
 }: {
   used: number;
   allocated: number;
@@ -88,7 +89,22 @@ function UsedPill({
   actualCurrency: string | undefined;
   rate: number | null | undefined;
   labelInline?: boolean;
+  loading?: boolean;
 }) {
+  // Avoid a real-looking "0%" while spend is still loading (#216).
+  if (loading) {
+    return (
+      <div>
+        <span
+          className={`inline-flex items-center text-xs font-bold px-2.5 py-0.5 rounded-full animate-pulse ${USED_TONE_CLASSES.neutral}`}
+        >
+          …
+        </span>
+        <div className="text-xs text-slate-400 mt-1">Loading…</div>
+      </div>
+    );
+  }
+
   const pct = allocated > 0 ? Math.round((used / allocated) * 100) : null;
   const tone: "good" | "warn" | "danger" | "neutral" =
     pct === null || pct > 100
@@ -144,14 +160,8 @@ export function BudgetViewLinesTable({
   onClose: () => void;
   readOnly?: boolean;
 }) {
-  const {
-    budget,
-    setBudget,
-    budgetCategories,
-    existingExtraKeys,
-    budgetCategoryNames,
-    spendByLineId,
-  } = useDetailedBudget();
+  const { budget, setBudget, spendByLineId, isSpendPending } =
+    useDetailedBudget();
   const [displayMode, setDisplayMode] = useState<CurrencyDisplayMode>("local");
   const rate = budget?.estimated_exchange_rate;
   // A rate of exactly 0 is meaningless (division by zero downstream in
@@ -315,6 +325,7 @@ export function BudgetViewLinesTable({
             actualCurrency={budget?.actual_currency}
             rate={rate}
             labelInline={displayMode === "both"}
+            loading={isSpendPending}
           />
         ),
         aggregatedCell: (info) => (
@@ -326,6 +337,7 @@ export function BudgetViewLinesTable({
             actualCurrency={budget?.actual_currency}
             rate={rate}
             labelInline={displayMode === "both"}
+            loading={isSpendPending}
           />
         ),
       },
@@ -372,11 +384,17 @@ export function BudgetViewLinesTable({
     budget?.local_currency,
     budget?.actual_currency,
     spendByLineId,
+    isSpendPending,
     displayMode,
     rate,
     localCode,
     donorCode,
   ]);
+
+  // react-table caches each row's computed cell values keyed off `data`'s
+  // reference alone, oblivious to accessorFn closing over spendByLineId —
+  // force a cache bust when spend data changes (#216).
+  const tableData = useMemo(() => [...(lines ?? [])], [lines, spendByLineId]);
 
   // Mobile card list: same data as the desktop table, grouped by category
   // like TableCommon's grouping does, but always-expanded (no separate
@@ -439,7 +457,7 @@ export function BudgetViewLinesTable({
       </div>
 
       <div className="hidden sm:block">
-        <TableCommon data={lines || []} columns={columns} bare />
+        <TableCommon data={tableData} columns={columns} bare />
       </div>
 
       <div className="sm:hidden flex flex-col gap-4">
@@ -484,6 +502,7 @@ export function BudgetViewLinesTable({
                       displayMode={displayMode}
                       actualCurrency={budget?.actual_currency}
                       rate={rate}
+                      loading={isSpendPending}
                     />
                   </div>
                 </div>
@@ -511,6 +530,7 @@ export function BudgetViewLinesTable({
                         displayMode={displayMode}
                         actualCurrency={budget?.actual_currency}
                         rate={rate}
+                        loading={isSpendPending}
                       />
                       {extraFieldKeys
                         .filter((key) => line.extra_fields?.[key] !== undefined)

--- a/openspec/config.yaml
+++ b/openspec/config.yaml
@@ -6,6 +6,7 @@ context: |
   Repo: GrantFlow (nonprofit grant budgeting/reporting platform).
   Services: services/budget, services/users, services/ai, services/chat (FastAPI); frontend-typescript (React + TypeScript, React Query); nginx gateway proxying /api/v1/<prefix>/ to each service.
   GitHub tickets are created with scripts/new-issue.sh; branch naming is <ServiceName>/Issue-<number>/<short-desc> (ServiceName in Platform, Frontend, Shared, Budget, Users, AI, Chat).
+  Code comments: keep to short one- or two-liners explaining WHY, not WHAT; no multi-line rationale blocks in source files.
 
 # Per-artifact rules (optional)
 # Add custom rules for specific artifacts.


### PR DESCRIPTION
## Summary
- root cause: `@tanstack/react-table`'s `getCoreRowModel()` memoizes solely on the `data` array's reference, and each `Row` permanently caches its first computed `accessorFn` result (`row._valuesCache`) — since the "used" column's accessorFn reads `spendByLineId` (an external value) via closure rather than from `row.original`, a row that computed 0% before spend data loaded stayed stuck at 0% forever, regardless of later re-renders with correct data. Fixed by giving the table a `data` array that changes reference whenever `spendByLineId` changes, forcing react-table's row cache to bust.
- also memoizes the `useQueries` `queries` array in `SingleBudgetViewContext` (was rebuilt fresh every render, unnecessarily re-configuring the observer)
- adds a loading-pill state so the Used column shows "…" instead of a real-looking "0%" while spend data is still in flight

## Test plan
- [x] `BudgetViewLinesTable.test.tsx` (13 tests) and `SingleBudgetViewContext.test.tsx` (3 tests) pass
- [x] `tsc --noEmit` clean
- [ ] manual verification on cold load (confirmed fixed during debugging session)

Closes #216