### PR TITLE
Propose superuser customer impersonation (OpenSpec)

### DIFF
--- a/openspec/changes/superuser-cross-tenant-access/.openspec.yaml
+++ b/openspec/changes/superuser-cross-tenant-access/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-15

--- a/openspec/changes/superuser-cross-tenant-access/design.md
+++ b/openspec/changes/superuser-cross-tenant-access/design.md
@@ -1,0 +1,77 @@
+## Context
+
+This change was originally scoped as parameter-driven cross-tenant reads (superuser passes an explicit `customer_id` per endpoint, extending the existing donor-grantee pattern — `services/users/app/services/donor_grantees_services.py:33-53`). That approach was discussed and superseded: the actual driving need is broader — logging into any customer's account (read *and* write, e.g. configuring BYOK AI settings during sales demos) without asking for their credentials or touching the DB directly. Rebuilding a parameter-driven override for every page one endpoint at a time doesn't scale to that; a session-level impersonation mechanism does, because it reuses the entire existing app unmodified.
+
+Three implementation findings shaped the design:
+- `services/budget/app/services/budget_services.py` (`list_budget_service`, `get_budget_service`, `_resolve_updatable_budget`, `_can_view_budget`/`get_viewable_budget_service`), `budget_line_services.py`, and `report_services.py` all contain unconditional `if valid_user["role"] == "superuser": <return everything unscoped>` branches, predating this change. This is a live gap independent of anything being built here: any superuser token can list every customer's budgets today, with no auditing and no concept of "which customer." Once impersonation exists, leaving this in place creates a redundant, unaudited backdoor next to the audited front door — worse than the gap alone.
+- `services/ai/app/api/settings_routes.py:64-126` (AI provider key/model config) already gates on `role in {"superuser", "admin"}`, but every operation (`get_ai_settings`/`save_ai_settings`/`clear_ai_key`) is keyed by the caller's own `user_id` via `services/ai/app/crud/user_provider_key.py`'s `get_key`/`upsert_key`/`delete_key` — despite a frontend comment (`AiIntegrationsSection.tsx:209-210`) asserting it's customer-scoped. This is a pre-existing bug (two admins of the same org can silently create separate key rows, and an impersonating superuser using their own identity would create yet another one invisible to the org's real admins) that needs fixing for impersonation to behave correctly.
+- The deployment is genuinely DB-per-service (verified via `docker-compose.local.yml`): one Postgres server, but each service connects to its own named database. No cross-service SQL joins are possible — carried over from the earlier version of this design and still true.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Let a superuser act as any customer — read and write, across any current or future page — without that customer's credentials and without direct DB access.
+- Preserve true-actor accountability: every action taken during an impersonated session must be attributable to the real superuser, not the customer whose account is being used. This is a GDPR Art. 5(2) accountability / ISO 27001 A.8.15 logging requirement, not just a nice-to-have.
+- Log every request made under impersonation — including reads ("even viewed") — not just mutations.
+- Fix `UserProviderKey` to be genuinely customer-scoped.
+- Disclose the capability in the privacy policy and security docs.
+
+**Non-Goals:**
+- Extending the previous parameter-driven `customer_id`-override pattern to budget/report/other endpoints. Superseded by impersonation — not needed.
+- Modifying the existing donor-grantee superuser bypass. Left as-is; a separate, already-shipped mechanism, out of scope here.
+- A cross-service audit *query* API or a full internal admin console (customer list/search beyond the top-bar picker, session history view, etc.). The audit table stays DB-only for v1; the UI is limited to starting/ending impersonation, not browsing the audit log.
+- An ELT/data-warehouse layer for cross-service audit aggregation. Same reasoning as before — not warranted at this scale.
+- Cross-tenant access to org profile/notifications/billing settings pages — these have no backend yet (frontend placeholders only in `frontend-typescript/src/pages/Settings/components/`); impersonation will cover them automatically once they're built, no extra work needed then.
+
+## Decisions
+
+### 1. Session-level impersonation, not parameter-driven access
+Superuser mints a short-lived token scoped to a target `customer_id`, rather than passing an explicit `customer_id` per request. This is the reversal of the earlier version of this change's Decision 1 — see Context for why. The core tradeoff we accepted then (parameter-driven is cheaper but relies on every new endpoint remembering to scope) is exactly what impersonation avoids structurally: since the token just looks like a normal customer session, every existing and future endpoint already handles it correctly with zero new code.
+
+### 2. Token carries the superuser's real identity, not a borrowed one
+The impersonation token sets `customer_id = target`, admin-equivalent permissions, but `user_id = the superuser's own real id`.
+
+**Alternative considered**: borrow the target customer's actual admin user's identity (so `user_id` in the token is theirs), which would make user-keyed features like the current `UserProviderKey` behave correctly without a data-model fix, and would make the customer's own later view of Settings show the change as if they made it. Rejected: this makes every `created_by`/`updated_by` field in the app misattribute the superuser's actions to a real named person who didn't perform them, which fails the accountability goal above and is exactly the kind of surface a GDPR/ISO audit would flag — "who actually did this" must be answerable without reconstructing it from session-boundary timestamps (which breaks under overlapping sessions, session leaks, etc.). Fixing `UserProviderKey` to be customer-scoped (Decision 4) removes the only reason to prefer identity-borrowing.
+
+This also sidesteps a question that doesn't need answering: which admin to impersonate if a customer has several, or none yet (e.g. a fresh signup mid-onboarding). Since no identity is borrowed, it doesn't matter.
+
+### 3. Centralized audit hook, not per-route instrumentation
+Log every request under an impersonation-flagged token from a single point — the shared `get_validated_user` dependency (`shared/security/dependencies.py:62`), used by every service on every authenticated request — rather than requiring each route to call an audit helper.
+
+**Alternative considered**: per-route audit calls (the approach in the earlier version of this change). Rejected for this mechanism specifically because the goal is "even viewed" — full coverage of reads, not just mutations — and per-route instrumentation can only cover routes someone remembered to instrument. A centralized hook can't be forgotten because it isn't opt-in.
+
+**Granularity tradeoff, left open**: the centralized hook naturally logs at the request level (method + path + target `customer_id` + actor + timestamp), not with the fine-grained `resource_type`/`resource_id` the earlier per-route design could capture. Acceptable for v1 — coarse-but-complete beats fine-but-optional for an audit requirement — and specific high-value routes can be enriched later without weakening the baseline.
+
+### 4. Fix `UserProviderKey` to be customer_id-keyed
+Change the lookup key for AI provider settings from `user_id` to `customer_id`, matching the frontend's existing (currently false) assumption. This is a correctness fix independent of impersonation, but is required for impersonated AI-settings changes to be visible to the customer afterward, and closes the two-admins-shadow-each-other bug as a side effect.
+
+### 5. Audit log stays per-service, not centralized
+Same reasoning as the earlier version of this design: genuine DB-per-service isolation means a centralized table would add a synchronous cross-service dependency to every request under impersonation, which is worse here than in the earlier design since impersonated sessions can touch every service, not just budget. Each service logs locally.
+
+### 6. Persistent, non-dismissible warning banner while impersonating
+The picker lives in the top bar next to the existing user menu (`frontend-typescript/src/pages/Dashboard/TopBar.tsx`), visible only to superusers. Once a session is active, a banner naming the impersonated customer is shown on every page, with no way to hide it short of ending the session.
+
+**Rationale**: this is a well-known failure mode in "log in as" tooling generally (Django's hijack, Stripe/Intercom-style impersonation) — an admin forgets they're impersonating and acts on a customer's live account thinking it's their own, or a customer's real data gets edited without anyone noticing the session was privileged. A dismissible banner (or none at all) doesn't prevent this; a persistent one does, cheaply — it's a single conditional wrapper around the layout, not per-page work.
+
+### 7. Remove role-based bypasses in favor of customer_id-presence scoping
+Delete the `if valid_user["role"] == "superuser": <unscoped>` branches in budget/report service functions rather than adding an impersonation-awareness check alongside them. Replace with: always scope by `valid_user.get("customer_id")`, exactly as already happens for a regular customer user; if it's absent (a superuser with no active impersonation session), the caller gets nothing — empty list, not-found for single-resource lookups.
+
+**Why not keep the role check and just add "unless impersonating"**: that would leave two ways to reach cross-tenant data — impersonation, and a still-live role-based special case — which reintroduces the exact "unaudited backdoor next to the audited front door" problem this fix exists to close. Removing the branch entirely means `customer_id` presence is the only signal any of this code needs to understand, and it requires zero further changes to budget/report code when impersonation ships later: an impersonation token naturally carries `customer_id = target` (Decision 2), so the already-correct customer-scoped path starts working for impersonating superusers automatically, with no new code path added.
+
+## Risks / Trade-offs
+
+- **[Risk]** An impersonation token that leaks or outlives its intended use grants full read/write access to a customer's account. → **Mitigation**: short expiry (exact TTL is an implementation choice, not a spec-level decision), and every request under it is logged, so misuse is at least detectable even if not prevented in real time.
+- **[Risk]** Centralized request-level audit logging is coarse — it won't by itself say "the superuser viewed budget #123," only "GET /budgets/123." → **Mitigation**: accepted for v1 (Decision 3); path alone is usually enough to reconstruct intent, and can be enriched later.
+- **[Trade-off]** Logging every read, not just writes, means more audit volume and a stronger reliability bar (see Open Questions on fail-closed for reads). Accepted because impersonation sessions are inherently rare and short (support/demo use, not routine traffic), so volume stays low regardless.
+
+## Migration Plan
+
+1. Ship the `UserProviderKey` customer_id-keying fix first, independent of impersonation — it's a self-contained correctness fix with its own migration and doesn't depend on anything else in this change.
+2. Ship the per-service `privileged_access_logs` tables and the centralized audit hook together with impersonation token issuance in the same window — an impersonation mechanism without audit logging from day one would be a real gap, not just a sequencing nicety, given the accountability goal.
+3. No rollback complexity beyond standard migration reversibility.
+
+## Open Questions
+
+- **Fail-closed on reads vs. writes**: should a failed audit-log write block the request even for a plain page view, or only for mutations? Fail-closed on writes is the easier call (matches the earlier version of this change's reasoning); fail-closed on reads has a real UX cost (a broken audit table would lock a superuser out of *viewing* anything during an active demo). Left open — revisit during implementation.
+- Exact impersonation token TTL.
+- Should specific high-value routes (e.g. AI settings writes) get enriched `resource_type` logging in addition to the centralized coarse hook, or is coarse logging acceptable indefinitely?

--- a/openspec/changes/superuser-cross-tenant-access/proposal.md
+++ b/openspec/changes/superuser-cross-tenant-access/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+The eventual goal is superuser access to any customer page — originally motivated by needing to configure AI settings (BYOK API keys) for prospects during sales demos without asking for their credentials or touching the DB directly. Extending cross-tenant read access one endpoint at a time (the earlier version of this change) doesn't scale to "any page" and doesn't cover writes at all. Session-level impersonation — a superuser picks a target `customer_id` and gets a token scoped to act as that customer — reuses the entire existing app (frontend + every service) unmodified, covering every current and future page for free, at the cost of building the impersonation mechanism once.
+
+## What Changes
+
+- Add a superuser-only endpoint to mint a short-lived **impersonation token**: superuser supplies a target `customer_id`, receives a token with admin-equivalent permissions scoped to that customer, but with `user_id` set to the superuser's own real identity (not borrowed from an existing user of that customer) — so every existing `created_by`/`updated_by` attribution in the app already reflects the true actor.
+- Add a centralized audit hook in the shared `get_validated_user` dependency (`shared/security/dependencies.py`, used by every service): when a request carries an impersonation-flagged token, log it — method, path, target `customer_id`, actor, timestamp — to that service's own local `privileged_access_logs` table. Covers reads and writes uniformly, and can't be forgotten per-route since it's not opt-in.
+- **BREAKING (internal only)**: fix `UserProviderKey` (`services/ai/app/models/user_provider_key.py`) to be looked up by `customer_id` instead of `user_id` — the existing "customer-scoped" claim in the frontend doesn't match the backend today. Needed for AI settings to behave correctly under an impersonation token (and fixes a pre-existing bug where two admins of the same org can silently shadow each other's key).
+- Add a documented administrative-access policy disclosing that superusers may temporarily access any organization's account (read and write, as if logged in) for support/demo/compliance purposes, and that all such sessions are logged.
+
+## Capabilities
+
+### New Capabilities
+- `customer-impersonation`: superuser mints a time-boxed session scoped to any customer, without needing that customer's credentials.
+- `privileged-access-audit`: every request made under an impersonation session is logged with the true actor's identity, per-service, append-only.
+- `ai-provider-settings`: BYOK API key/model configuration is scoped by `customer_id`, not by whichever individual user last saved it.
+
+### Modified Capabilities
+- `security-documentation`: administrative-access disclosure, updated to describe impersonation (not just read access).
+
+## Impact
+
+- **Code**: `shared/security/` (impersonation token issuance + shared audit hook), `services/users/` (impersonation endpoint, session table), every service's local DB (new `privileged_access_logs` table), `services/ai/app/models/user_provider_key.py` + `services/ai/app/crud/user_provider_key.py` + `services/ai/app/api/settings_routes.py` (customer_id keying fix).
+- **Docs**: `docs/legal/privacy-policy-stub.md`, `SECURITY.md`.
+- **Supersedes** the previous version of this change (parameter-driven per-endpoint `customer_id` overrides extended from the donor-grantee pattern to budget/report) — not needed once impersonation exists, since impersonated requests flow through the existing customer-scoped code paths unmodified. The existing donor-grantee superuser bypass (`_resolve_scoped_customer_id`) is left as-is, untouched by this change.
+- **Frontend**: a customer-search picker in the top bar (`frontend-typescript/src/pages/Dashboard/TopBar.tsx`), visible only to superusers, plus a persistent, non-dismissible warning banner shown whenever impersonation is active. Otherwise the impersonated session uses the existing customer-facing app as-is — no other frontend changes.

--- a/openspec/changes/superuser-cross-tenant-access/specs/ai-provider-settings/spec.md
+++ b/openspec/changes/superuser-cross-tenant-access/specs/ai-provider-settings/spec.md
@@ -1,0 +1,12 @@
+## ADDED Requirements
+
+### Requirement: AI provider settings are scoped by customer, not by individual user
+The system SHALL store and look up AI provider key/model configuration (`UserProviderKey`) by the acting user's `customer_id`, not by their individual `user_id`. Any admin-or-above user acting for a customer — including a superuser impersonating that customer — SHALL see and modify the same configuration as any other admin-or-above user of that customer.
+
+#### Scenario: One admin sees another admin's configured key
+- **WHEN** an admin of a customer configures an AI provider key, and a different admin of the same customer subsequently views AI settings
+- **THEN** the second admin sees the key as configured, not as unconfigured
+
+#### Scenario: Impersonating superuser and the customer's own admin see the same configuration
+- **WHEN** a superuser impersonating a customer configures an AI provider key, and the customer's own admin subsequently views AI settings
+- **THEN** the admin sees the key as configured, matching what the superuser set

--- a/openspec/changes/superuser-cross-tenant-access/specs/customer-impersonation/spec.md
+++ b/openspec/changes/superuser-cross-tenant-access/specs/customer-impersonation/spec.md
@@ -1,0 +1,75 @@
+## ADDED Requirements
+
+### Requirement: Superuser starts an impersonation session for any customer
+The system SHALL allow a caller with the `superuser` role to request a time-boxed impersonation token scoped to any target `customer_id`, without needing that customer's credentials. The resulting token SHALL grant admin-equivalent permissions for the target customer.
+
+#### Scenario: Superuser starts impersonating a customer
+- **WHEN** a superuser requests an impersonation token for a target `customer_id`
+- **THEN** the system issues a token scoped to that customer with admin-equivalent permissions, and the request is logged per the `privileged-access-audit` capability
+
+#### Scenario: Non-superuser cannot start an impersonation session
+- **WHEN** a caller without the `superuser` role requests an impersonation token
+- **THEN** the system rejects the request
+
+#### Scenario: Superuser can switch target customer at any time
+- **WHEN** a superuser who already holds one impersonation token requests a new one for a different `customer_id`
+- **THEN** the system issues a new token scoped to the new target, independent of any prior impersonation token
+
+### Requirement: Impersonation token preserves the superuser's real identity
+The impersonation token SHALL carry the superuser's own real user identity, not an identity borrowed from any existing user of the target customer. Actions performed using the token SHALL be attributed to the superuser's real identity wherever the system records who performed an action.
+
+#### Scenario: A write made during impersonation is attributed to the superuser
+- **WHEN** a superuser, while impersonating a customer, performs an action that the system records with an actor/creator field
+- **THEN** that field reflects the superuser's own real identity, not any identity belonging to the target customer
+
+### Requirement: Impersonation tokens are time-boxed
+The system SHALL issue impersonation tokens with a limited lifetime; a token SHALL stop granting access once it expires.
+
+#### Scenario: Expired impersonation token is rejected
+- **WHEN** a request is made using an impersonation token past its expiry
+- **THEN** the system rejects the request
+
+### Requirement: Superuser has no cross-tenant data access outside an active impersonation session
+A caller with the `superuser` role but no active impersonation session (no `customer_id` resolved on their token) SHALL NOT receive another customer's data through any endpoint. List endpoints SHALL return an empty result and single-resource endpoints SHALL behave as not-found, rather than falling back to returning data across all customers. Impersonation SHALL be the only channel through which a superuser accesses customer data; no endpoint SHALL grant a blanket bypass based on the `superuser` role alone.
+
+#### Scenario: Superuser without an active session lists a resource
+- **WHEN** a superuser with no active impersonation session requests a list of budgets, reports, or other customer-owned resources
+- **THEN** the system returns an empty result, not the resources of every customer
+
+#### Scenario: Superuser without an active session requests a specific resource
+- **WHEN** a superuser with no active impersonation session requests a specific customer's resource by id
+- **THEN** the system responds as if the resource does not exist
+
+#### Scenario: Superuser with an active session sees exactly the impersonated customer's data
+- **WHEN** a superuser has an active impersonation session for a target customer
+- **THEN** the system scopes their requests to that customer exactly as it would for that customer's own user, with no special-casing based on the `superuser` role
+
+### Requirement: Superuser selects a customer to impersonate from the top bar
+The application SHALL provide a customer-search control in the top navigation bar, visible only to users with the `superuser` role, allowing them to search for and select any customer to begin an impersonation session.
+
+#### Scenario: Superuser searches for a customer to impersonate
+- **WHEN** a superuser opens the customer-search control and types a customer name
+- **THEN** the system shows matching customers, and selecting one starts an impersonation session for that customer
+
+#### Scenario: Non-superuser does not see the control
+- **WHEN** a user without the `superuser` role views the top bar
+- **THEN** the customer-search control is not present
+
+### Requirement: Active impersonation shows a persistent, non-dismissible warning banner
+Whenever a superuser has an active impersonation session, the application SHALL display a persistent, high-visibility warning banner stating that the current view is a superuser impersonation session and naming the customer being viewed. The banner SHALL remain visible across navigation while the session is active, and SHALL NOT offer any way to hide or dismiss it other than exiting the impersonation session.
+
+#### Scenario: Banner appears immediately on starting impersonation
+- **WHEN** a superuser selects a customer from the picker and impersonation begins
+- **THEN** the warning banner is displayed immediately, naming the impersonated customer
+
+#### Scenario: Banner persists across navigation
+- **WHEN** a superuser navigates between pages while impersonating
+- **THEN** the warning banner remains visible on every page
+
+#### Scenario: Banner cannot be dismissed without ending the session
+- **WHEN** a superuser is impersonating a customer
+- **THEN** the application provides no control to hide the banner that does not also end the impersonation session
+
+#### Scenario: Exiting impersonation removes the banner and restores the superuser's own session
+- **WHEN** a superuser uses the banner's exit control
+- **THEN** the impersonation session ends, the banner disappears, and the superuser returns to their own normal session

--- a/openspec/changes/superuser-cross-tenant-access/specs/privileged-access-audit/spec.md
+++ b/openspec/changes/superuser-cross-tenant-access/specs/privileged-access-audit/spec.md
@@ -1,0 +1,23 @@
+## ADDED Requirements
+
+### Requirement: Every request under an impersonation session is logged
+Each service SHALL maintain its own append-only `privileged_access_logs` table, local to that service's database. Whenever a request is made using an impersonation token (per the `customer-impersonation` capability), the system SHALL log it — at minimum the acting superuser's identity, the target `customer_id`, the request path and method, and a timestamp — regardless of whether the request is a read or a write.
+
+#### Scenario: A view performed during impersonation is logged
+- **WHEN** a superuser, while impersonating a customer, makes a read-only request
+- **THEN** the system writes a `privileged_access_logs` entry recording the actor, target customer, request, and timestamp
+
+#### Scenario: A write performed during impersonation is logged
+- **WHEN** a superuser, while impersonating a customer, makes a request that changes data
+- **THEN** the system writes a `privileged_access_logs` entry recording the actor, target customer, request, and timestamp
+
+#### Scenario: Requests outside an impersonation session are not logged as privileged
+- **WHEN** a customer's own user makes a request using their normal (non-impersonation) session
+- **THEN** the system does not write a `privileged_access_logs` entry
+
+### Requirement: Privileged access log entries are immutable
+The system SHALL NOT provide any way to update or delete a `privileged_access_logs` entry through the application.
+
+#### Scenario: No update path exists
+- **WHEN** any code path attempts to modify an existing `privileged_access_logs` entry
+- **THEN** no such application code path exists; entries are write-once

--- a/openspec/changes/superuser-cross-tenant-access/specs/security-documentation/spec.md
+++ b/openspec/changes/superuser-cross-tenant-access/specs/security-documentation/spec.md
@@ -1,0 +1,8 @@
+## ADDED Requirements
+
+### Requirement: Documented Administrative Access Policy
+The project SHALL maintain written disclosure, in the privacy policy and security documentation, that authorized superusers may temporarily access any organization's account — including the ability to view and modify its data, as if logged in as that organization — for support, demo, security, and compliance purposes, and that every such action, including views, is logged.
+
+#### Scenario: Customer reviews what admin access exists
+- **WHEN** a customer or reviewer reads the privacy policy or security documentation
+- **THEN** it discloses that superusers may temporarily access their organization's account with full read/write capability, and that such access is logged

--- a/openspec/changes/superuser-cross-tenant-access/tasks.md
+++ b/openspec/changes/superuser-cross-tenant-access/tasks.md
@@ -1,0 +1,51 @@
+Workflow rule: one task group = one GitHub ticket = one PR, merged before the next group starts.
+
+## 1. Close superuser blanket cross-tenant access in budget/report
+
+- [ ] 1.1 Remove the `if valid_user["role"] == "superuser": <unscoped>` branch in `services/budget/app/services/budget_services.py::list_budget_service`; always call `list_budgets(db, customer_id=valid_user.get("customer_id"))`, returning an empty list when `customer_id` is absent
+- [ ] 1.2 Remove the equivalent branches in `budget_services.py::get_budget_service`, `_resolve_updatable_budget`, `_can_view_budget`/`get_viewable_budget_service` — scope purely by `valid_user.get("customer_id")`, treating its absence as not-found
+- [ ] 1.3 Remove the equivalent branches in `services/budget/app/services/budget_line_services.py` (`get_viewable_budget_lines_service`, `get_budget_lines_service`, `get_budget_line_by_id_service`)
+- [ ] 1.4 Remove the equivalent branch in `services/budget/app/services/report_services.py` (`get_viewable_budget`/`_get_budget_or_404`)
+- [ ] 1.5 Tests: a superuser token with no `customer_id` gets an empty list from every list endpoint touched above, and not-found from every single-resource endpoint touched above; a regular customer's own access is unaffected
+- [ ] 1.6 Run budget-service test suite and flake8 (`--max-line-length=100`) clean; PR merged
+
+## 2. Fix AI provider settings to be customer-scoped
+
+- [ ] 2.1 Add migration `services/ai/migrations/versions/` adding a unique/lookup index on `UserProviderKey.customer_id` (per provider), and a data-migration note for any existing rows (dev/demo data only at this stage — no production backfill concern yet)
+- [ ] 2.2 Change `services/ai/app/crud/user_provider_key.py`'s `get_key`/`upsert_key`/`delete_key` to key by `customer_id` instead of `user_id`
+- [ ] 2.3 Update `services/ai/app/api/settings_routes.py` (`get_ai_settings`/`save_ai_settings`/`clear_ai_key`) to resolve and pass `customer_id` (via existing `resolve_customer_id`) instead of `user_id` to the CRUD functions
+- [ ] 2.4 Update/add tests: two different admin-role users of the same customer see and modify the same AI settings row
+- [ ] 2.5 Run ai-service test suite and flake8 (`--max-line-length=100`) clean; PR merged
+
+## 3. Impersonation token issuance — depends on 1
+
+- [ ] 3.1 Add `impersonation_sessions` (or fold into `privileged_access_logs`, see Group 4) tracking in `services/users` if session bookkeeping beyond the JWT itself is needed (e.g. for revocation) — decide during implementation per design.md's open question on TTL
+- [ ] 3.2 Add superuser-only endpoint in `services/users` to mint an impersonation token: accepts target `customer_id`, issues a token with admin-equivalent permissions scoped to that customer, `user_id` set to the superuser's own real id, and an impersonation flag/claim
+- [ ] 3.3 Set a short, fixed expiry on impersonation tokens (see design.md open question for TTL value)
+- [ ] 3.4 Tests: superuser can mint a token for any `customer_id`; non-superuser is rejected; token grants access scoped to the target customer; token carries the superuser's real `user_id`; expired token is rejected; a superuser token with no impersonation session still gets empty/not-found per Group 1's fix
+- [ ] 3.5 Run users-service test suite and flake8 (`--max-line-length=100`) clean; PR merged
+
+## 4. Centralized privileged-access audit hook — depends on 3
+
+- [ ] 4.1 Add `privileged_access_logs` model + migration to each service (budget, users, ai, chat), modeled on `services/ai/app/models/audit_log.py::AIAuditLog`'s append-only shape, but generic (actor, target `customer_id`, request path, method, timestamp) rather than AI-specific
+- [ ] 4.2 Add the audit-write hook at (or immediately after) `shared/security/dependencies.py:62`'s `get_validated_user`, firing whenever the decoded token carries the impersonation flag — each service writes to its own local table
+- [ ] 4.3 Decide and implement the fail-closed/fail-open question for audit-write failures (design.md Open Questions) — writes should fail closed at minimum; confirm and implement the read-path behavior during this ticket
+- [ ] 4.4 Tests per service: a read during impersonation produces a log entry; a write during impersonation produces a log entry; a normal (non-impersonation) request produces no entry; audit-write failure behavior matches the decision made in 4.3
+- [ ] 4.5 Run full test suite (all services touched) and flake8 (`--max-line-length=100`) clean; PR merged
+
+## 5. Impersonation UI: top bar picker + warning banner — depends on 3
+
+- [ ] 5.1 Add `is_superuser` (and any impersonation-active state) to the decoded JWT claims surfaced by `AuthContext` (`frontend-typescript/src/context/AuthContext.tsx`)
+- [ ] 5.2 Add a customer-search endpoint call (reuse the existing customer search pattern from `ManageGrantees.tsx`'s donor→grantee NGO search) wired to a new `<ImpersonatePicker />` component, rendered in `TopBar.tsx` to the left of the existing user menu, visible only when `isSuperuser` is true
+- [ ] 5.3 Selecting a customer in the picker calls the impersonation-token endpoint (Group 3) and swaps the app's active auth token, without discarding the superuser's own original token client-side (needed for exit)
+- [ ] 5.4 Add `<ImpersonationBanner />`, rendered once in `DashboardLayout` above `TopBar`, visible whenever an impersonation session is active, naming the impersonated customer, with an always-visible **Exit** control and no other way to hide it
+- [ ] 5.5 Exit control ends the impersonation session and restores the superuser's own original session/token
+- [ ] 5.6 Tests: picker is absent for non-superusers; banner appears immediately on impersonation start and persists across route changes; banner has no dismiss/hide control other than exit; exit restores the superuser's own session
+- [ ] 5.7 Run frontend test suite and lint clean; PR merged
+
+## 6. Disclosure — depends on 3, 4, 5
+
+- [ ] 6.1 Add a subsection to `docs/legal/privacy-policy-stub.md` disclosing that superusers may temporarily access any organization's account (read and write) for support/demo/security/compliance purposes, and that every such action is logged
+- [ ] 6.2 Add an "Administrative Access" section to `SECURITY.md` describing impersonation and the audit log as the mitigation
+- [ ] 6.3 Check `docs/security/subprocessors.md` for whether any cross-reference is needed (expected: no change)
+- [ ] 6.4 PR merged


### PR DESCRIPTION
## Summary
- Adds OpenSpec change `superuser-cross-tenant-access`: session-level impersonation lets a superuser act as any customer (read + write) for support/demo purposes, without their credentials.
- Includes: impersonation token issuance (real-identity attribution, not borrowed), centralized per-service audit logging (every request, not just writes), top-bar customer picker + non-dismissible warning banner, a fix for AI provider settings being keyed by `user_id` instead of `customer_id`, and closing an existing unaudited role-based bypass in budget/report read paths.
- Planning artifacts only (proposal/design/specs/tasks) — no implementation in this PR.

## Test plan
- [ ] `openspec validate superuser-cross-tenant-access --strict` passes
- [ ] Review proposal.md / design.md / specs / tasks.md for scope and sequencing

🤖 Generated with [Claude Code](https://claude.com/claude-code)