### PR TITLE
Fix unverified-user auth loophole: gate sessions on email verification

### DIFF
--- a/frontend-typescript/e2e/specs/api/auth-budget-chain.spec.ts
+++ b/frontend-typescript/e2e/specs/api/auth-budget-chain.spec.ts
@@ -12,12 +12,16 @@ interface JwtPayload {
   user_id: string;
 }
 
-// Register issues a token for a "pending" user with no org attached yet;
-// budgets require an owner_id (customer_id), so the chain onboards the user
+// Register no longer issues a session — the account stays unauthenticated
+// until /verify-email succeeds, which is now the first login moment. There's
+// no real inbox in e2e, so the verification token is pulled via the
+// debug-only resend-verification field (EXPOSE_VERIFICATION_TOKEN_FOR_TESTS,
+// set in services/users/.env.users.local — never enabled in prod). Budgets
+// require an owner_id (customer_id), so the chain onboards the user
 // (creating an org) before logging back in to pick up a token whose claims
-// actually carry that customer_id — mirrors the real Register -> Onboarding
-// -> Dashboard flow in the frontend (see src/pages/OnBoarding.tsx).
-test("register, onboard, login, then drive the budget CRUD chain", async ({
+// actually carry that customer_id — mirrors the real Register -> Verify ->
+// Onboarding -> Dashboard flow in the frontend (see src/pages/OnBoarding.tsx).
+test("register, verify, onboard, login, then drive the budget CRUD chain", async ({
   request,
   baseURL,
 }) => {
@@ -35,15 +39,27 @@ test("register, onboard, login, then drive the budget CRUD chain", async ({
     },
   });
   expect(registerRes.status()).toBe(200);
-  const registerBody: TokenResponse = await registerRes.json();
-  expect(registerBody.access_token).toBeTruthy();
 
-  const userId = jwtDecode<JwtPayload>(registerBody.access_token).user_id;
+  const resendRes = await request.post("/api/v1/auth/resend-verification", {
+    data: { email },
+  });
+  expect(resendRes.status()).toBe(200);
+  const { debug_token: debugToken } = await resendRes.json();
+  expect(debugToken).toBeTruthy();
+
+  const verifyRes = await request.post("/api/v1/auth/verify-email", {
+    data: { email, token: debugToken },
+  });
+  expect(verifyRes.status()).toBe(200);
+  const verifyBody: TokenResponse = await verifyRes.json();
+  expect(verifyBody.access_token).toBeTruthy();
+
+  const userId = jwtDecode<JwtPayload>(verifyBody.access_token).user_id;
   expect(userId).toBeTruthy();
 
   const registerContext = await pwRequest.newContext({
     baseURL,
-    extraHTTPHeaders: { Authorization: `Bearer ${registerBody.access_token}` },
+    extraHTTPHeaders: { Authorization: `Bearer ${verifyBody.access_token}` },
   });
   const onboardRes = await registerContext.patch(`/api/v1/users/${userId}/`, {
     data: { new_customer_name: `E2E Org ${unique}` },

--- a/frontend-typescript/e2e/specs/browser/auth-budget-crud.spec.ts
+++ b/frontend-typescript/e2e/specs/browser/auth-budget-crud.spec.ts
@@ -30,15 +30,13 @@ test("register, onboard, log in through the form, then drive the budget CRUD cha
   // resend-verification field (EXPOSE_VERIFICATION_TOKEN_FOR_TESTS, set in
   // services/users/.env.users.local — never enabled in prod) and drive the
   // real /verify-email page with it, same as a user clicking the emailed
-  // link would.
+  // link would. Registration issues no session, so this call is identified
+  // by email in the body, not a bearer token.
   await page.waitForURL("/confirm-email");
 
-  const accessToken = await page.evaluate(
-    () => sessionStorage.getItem("token") || localStorage.getItem("token"),
-  );
   const resendRes = await page.request.post(
     `${GATEWAY_URL}/api/v1/auth/resend-verification`,
-    { headers: { Authorization: `Bearer ${accessToken}` } },
+    { data: { email } },
   );
   expect(resendRes.status()).toBe(200);
   const { debug_token: debugToken } = await resendRes.json();

--- a/frontend-typescript/src/App.tsx
+++ b/frontend-typescript/src/App.tsx
@@ -20,17 +20,6 @@ import FundedReportsPage from "./pages/Budgets/FundedReportsPage";
 import DashboardLayout from "./pages/Dashboard/DashboardLayout";
 import SettingsPage from "./pages/Settings/Settings";
 
-// Authenticated, but doesn't require a verified email — used for the
-// confirm-email screen itself, which must stay reachable by unverified
-// users (otherwise PrivateRoute's redirect target would loop back to
-// itself).
-function AuthOnlyRoute({ children }: { children: JSX.Element }) {
-  const { isAuthenticated, loading } = useAuth();
-  if (loading) return <div>Loading...</div>;
-  if (!isAuthenticated) return <Navigate to="/login" replace />;
-  return children;
-}
-
 function PrivateRoute({ children }: { children: JSX.Element }) {
   const { isAuthenticated, loading, emailVerified } = useAuth();
   if (loading) return <div>Loading...</div>;
@@ -59,14 +48,7 @@ export default function App() {
             <Route path="/register" element={<Register />} />
             <Route path="/verify-email" element={<VerifyEmail />} />
             <Route path="/accept-invite" element={<AcceptInvite />} />
-            <Route
-              path="/confirm-email"
-              element={
-                <AuthOnlyRoute>
-                  <ConfirmEmail />
-                </AuthOnlyRoute>
-              }
-            />
+            <Route path="/confirm-email" element={<ConfirmEmail />} />
             <Route
               path="/onboarding"
               element={

--- a/frontend-typescript/src/api/axiosConfig.test.ts
+++ b/frontend-typescript/src/api/axiosConfig.test.ts
@@ -84,3 +84,42 @@ describe("axiosConfig silent refresh write-back", () => {
     expect(sessionStorage.getItem("token")).toBeNull();
   });
 });
+
+describe("axiosConfig email-not-verified handling", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    sessionStorage.clear();
+    mockPost.mockReset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // jsdom can't observe real navigation, so this only checks the no-refresh part.
+  it("does not attempt a silent refresh on a 403 email_not_verified response", async () => {
+    localStorage.setItem("refreshToken", "some-refresh-token");
+    const instance = createAxiosInstance("http://api.test") as any;
+
+    await instance
+      ._responseRejected({
+        response: { status: 403, data: { detail: "email_not_verified" } },
+        config: { url: "/some/protected/endpoint", headers: {} },
+      })
+      .catch(() => {});
+
+    expect(mockPost).not.toHaveBeenCalled();
+  });
+
+  it("does not intercept a 403 with an unrelated detail", async () => {
+    const instance = createAxiosInstance("http://api.test") as any;
+
+    const rejection = instance._responseRejected({
+      response: { status: 403, data: { detail: "some_other_reason" } },
+      config: { url: "/some/protected/endpoint", headers: {} },
+    });
+
+    await expect(rejection).rejects.toMatchObject({ response: { status: 403 } });
+    expect(mockPost).not.toHaveBeenCalled();
+  });
+});

--- a/frontend-typescript/src/api/axiosConfig.ts
+++ b/frontend-typescript/src/api/axiosConfig.ts
@@ -58,9 +58,13 @@ function createAxiosInstance(baseURL: string): AxiosInstance {
 
       if (
         error.response?.status === 403 &&
-        (error.response.data as { detail?: string })?.detail === "email_not_verified"
+        (error.response.data as { detail?: string })?.detail === "email_not_verified" &&
+        !isAuthExempt(originalRequest?.url)
       ) {
         // Valid token, just unverified — go confirm, don't try to refresh.
+        // /auth/login itself is exempt: Login.tsx already routes this case
+        // via a SPA navigate() that carries the typed email as router state,
+        // which a hard redirect here would otherwise race and destroy.
         if (window.location.pathname !== "/confirm-email") {
           window.location.href = "/confirm-email";
         }

--- a/frontend-typescript/src/api/axiosConfig.ts
+++ b/frontend-typescript/src/api/axiosConfig.ts
@@ -57,6 +57,17 @@ function createAxiosInstance(baseURL: string): AxiosInstance {
       const originalRequest = error.config as any;
 
       if (
+        error.response?.status === 403 &&
+        (error.response.data as { detail?: string })?.detail === "email_not_verified"
+      ) {
+        // Valid token, just unverified — go confirm, don't try to refresh.
+        if (window.location.pathname !== "/confirm-email") {
+          window.location.href = "/confirm-email";
+        }
+        return Promise.reject(error);
+      }
+
+      if (
         error.response?.status === 401 &&
         !originalRequest?._retry &&
         !isAuthExempt(originalRequest?.url)

--- a/frontend-typescript/src/api/usersApi.ts
+++ b/frontend-typescript/src/api/usersApi.ts
@@ -28,8 +28,8 @@ export const verifyEmail = async (email: string, token: string) => {
   return data;
 };
 
-export const resendVerification = async () => {
-  const { data } = await gatewayApi.post("/auth/resend-verification", {});
+export const resendVerification = async (email: string) => {
+  const { data } = await gatewayApi.post("/auth/resend-verification", { email });
   return data;
 };
 

--- a/frontend-typescript/src/pages/ConfirmEmail.tsx
+++ b/frontend-typescript/src/pages/ConfirmEmail.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { useLocation } from "react-router-dom";
 import { useMutation } from "@tanstack/react-query";
 import { resendVerification } from "@/api/usersApi";
 import { useAuth } from "@/context/AuthContext";
@@ -6,11 +7,14 @@ import Button from "@/components/ui/Button";
 import { MailCheck } from "lucide-react";
 
 export default function ConfirmEmail() {
-  const { username, logout } = useAuth();
+  // Reachable unauthenticated now, so prefer the email passed via navigation.
+  const location = useLocation();
+  const { username, isAuthenticated, logout } = useAuth();
+  const email = (location.state as { email?: string } | null)?.email || username;
   const [justSent, setJustSent] = useState(false);
 
   const mutation = useMutation({
-    mutationFn: resendVerification,
+    mutationFn: () => resendVerification(email as string),
     onSuccess: () => setJustSent(true),
   });
 
@@ -28,7 +32,7 @@ export default function ConfirmEmail() {
         </h1>
         <p className="text-gray-500 mb-8">
           We sent a confirmation link to{" "}
-          {username ? <strong>{username}</strong> : "your email address"}.
+          {email ? <strong>{email}</strong> : "your email address"}.
           Click it to finish setting up your account.
         </p>
 
@@ -44,7 +48,7 @@ export default function ConfirmEmail() {
           type="button"
           variant="primary"
           className="w-full disabled:opacity-50 disabled:cursor-not-allowed font-medium"
-          disabled={mutation.isPending || justSent}
+          disabled={!email || mutation.isPending || justSent}
           onClick={() => mutation.mutate()}
         >
           {justSent
@@ -54,16 +58,28 @@ export default function ConfirmEmail() {
               : "Resend confirmation email"}
         </Button>
 
-        <p className="text-center text-gray-600 mt-6">
-          Wrong account?{" "}
-          <button
-            type="button"
-            onClick={logout}
-            className="text-slate-700 font-semibold hover:text-slate-900 hover:underline"
-          >
-            Log out
-          </button>
-        </p>
+        {isAuthenticated ? (
+          <p className="text-center text-gray-600 mt-6">
+            Wrong account?{" "}
+            <button
+              type="button"
+              onClick={logout}
+              className="text-slate-700 font-semibold hover:text-slate-900 hover:underline"
+            >
+              Log out
+            </button>
+          </p>
+        ) : (
+          <p className="text-center text-gray-600 mt-6">
+            Wrong account?{" "}
+            <a
+              href="/register"
+              className="text-slate-700 font-semibold hover:text-slate-900 hover:underline"
+            >
+              Register again
+            </a>
+          </p>
+        )}
       </div>
     </div>
   );

--- a/frontend-typescript/src/pages/Login.test.tsx
+++ b/frontend-typescript/src/pages/Login.test.tsx
@@ -6,6 +6,8 @@ import Login from "./Login";
 import * as usersApi from "@/api/usersApi";
 import * as authContext from "@/context/AuthContext";
 
+const mockNavigate = vi.fn();
+
 vi.mock("@/api/usersApi", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/api/usersApi")>();
   return { ...actual, loginUser: vi.fn() };
@@ -14,6 +16,11 @@ vi.mock("@/api/usersApi", async (importOriginal) => {
 vi.mock("@/context/AuthContext", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/context/AuthContext")>();
   return { ...actual, useAuth: vi.fn() };
+});
+
+vi.mock("react-router-dom", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react-router-dom")>();
+  return { ...actual, useNavigate: () => mockNavigate };
 });
 
 function renderLogin() {
@@ -54,5 +61,18 @@ describe("Login error messages", () => {
     renderLogin();
     await submit();
     expect(await screen.findByText("Invalid username or password")).toBeInTheDocument();
+  });
+
+  it("routes to /confirm-email on a 403 email_not_verified response", async () => {
+    vi.mocked(usersApi.loginUser).mockRejectedValue({
+      response: { status: 403, data: { detail: "email_not_verified" } },
+    });
+    renderLogin();
+    await submit();
+    await vi.waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith("/confirm-email", {
+        state: { email: "user@example.com" },
+      });
+    });
   });
 });

--- a/frontend-typescript/src/pages/Login.tsx
+++ b/frontend-typescript/src/pages/Login.tsx
@@ -4,7 +4,6 @@ import { loginUser } from "@/api/usersApi";
 import { useNavigate } from "react-router-dom";
 import Button from "@/components/ui/Button";
 import { LogIn } from "lucide-react";
-import { safeDecodeToken } from "@/utils/token";
 
 export default function Login() {
   const { isAuthenticated, isRegistering, login } = useAuth();
@@ -27,12 +26,7 @@ export default function Login() {
         res.status,
         res.refresh_token,
       );
-      const claims = safeDecodeToken<{ email_verified?: boolean }>(
-        res.access_token,
-      );
-      if (!claims?.email_verified) {
-        navigate("/confirm-email");
-      } else if (res.status === STATUS.PENDING) {
+      if (res.status === STATUS.PENDING) {
         navigate("/onboarding");
       } else {
         navigate("/dashboard");
@@ -40,7 +34,10 @@ export default function Login() {
     } catch (err: any) {
       const status = err?.response?.status;
       const detail = err?.response?.data?.detail;
-      if (status === 429) {
+      if (status === 403 && detail === "email_not_verified") {
+        // Valid credentials, but no session — route to confirm-email.
+        navigate("/confirm-email", { state: { email: username } });
+      } else if (status === 429) {
         setError(detail || "Too many failed login attempts. Try again later.");
       } else if (status === 401) {
         setError("Invalid username or password");

--- a/frontend-typescript/src/pages/Register.tsx
+++ b/frontend-typescript/src/pages/Register.tsx
@@ -3,7 +3,6 @@ import React, { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { useMutation } from "@tanstack/react-query";
 import { registerUser } from "@/api/usersApi";
-import { useAuth } from "@/context/AuthContext";
 import { Eye, EyeOff, UserPlus } from "lucide-react";
 
 export default function Register() {
@@ -17,22 +16,13 @@ export default function Register() {
   const [consentDataProcessing, setConsentDataProcessing] = useState(false);
   const [consentMarketing, setConsentMarketing] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const { login } = useAuth();
 
   const mutation = useMutation({
     mutationFn: ({ email, password }: { email: string; password: string }) =>
       registerUser(email, password, consentDataProcessing, consentMarketing),
     onSuccess: (data) => {
-      login(
-        data.access_token,
-        email,
-        false,
-        data.status,
-        data.refresh_token || "",
-      );
-      // A brand-new account is never email-verified yet — go straight to
-      // the confirm-email screen instead of onboarding.
-      navigate("/confirm-email");
+      // Registration no longer authenticates.
+      navigate("/confirm-email", { state: { email: data.email } });
     },
     onError: (error: any) => {
       setError(error?.response?.data?.detail || "Registration failed. Please try again.");

--- a/frontend-typescript/src/pages/VerifyEmail.test.tsx
+++ b/frontend-typescript/src/pages/VerifyEmail.test.tsx
@@ -13,16 +13,7 @@ vi.mock("@/api/usersApi", async (importOriginal) => {
   };
 });
 
-vi.mock("@/api/gatewayApi", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("@/api/gatewayApi")>();
-  return {
-    ...actual,
-    refreshToken: vi.fn(),
-  };
-});
-
 import { verifyEmail } from "@/api/usersApi";
-import { refreshToken } from "@/api/gatewayApi";
 
 function renderAt(path: string) {
   const queryClient = new QueryClient({
@@ -46,7 +37,6 @@ describe("VerifyEmail", () => {
     localStorage.clear();
     sessionStorage.clear();
     vi.mocked(verifyEmail).mockReset();
-    vi.mocked(refreshToken).mockReset();
   });
 
   it("shows an invalid-link message when the URL has no token", async () => {
@@ -64,7 +54,12 @@ describe("VerifyEmail", () => {
   });
 
   it("shows success and continues on a valid token+email", async () => {
-    vi.mocked(verifyEmail).mockResolvedValue({ email_verified: true });
+    vi.mocked(verifyEmail).mockResolvedValue({
+      email_verified: true,
+      access_token: "new-access-token",
+      refresh_token: "new-refresh-token",
+      status: "pending",
+    });
 
     renderAt("/verify-email?token=good-token&email=user%40example.com");
 
@@ -74,10 +69,9 @@ describe("VerifyEmail", () => {
     expect(verifyEmail).toHaveBeenCalledWith("user@example.com", "good-token");
   });
 
-  it("refreshes the token after a successful verification so the client's claim is current", async () => {
-    localStorage.setItem("refreshToken", "stored-refresh-token");
-    vi.mocked(verifyEmail).mockResolvedValue({ email_verified: true });
-    vi.mocked(refreshToken).mockResolvedValue({
+  it("logs the user in with the tokens returned by verify-email", async () => {
+    vi.mocked(verifyEmail).mockResolvedValue({
+      email_verified: true,
       access_token: "new-access-token",
       refresh_token: "new-refresh-token",
       status: "pending",
@@ -86,8 +80,9 @@ describe("VerifyEmail", () => {
     renderAt("/verify-email?token=good-token&email=user%40example.com");
 
     await waitFor(() => {
-      expect(refreshToken).toHaveBeenCalledWith("stored-refresh-token");
+      expect(sessionStorage.getItem("token")).toBe("new-access-token");
     });
+    expect(sessionStorage.getItem("refreshToken")).toBe("new-refresh-token");
   });
 
   it("shows an error state when the token is expired or already used", async () => {

--- a/frontend-typescript/src/pages/VerifyEmail.tsx
+++ b/frontend-typescript/src/pages/VerifyEmail.tsx
@@ -2,7 +2,6 @@ import { useEffect } from "react";
 import { Link, useNavigate, useSearchParams } from "react-router-dom";
 import { useMutation } from "@tanstack/react-query";
 import { verifyEmail } from "@/api/usersApi";
-import { refreshToken as refreshTokenApi } from "@/api/gatewayApi";
 import { useAuth } from "@/context/AuthContext";
 import Button from "@/components/ui/Button";
 import { CheckCircle2, XCircle } from "lucide-react";
@@ -12,31 +11,13 @@ export default function VerifyEmail() {
   const token = searchParams.get("token");
   const email = searchParams.get("email");
   const navigate = useNavigate();
-  const { username, login, isAuthenticated } = useAuth();
+  const { login, isAuthenticated } = useAuth();
 
   const mutation = useMutation({
     mutationFn: () => verifyEmail(email as string, token as string),
-    onSuccess: async () => {
-      // The JWT's email_verified claim is only correct as of issuance —
-      // this request verified the account after the current token was
-      // handed out, so the client must refresh to pick up the new claim
-      // rather than relying on a stale one already in storage.
-      const storedRefreshToken =
-        sessionStorage.getItem("refreshToken") ||
-        localStorage.getItem("refreshToken");
-      if (!storedRefreshToken) return;
-      try {
-        const data = await refreshTokenApi(storedRefreshToken);
-        login(
-          data.access_token,
-          username || "",
-          !!localStorage.getItem("refreshToken"),
-          data.status,
-          data.refresh_token || ""
-        );
-      } catch (e) {
-        console.error("Token refresh after email verification failed", e);
-      }
+    onSuccess: (data) => {
+      // Verification is the account's first session.
+      login(data.access_token, email || "", false, data.status, data.refresh_token || "");
     },
   });
 

--- a/openspec/changes/high-email-verification-fix/.openspec.yaml
+++ b/openspec/changes/high-email-verification-fix/.openspec.yaml
@@ -1,0 +1,3 @@
+schema: spec-driven
+created: 2026-08-18
+priority: HIGH

--- a/openspec/changes/high-email-verification-fix/design.md
+++ b/openspec/changes/high-email-verification-fix/design.md
@@ -1,0 +1,50 @@
+## Context
+
+`POST /register` currently creates the user and immediately issues a full access+refresh session (`services/users/app/api/auth_routes.py:107-166`), before the user has confirmed ownership of their email address. No API endpoint checks the `email_verified` JWT claim or user status — `shared/security/dependencies.py`'s `get_validated_user` (used by every service: budget, ai, chat, users) only validates signature, expiry, and session revocation. The frontend's `PrivateRoute` guard (`frontend-typescript/src/App.tsx:34-40`) is the only thing currently preventing an unverified account from reaching real data, and it is UI-only — a direct API call with the user's own token bypasses it entirely. Separately, `/auth/resend-verification` requires that same session (`Depends(get_validated_user)`), so a user whose 20-minute access token and 7-day refresh token both lapse before they act on their verification email has no self-serve recovery path.
+
+This surfaced during investigation of a production incident where verification emails silently failed to send (unrelated Mailjet provider outage) — that outage is not part of this change; it exposed these pre-existing gaps rather than causing them.
+
+## Goals / Non-Goals
+
+**Goals:**
+- No authenticated session exists for an account until its email is confirmed.
+- `email_verified` is enforced server-side, at the single shared auth dependency, not just in the frontend.
+- A user can always request a new verification link without needing an active session.
+- Verification-link requests don't leak whether an email is registered or already verified.
+
+**Non-Goals:**
+- Fixing the Mailjet provider outage itself (separate ops issue, tracked outside this change).
+- Changing the password-reset token flow (separate mechanism, not touched here).
+- Building account lockout/abuse tooling beyond reusing the existing rate-limit pattern.
+- Retroactively deciding whether invited users (`/auth/accept-invite`) should be treated as pre-verified — flagged as an open question, not resolved here.
+
+## Decisions
+
+**Login also returns no session for an unverified account.** The existing spec explicitly allowed unverified users to log in and receive a token (`email-verification` capability, "Login remains available to unverified users"), gating only the onboarding UI on the claim. That's incompatible with enforcing `email_verified` at `get_validated_user`: an unverified user's login would appear to succeed (200, token issued) but the token would be rejected on the very next authenticated call, which is a confusing dead end rather than a fix. `login_endpoint` is updated to check `user.email_verified` after credential validation and, if false, skip session issuance and return a distinct response pointing the user at resend-verification — consistent with registration's behavior rather than a special case of it.
+
+**Registration returns no session.** `register_endpoint` drops the `create_refresh_token`/`create_session`/access-token issuance block entirely and returns a minimal confirmation (e.g. `{"message": "...", "email": ...}`) instead of `TokenResponse`. This is a **BREAKING** change to `/register`'s response contract. Alternative considered: keep issuing a token but scope it (a restricted "pre-verification" token type). Rejected — a second token type is more moving parts than removing the token, and the fail-closed property (no token = literally cannot call protected endpoints) is stronger than any scoping logic that has to be remembered and correctly enforced everywhere.
+
+**`/auth/verify-email` becomes the session-issuing endpoint.** On successful token validation, in addition to setting `email_verified = true` (existing behavior), it now creates the refresh token + session and returns them, same shape as today's login response. This is the natural point to log the user in — it's the first moment identity is actually confirmed.
+
+**`/auth/resend-verification` becomes anonymous.** Drops `Depends(get_validated_user)`, takes `email` in the request body. Rate-limited by combined `(email, client_ip)` key using the same `is_locked_out`/`record_failed_attempt` mechanism `/register` already uses (`auth_routes.py:116-120`), under a new bucket. Regardless of whether the account exists, is already verified, or is pending, the endpoint returns an identical generic response (e.g. "If that account exists and needs verification, we've sent a link") and takes the same code path length/shape internally, to avoid both user enumeration and timing-based enumeration. A real send is only enqueued for an existing, pending account.
+
+**`get_validated_user` additionally requires `email_verified: true` in the JWT.** Single choke point (`shared/security/dependencies.py`), so every service inherits the check automatically. Returns 403 (not 401) with a distinct body (e.g. `{"detail": "email_not_verified"}`) — 401 conventionally means "not authenticated / go log in again," which would be wrong here since the token is otherwise valid; 403 lets the frontend distinguish "needs to verify" from "needs to log back in" without guessing from message text. Given registration no longer issues a session, this check should be unreachable in steady state — it exists as defense-in-depth against future code paths that (re-)introduce pre-verification tokens, and to close the gap for sessions issued before this change ships (see Migration Plan).
+
+## Risks / Trade-offs
+
+- **[Risk]** `/register`'s breaking response change requires the frontend deploy to land no earlier than the backend, or registration briefly breaks for new users mid-rollout. → Mitigation: this is a single-consumer API (only `frontend-typescript`); coordinate as one release rather than independent deploys.
+- **[Risk]** Enforcing `email_verified` at `get_validated_user` could lock out already-verified users if their existing token's claim is stale or if any token-issuing path (e.g. the plain `/auth/login` endpoint) doesn't stamp `email_verified` correctly. → Mitigation: verify during implementation that `/auth/login` (not just register/verify-email) builds the claim from current `user.email_verified` at each login, not a cached/stale value.
+- **[Risk]** Revoking sessions for currently-pending users at rollout logs out anyone mid-registration at deploy time. → Mitigation: acceptable — they weren't verified and couldn't reach sensitive data anyway; they self-recover via the now-anonymous resend endpoint with no data loss.
+- **[Trade-off]** True constant-time enumeration resistance (matching response latency exactly regardless of DB hit) is not being built — only response *shape* is normalized. Residual timing side-channel is accepted as low-severity for this change.
+
+## Migration Plan
+
+1. Ship backend changes (`get_validated_user`, `resend-verification`, `verify-email`, `register`) and frontend changes together in one deploy.
+2. As part of rollout, run a one-time revocation of sessions belonging to users with `email_verified = false`, so the server-side enforcement takes effect immediately rather than waiting up to 7 days for old refresh tokens to expire naturally. Exact mechanism (script vs. migration) to be determined in tasks — depends on the existing session-revocation primitive used by the logout endpoint.
+3. The two known-affected accounts from the recent incident (`toby@sansome.org`, `avnikmelikian@gmail.com`) verify themselves through the new anonymous resend flow post-rollout; no manual token generation needed.
+4. Rollback: revert the deploy. No irreversible data migration is involved — revoked sessions simply require affected pending users to log in again via resend, which they'd need to do anyway.
+
+## Open Questions
+
+- Should `/auth/accept-invite` treat the invited user as pre-verified (since the admin already sent the invite to a specific address, and acceptance implies delivery)? Needs a decision before implementation touches the invite flow — if unresolved, leave invite-accept behavior untouched and out of scope for this change.
+- Exact primitive for bulk-revoking sessions by user (does one already exist, or does logout only revoke the caller's own session)?

--- a/openspec/changes/high-email-verification-fix/proposal.md
+++ b/openspec/changes/high-email-verification-fix/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+Registration currently issues a full-scope, authenticated session before the user's email is confirmed, and no API endpoint checks verification status server-side — only the frontend route guard does. A user was observed reaching the dashboard for an unverified account, and independently, `/auth/resend-verification` requires that same session, so a user whose access/refresh token has expired before they act on their verification email has no self-serve way to get a new link. Both stem from treating "has a session" as equivalent to "owns this email," which they are not. Given a recent production incident where verification email delivery silently failed, this is being fixed now while the failure mode is fresh and before it's exploited.
+
+## What Changes
+
+- **BREAKING**: `/register` no longer issues an access/refresh token or session. It creates the pending user and returns a non-authenticating confirmation response.
+- **BREAKING**: `/auth/login` no longer issues a session for an account whose email is still unverified (e.g. someone who registered previously and never confirmed). It returns a distinct response directing them to request a new verification link, instead of issuing a token that would be rejected on every subsequent call anyway.
+- `/auth/resend-verification` becomes an unauthenticated, email-based endpoint, rate-limited by email+IP (reusing the existing lockout pattern from `/register`), always returning a generic response regardless of account existence or current verification state (prevents enumeration).
+- `/auth/verify-email` now issues the first access/refresh token pair and session on successful verification — this becomes the actual login moment for a new registration.
+- `shared/security/dependencies.py`'s `get_validated_user` additionally rejects tokens for users whose `email_verified` claim is false, as defense-in-depth against any other pre-verification token issuance path and against sessions already outstanding from before this fix ships.
+- Frontend: registration flow shows a static "check your email" confirmation instead of landing in an authenticated shell; `/verify-email` handles the token response and logs the user in on success.
+- Existing sessions for currently-pending users are proactively revoked as part of rollout so the fix takes effect immediately rather than waiting up to 7 days for old refresh tokens to expire.
+
+## Capabilities
+
+### New Capabilities
+(none — this modifies existing auth behavior, not new capability surface)
+
+### Modified Capabilities
+- `email-verification`: registration no longer issues a session; `/auth/verify-email` issues the first session on success; resend-verification becomes unauthenticated and enumeration-safe.
+- `session-security`: session authentication additionally requires `email_verified: true`; sessions held by pending (unverified) users are revoked at rollout.
+- `auth-hardening`: resend-verification gains per-email+IP rate limiting, matching the existing registration lockout pattern.
+
+## Impact
+
+- **Backend (users service)**: `services/users/app/api/auth_routes.py` (`register_endpoint`, `login_endpoint`, `resend_verification_endpoint`, `verify_email_endpoint`), `services/users/app/crud/user_crud.py`.
+- **Shared**: `shared/security/dependencies.py` (`get_validated_user`) — affects every service (budget, ai, chat, users) that depends on it for auth.
+- **Frontend**: registration and verify-email pages/flows, `AuthContext`, `PrivateRoute` (`frontend-typescript/src`).
+- **Data/session**: one-time revocation of existing sessions belonging to pending (unverified) users at rollout.
+- **Two known-affected accounts** (`toby@sansome.org`, `avnikmelikian@gmail.com`) from the recent incident should complete verification through the new resend flow once shipped, rather than via manual token generation.

--- a/openspec/changes/high-email-verification-fix/specs/auth-hardening/spec.md
+++ b/openspec/changes/high-email-verification-fix/specs/auth-hardening/spec.md
@@ -1,0 +1,21 @@
+## ADDED Requirements
+
+### Requirement: Resend-Verification Rate Limiting
+The system SHALL limit the rate of resend-verification requests per combined email+source-IP key, using the same lockout mechanism applied to login and registration, matching the existing `auth-hardening` rate-limiting pattern.
+
+#### Scenario: Repeated resend requests from one source
+- **WHEN** a combined email+source-IP key submits more resend-verification requests than the configured threshold within the configured window
+- **THEN** the system rejects further resend requests for that key with a 429 response until the lockout window elapses
+
+## MODIFIED Requirements
+
+### Requirement: Registration Cannot Set Privileged Role
+The system SHALL ignore any `role` value supplied by the client on `POST /api/register` and SHALL always create the new account with role `user`. Elevation to `admin` or `superuser` SHALL only be possible through the `company-onboarding` promotion path or the protected admin-management endpoints, never through registration. Since registration no longer returns a session, this SHALL be verified against the persisted account record and, once available, the role claim of the session issued at successful email verification — not against a token returned by registration itself.
+
+#### Scenario: Client attempts to self-register as superuser
+- **WHEN** an unauthenticated caller submits `POST /api/register` with `"role": "superuser"` (or any value other than `user`) in the request body
+- **THEN** the account is created with `role: user`, and the session subsequently issued at successful email verification carries a `role` claim of `user`
+
+#### Scenario: Client attempts to self-register as admin
+- **WHEN** an unauthenticated caller submits `POST /api/register` with `"role": "admin"` in the request body
+- **THEN** the account is created with `role: user`, and the session subsequently issued at successful email verification carries a `role` claim of `user`

--- a/openspec/changes/high-email-verification-fix/specs/email-verification/spec.md
+++ b/openspec/changes/high-email-verification-fix/specs/email-verification/spec.md
@@ -1,0 +1,70 @@
+## ADDED Requirements
+
+### Requirement: Registration does not grant a session
+The system SHALL NOT issue an access token, refresh token, or session as part of a successful `POST /register` response. Registration SHALL only create the pending account, generate a verification token, and enqueue the confirmation email.
+
+#### Scenario: Registration returns a non-authenticating confirmation
+- **WHEN** a new user completes `POST /register` with a valid, unique email
+- **THEN** the response contains no access token, refresh token, or session identifier, and the account remains unauthenticated until email verification succeeds
+
+## MODIFIED Requirements
+
+### Requirement: Email verification endpoint
+The system SHALL provide an endpoint that accepts a verification token, marks the corresponding account as verified when the token is valid and unexpired, and rejects invalid, expired, or already-used tokens. On successful verification, the system SHALL issue a new access token, refresh token, and session for the account, since this is the first point at which a session is authorized to exist.
+
+#### Scenario: Valid token verifies the account
+- **WHEN** a user submits a verification token that matches a stored, unexpired token for their account
+- **THEN** the account's `email_verified` flag is set to true and the stored token is cleared so it cannot be reused
+
+#### Scenario: Expired token is rejected
+- **WHEN** a user submits a verification token whose expiry timestamp has passed
+- **THEN** the request is rejected and the account remains unverified
+
+#### Scenario: Already-used token is rejected
+- **WHEN** a user submits a verification token that was already consumed by a prior successful verification
+- **THEN** the request is rejected because no matching pending token exists
+
+#### Scenario: Successful verification issues a session
+- **WHEN** a verification token is successfully validated and the account is marked verified
+- **THEN** the response includes a new access token and refresh token whose `email_verified` claim is true, and a corresponding session is created
+
+### Requirement: Resend verification email
+The system SHALL provide an unauthenticated endpoint, identified by email address, that issues a new verification token and enqueues a new confirmation email for an account that is not yet verified, invalidating any previously issued token for that account. The endpoint SHALL be rate-limited per combined email+source-IP key, and SHALL return an identical, generic response regardless of whether the account exists, is already verified, or is pending, to prevent account enumeration.
+
+#### Scenario: Resend for an unverified account
+- **WHEN** an unverified account's owner requests a resend of the verification email, without needing to be logged in
+- **THEN** a new token and expiry are generated, any prior token is invalidated, and a new confirmation email is enqueued
+
+#### Scenario: Resend for an already-verified account
+- **WHEN** a resend is requested for an email belonging to an already-verified account
+- **THEN** the system SHALL NOT generate a new token or enqueue an email, but SHALL return the same generic response as a successful resend
+
+#### Scenario: Resend for a nonexistent email
+- **WHEN** a resend is requested for an email with no matching account
+- **THEN** the system SHALL NOT reveal that the account does not exist, and SHALL return the same generic response as a successful resend
+
+### Requirement: Login remains available to unverified users
+The system SHALL allow a user with an unverified email to submit correct credentials to `POST /login`, but SHALL NOT issue an access token, refresh token, or session in response. Instead the system SHALL return a distinct, non-authenticating response indicating the account requires verification, directing the user toward the resend-verification endpoint.
+
+#### Scenario: Unverified user submits correct credentials
+- **WHEN** a registered but unverified user submits correct credentials to `POST /login`
+- **THEN** the system confirms the credentials were valid but issues no token or session, and the response indicates the account needs email verification
+
+#### Scenario: Verified user logs in as before
+- **WHEN** a registered and verified user submits correct credentials to `POST /login`
+- **THEN** authentication succeeds exactly as before this change, with a session issued and `email_verified: true` in the JWT
+
+### Requirement: Verification state reflected in JWT claims
+The system SHALL include an `email_verified` boolean claim in every issued JWT, kept consistent with the account's current verification state at the time of issuance.
+
+#### Scenario: Claim reflects current state at token issuance
+- **WHEN** a JWT is issued at email verification, login, or refresh
+- **THEN** the token's `email_verified` claim matches the account's `email_verified` value in the database at that moment
+
+## REMOVED Requirements
+
+### Requirement: Onboarding gated on email verification
+**Reason**: Superseded by server-side enforcement at the shared session-authentication dependency (see `session-security` capability), which now rejects any request from an unverified account across every protected endpoint, not just onboarding. Since unverified accounts no longer hold a session at all, the narrower onboarding-only gate is subsumed by the broader one.
+
+**Migration**: No client action needed. Any code that specifically checked this onboarding-only gate should rely on the general protected-access enforcement instead.
+

--- a/openspec/changes/high-email-verification-fix/specs/session-security/spec.md
+++ b/openspec/changes/high-email-verification-fix/specs/session-security/spec.md
@@ -1,0 +1,19 @@
+## ADDED Requirements
+
+### Requirement: Session Authentication Requires Verified Email
+The system SHALL reject an otherwise-valid, non-revoked, unexpired access token if its `email_verified` claim is not true, at the same shared dependency that authenticates every request across all services. The rejection SHALL use a distinct status/response from an invalid or expired token, so clients can distinguish "needs to verify" from "needs to re-authenticate."
+
+#### Scenario: Unverified token rejected on a protected endpoint
+- **WHEN** a request presents an access token whose `email_verified` claim is false, but is otherwise valid and not revoked
+- **THEN** the system rejects the request with a 403 response indicating the account is not verified, distinct from the 401 used for invalid/expired/revoked tokens
+
+#### Scenario: Verified token behaves as before
+- **WHEN** a request presents an access token whose `email_verified` claim is true
+- **THEN** authentication proceeds exactly as it did before this change
+
+### Requirement: Pending Accounts' Sessions Revoked At Rollout
+The system SHALL, as a one-time migration step at deployment of this change, revoke all existing sessions belonging to accounts whose `email_verified` is false, so server-side enforcement takes effect immediately rather than waiting for those sessions' tokens to expire naturally.
+
+#### Scenario: Migration revokes pending users' sessions
+- **WHEN** the rollout migration runs against the existing sessions table
+- **THEN** every session belonging to a user with `email_verified = false` is marked revoked, and previously verified users' sessions are left untouched

--- a/openspec/changes/high-email-verification-fix/tasks.md
+++ b/openspec/changes/high-email-verification-fix/tasks.md
@@ -1,0 +1,37 @@
+Workflow rule: one task group = one GitHub ticket = one PR, merged before the next group starts.
+
+## 1. Registration & verification core flow
+
+- [x] 1.1 Remove session/token issuance from `register_endpoint` (`services/users/app/api/auth_routes.py`); return a minimal confirmation response instead of `TokenResponse`
+- [x] 1.2 Update `verify_email_endpoint` to issue a new access token, refresh token, and session (`create_refresh_token`/`create_session`) on successful verification, returning them in the response
+- [x] 1.3 Update the two `auth-hardening` "Registration Cannot Set Privileged Role" test scenarios to assert against the persisted `user.role` and the role claim of the session issued at verify-email, not a token returned by registration
+- [x] 1.4 Frontend: registration submit no longer stores a token/logs in; show a static "check your email" confirmation page instead
+- [x] 1.5 Frontend: `/verify-email` page consumes the access/refresh tokens now returned by the verify endpoint, logs the user in via `AuthContext`, and routes to the dashboard/onboarding on success
+- [x] 1.6 Tests: registration issues no session; verify-email issues a valid session with `email_verified: true`; expired/already-used/invalid tokens still rejected as before
+- [ ] 1.7 Run users-service test suite and flake8 (`--max-line-length=100`), and frontend test suite and lint, clean; PR merged
+
+## 2. Anonymous, rate-limited resend-verification — depends on 1
+
+- [x] 2.1 Drop `Depends(get_validated_user)` from `resend_verification_endpoint`; accept `email` in the request body instead
+- [x] 2.2 Add a `resend_verification` rate-limit bucket keyed on combined `(email, client_ip)`, reusing the existing `is_locked_out`/`record_failed_attempt`/`clear_failed_attempts` pattern from `register_endpoint`
+- [x] 2.3 Make the response identical in shape and content regardless of whether the account exists, is already verified, or is pending (generic "if that account exists, check your email" message); only issue a new token and enqueue an email for an existing, pending account
+- [x] 2.4 Frontend: update the resend-verification call site to no longer require an authenticated session (e.g. usable directly from the "check your email" / confirm-email screens)
+- [x] 2.5 Tests: resend works without auth for a pending account; resend for an already-verified or nonexistent email returns the same generic response and performs no token/email action; repeated requests past the threshold are rate-limited with 429
+- [ ] 2.6 Run users-service test suite and flake8 clean, and frontend test suite and lint clean; PR merged
+
+## 3. Login gating for unverified accounts — depends on 1, 2
+
+- [x] 3.1 Update `login_endpoint` to check `user.email_verified` after credential validation; if false, skip session issuance and return a distinct, non-authenticating response directing the user to resend-verification
+- [x] 3.2 Frontend: handle the new login response for unverified accounts — route to the confirm-email / resend screen instead of treating it as a login failure or a successful session
+- [x] 3.3 Tests: login with correct credentials for an unverified account issues no session and returns the distinct response; login for a verified account is unchanged
+- [ ] 3.4 Run users-service test suite and flake8 clean, and frontend test suite and lint clean; PR merged
+
+## 4. Server-side session enforcement + rollout migration — depends on 1, 2, 3
+
+- [x] 4.1 Update `get_validated_user` in `shared/security/dependencies.py` to reject tokens whose `email_verified` claim is not true, with a 403 response distinct from the existing 401 for invalid/expired/revoked tokens
+- [x] 4.2 Confirm every current token-issuing path (login, refresh, verify-email) stamps `email_verified` from the account's current DB value at issuance time, not a stale/cached value
+- [x] 4.3 Write a one-time rollout migration/script that revokes all existing sessions belonging to users with `email_verified = false`, using the same revocation mechanism as the logout endpoint
+- [x] 4.4 Frontend: handle the new 403 `email_not_verified` response distinctly from 401 in the API client/interceptor (route to confirm-email rather than logging out / attempting silent refresh)
+- [x] 4.5 Tests: a request with a valid but unverified token is rejected with 403 on a representative protected endpoint in each of users/budget/ai services (shared dependency, but verify it's actually wired the same way in each); a verified token behaves exactly as before
+- [ ] 4.6 Manually verify the two known-affected accounts (`toby@sansome.org`, `avnikmelikian@gmail.com`) can complete verification via the group-2 resend flow post-rollout (once the underlying Mailjet outage is separately resolved)
+- [ ] 4.7 Run affected services' test suites and flake8 clean, and frontend test suite and lint clean; PR merged

--- a/openspec/changes/user-session-fix/design.md
+++ b/openspec/changes/user-session-fix/design.md
@@ -2,18 +2,22 @@
 
 `services/users` persists one `user_sessions` row per login (model: `services/users/app/models/session.py`, columns include `revoked: bool` and `expires_at`). The panel at `frontend-typescript/src/pages/Settings/components/SecuritySection.tsx` calls `GET /auth/sessions`, which is backed by `get_non_revoked_sessions_for_user` (`services/users/app/crud/sessions_curd.py:35-41`). That query filters only on `revoked == False` and ignores `expires_at`, so sessions that expired days/weeks ago still render as "active" until a user manually clicks Revoke. Nothing ever purges expired rows — the only existing cleanup job, `services/worker/tasks/ai/cleanup_sessions.py` (Celery beat, daily at 03:00 UTC), deletes rows from the unrelated `ai_chat_sessions` table on the AI service's own database.
 
-One session row per login is intentional (the UI supports multiple simultaneous device sessions), so this is not a session-issuance bug — it's a listing-filter bug plus a missing hygiene job.
+One session row per login is intentional (the UI supports multiple simultaneous device sessions), so the original scope of this change was purely a listing-filter bug plus a missing hygiene job, not a session-issuance bug.
+
+A code review of the companion `high-email-verification-fix` change (which added `verify_email()`'s own session-issuance block to `auth_routes.py`) found that the same file now has three independently maintained copies of "issue refresh token → create session row → mint access token with role/verified claims" (`login()`, `refresh_token()`, `verify_email()`), and that `verify_email()` never revokes a pre-existing session when the same endpoint is reused to confirm an email-change (`get_user_by_verification_token` matches `pending_email` too, so an already-authenticated user's email-change confirmation flows through this same handler). Both are session-lifecycle defects adjacent enough to this change's existing scope to fix together rather than opening a third change touching the same file.
 
 ## Goals / Non-Goals
 
 **Goals:**
 - The active-sessions panel only ever shows sessions that are both non-revoked and not yet expired.
 - Expired `user_sessions` rows are eventually purged from the database so the table doesn't grow unbounded for users who never open the settings page.
+- Session issuance in `auth_routes.py` has one implementation, not three, so a future claim change can't silently apply to only some of `login`/`refresh_token`/`verify_email`.
+- `verify_email()` doesn't leave a pre-existing session alive in parallel with the new one when it's reused for the email-change confirmation flow.
 
 **Non-Goals:**
-- Changing login/refresh behavior or session issuance semantics.
+- Changing `login()`'s or `refresh_token()`'s external request/response contract — the shared-issuance refactor is internal; both endpoints keep issuing exactly the claims they do today.
 - Introducing a cap on concurrent sessions per user.
-- Revoking other sessions automatically on new login (would break legitimate multi-device use).
+- Revoking other sessions automatically on a *new* login (would break legitimate multi-device use) — the new revoke-on-reuse behavior is scoped specifically to `verify_email()`'s email-change case, not to `login()`.
 
 ## Decisions
 
@@ -21,12 +25,17 @@ One session row per login is intentional (the UI supports multiple simultaneous 
 - **Cleanup job placement**: add a new worker task `tasks.users.cleanup_sessions`, following the exact pattern of `tasks.ai.cleanup_sessions` (module-level lazy-initialized engine, raw `DELETE ... WHERE expires_at < :cutoff RETURNING id`, registered in `celery_app.py`'s `include` list, routed via the existing `"tasks.users.*"` queue rule, and added to `beat_schedule`). Chosen over extending the AI cleanup task because it operates on a different service's database (`services/users`, not `services/ai`) and should stay isolated per service, matching the existing per-service task module layout (`tasks/ai/`, `tasks/users/`, `tasks/debug/`).
 - **Retention window before delete**: purge sessions once `expires_at` has passed (no additional grace period) — the row's only purpose after expiry is historical audit, which isn't a current requirement. Alternative considered: keep a 30-day grace window like the AI cleanup task's `last_activity_at` cutoff; rejected because that task's grace period exists to bound *active* session count, whereas here `expires_at` already encodes the intended lifetime, so any additional delay just re-introduces the original bug's symptom (long-dead rows lingering) at a smaller scale.
 - **Database connectivity for the new task**: `services/worker/config.py` currently only defines `AI_DATABASE_URL`. This change adds a `USERS_DATABASE_URL` setting to the worker config, mirroring the existing pattern, sourced from the same connection string `services/users` already uses.
+- **Shared session-issuance helper**: add `_issue_session(db, user) -> TokenResponse`-shaped helper (name TBD at implementation) in `auth_routes.py` that does refresh-token creation, `create_session`, and access-token claim assembly in one place; `login()` and `refresh_token()` call it with their already-loaded `user`/`s.user`, and `verify_email()` calls it with the `user` returned by `mark_email_verified`. Because the helper always builds claims from a loaded `user.customer` (like `login()` already does), `verify_email()` no longer needs `_customer_role_claims(db, user.customer_id)`'s second DB fetch — that redundant query is removed as a side effect of the consolidation, not a separate change.
+- **Revoke-on-reuse for `verify_email()`**: before minting the new session, check whether the account already has any non-revoked sessions (`get_non_revoked_sessions_for_user(db, user.id)`, the same query this change is already touching). If any exist, this is not the account's first verification — it's an email-change confirmation on an already-sessioned account — so revoke them via the existing `_revoke_session_everywhere` helper (already used by `change_password()` for the same "sensitive account action forces re-auth on other devices" reasoning) before issuing the new one. Chosen over trying to identify and revoke one specific "originating" session, because `verify_email()` is an unauthenticated endpoint (identified by email + token, no bearer token) — there is no reliable way to know which browser/tab initiated the request, so "revoke everything that was valid before this confirmation" is the only implementable and secure option, and is consistent with treating an email change as sensitive enough to warrant it.
 
 ## Risks / Trade-offs
 
 - [New task touches `user_sessions` directly via raw SQL, bypassing the FastAPI service's ORM layer] → Mirrors the already-accepted pattern from `tasks.ai.cleanup_sessions`; low risk since the schema is stable and the delete is a single narrow predicate.
 - [Adding `USERS_DATABASE_URL` to the worker duplicates a connection string already known to `services/users`] → Same duplication already exists for `AI_DATABASE_URL`; consistent with current architecture, not a new pattern.
 - [Beat schedule cutover timing] → Cleanup runs daily at a fixed hour (proposed: 03:15 UTC, staggered from the existing 03:00 AI job to avoid both hitting the DB pool simultaneously); a user could still see a technically-expired-but-not-yet-purged session for up to 24h if the listing-filter fix weren't also shipped — mitigated because the filter fix (query-side) ships in the same change and is what actually controls what's visible, independent of purge timing.
+- [Consolidating session issuance touches `login()` and `refresh_token()`, the two highest-traffic auth endpoints] → Refactor is behavior-preserving by construction (same claims, same response shape); mitigated by task 3's requirement that `login`/`refresh_token`/`verify_email` are asserted to issue identical claim sets for equivalent users before/after, not just "tests still pass."
+- [Revoking sessions on email-change confirmation forces re-auth on every other device the user was logged in on] → Intentional: an email change is a primary-identifier change, similar in sensitivity to a password change, which already revokes other sessions (`change_password()`). A user who only ever has one session (the common case, and always true for first-time verification) sees no behavior change at all.
+- [The one-time `revoke_unverified_sessions.py` rollout script (fixed separately, in `high-email-verification-fix`, for an unrelated N+1-query issue) still duplicates the "revoke + mark in Redis" pattern that `_revoke_session_everywhere`/`_revoke_user_sessions` also implement, rather than reusing it] → Accepted, not unified: that script now does a single bulk SQL `UPDATE` across all affected sessions for performance (it can run against an unbounded number of accounts during rollout), which the per-session helpers can't do without giving up that bulk-query win. Three implementations of the same intent is a known, deliberate trade-off, not an oversight — revisit only if a fourth caller needs the same logic.
 
 ## Migration Plan
 
@@ -34,7 +43,9 @@ One session row per login is intentional (the UI supports multiple simultaneous 
 2. Add `USERS_DATABASE_URL` to worker config/env (all environments: local `.env`, deploy configs).
 3. Add `tasks/users/cleanup_sessions.py`, register it in `celery_app.py`'s `include` and `beat_schedule`.
 4. Deploy worker; verify the task runs on schedule and deletes only expired rows (spot-check via task result / logs).
-5. No rollback complexity: the filter change is a pure query addition (revert by removing the clause), and the cleanup task can be disabled by removing its `beat_schedule` entry without affecting request-serving paths.
+5. Add the shared `_issue_session` helper and switch `login()`/`refresh_token()`/`verify_email()` to use it; ship independently of steps 1-4 (touches a different part of the same file, no ordering dependency).
+6. Add the revoke-on-reuse check to `verify_email()`, after step 5 lands (it calls the same helper for issuance).
+7. No rollback complexity: the filter change is a pure query addition (revert by removing the clause), the cleanup task can be disabled by removing its `beat_schedule` entry, and the issuance consolidation / revoke-on-reuse check are both revertible by reverting their respective commits without any data migration.
 
 ## Open Questions
 

--- a/openspec/changes/user-session-fix/proposal.md
+++ b/openspec/changes/user-session-fix/proposal.md
@@ -2,10 +2,15 @@
 
 The "Active sessions" panel in account security settings lists sessions that are long expired, and every login leaves a permanent new row behind instead of superseding prior logins from the same device. Users see dozens of stale "Other device" entries they must manually revoke one by one, and cannot tell which sessions are actually still valid. This violates the intent of the existing `session-security` capability's "Active Session Visibility" requirement, which implies the list reflects genuinely active sessions.
 
+A code review of the companion email-verification change (`high-email-verification-fix`) surfaced three further session-lifecycle gaps in the same area of `services/users/app/api/auth_routes.py` that are cheapest to fix alongside this one: session issuance (refresh token → session row → access-token claims) is now independently duplicated across `login()`, `refresh_token()`, and `verify_email()`, risking claim drift between them; `verify_email()` re-fetches the customer record via a second DB query even though it's already loaded on the `user` object, an avoidable query on what is now effectively the account's first-login path; and `verify_email()` mints a brand-new session without revoking whichever session(s) were already active when the same endpoint is reused for the email-change/rectification flow, so old sessions accumulate with no cleanup path — the inverse problem of the stale-listing bug above, but on the issuance side instead of the display side. Two small frontend gaps in the same verification UI are included as opportunistic cleanup: the expired-link "Resend" action on `VerifyEmail.tsx` doesn't carry the typed email as router state the way Register/Login do, and `ConfirmEmail.tsx` duplicates its authenticated/unauthenticated JSX wrapper.
+
 ## What Changes
 
 - `GET /auth/sessions` filters out sessions past their `expires_at` in addition to `revoked`, so expired sessions no longer appear as "active." (Login itself is unchanged — one row per login is correct, since the panel intentionally supports multiple simultaneous device sessions.)
 - Add a scheduled cleanup task (mirroring the existing pattern in `services/worker/tasks/ai/cleanup_sessions.py`) that periodically deletes `user_sessions` rows past `expires_at`, so the table doesn't grow unbounded for users who never revisit the settings page to revoke old entries.
+- Consolidate session issuance in `auth_routes.py` behind one shared helper used by `login()`, `refresh_token()`, and `verify_email()`, and have it build claims from an already-loaded `user.customer` instead of `verify_email()`'s redundant second query.
+- `verify_email()` revokes the account's pre-existing active session(s) before issuing the new one whenever it's reused for the email-change/rectification flow (i.e. the account already had a session before this call), mirroring the existing revoke-other-sessions pattern in `change_password()`.
+- Frontend polish: `VerifyEmail.tsx`'s expired-link resend action carries `state={{ email }}`; `ConfirmEmail.tsx`'s duplicated authenticated/unauthenticated JSX wrapper is collapsed to one shared wrapper.
 
 ## Capabilities
 
@@ -13,11 +18,12 @@ The "Active sessions" panel in account security settings lists sessions that are
 (none)
 
 ### Modified Capabilities
-- `session-security`: "Active Session Visibility" requirement is clarified so the listed sessions are limited to those that are both non-revoked AND not expired; adds a new requirement that expired session records are purged rather than retained indefinitely.
+- `session-security`: "Active Session Visibility" requirement is clarified so the listed sessions are limited to those that are both non-revoked AND not expired; adds a new requirement that expired session records are purged rather than retained indefinitely; adds a new requirement that a pre-existing session is revoked when `/auth/verify-email` is reused to confirm an email change on an already-sessioned account.
 
 ## Impact
 
-- `services/users/app/api/auth_routes.py` (`list_sessions`)
+- `services/users/app/api/auth_routes.py` (`list_sessions`, `login`, `refresh_token`, `verify_email` — new shared `_issue_session` helper, revoke-on-reuse behavior)
 - `services/users/app/crud/sessions_curd.py` (`get_non_revoked_sessions_for_user`, new purge query)
 - `services/worker/tasks/` (new cleanup task) and its Celery beat schedule registration
-- No breaking API contract changes: `GET /auth/sessions` response shape is unchanged, only which rows are included.
+- `frontend-typescript/src/pages/VerifyEmail.tsx`, `frontend-typescript/src/pages/ConfirmEmail.tsx` (no behavior contract change, UI-only)
+- No breaking API contract changes: `GET /auth/sessions` response shape is unchanged, only which rows are included; `verify_email`'s response shape is unchanged, only its session-revocation side effect is new.

--- a/openspec/changes/user-session-fix/specs/session-security/spec.md
+++ b/openspec/changes/user-session-fix/specs/session-security/spec.md
@@ -13,6 +13,17 @@ The system SHALL allow an authenticated user to view their active sessions and r
 
 ## ADDED Requirements
 
+### Requirement: Session Superseded On Email Reverification
+When `/auth/verify-email` succeeds for an account that already has one or more non-revoked sessions at the time of the request, the system SHALL revoke those pre-existing sessions before issuing the new session. This covers the case where verification is reused to confirm an email-address change on an already-authenticated account, rather than a first-time registration verification.
+
+#### Scenario: Email-change confirmation revokes prior sessions
+- **WHEN** an already-verified user with an active session changes their email address and confirms it via `/auth/verify-email`
+- **THEN** their previously active session(s) are revoked and only the newly issued session remains valid
+
+#### Scenario: First-time verification has no prior sessions to revoke
+- **WHEN** a newly registered user verifies their email for the first time
+- **THEN** there are no pre-existing non-revoked sessions for the account, and the new session is issued without revoking anything
+
 ### Requirement: Expired Session Purge
 The system SHALL periodically delete session records whose expiration time has passed, so that expired sessions do not accumulate indefinitely in storage.
 

--- a/openspec/changes/user-session-fix/tasks.md
+++ b/openspec/changes/user-session-fix/tasks.md
@@ -16,3 +16,23 @@ One task group = one GitHub ticket = one PR, merged before the next group starts
 - [ ] 2.4 Add a unit test for the cleanup task's `_cleanup` function verifying it deletes rows with `expires_at` in the past and leaves non-expired rows (revoked or not) untouched.
 - [ ] 2.5 Manually verify: run the task against a local/dev DB with a manually-inserted expired session row, confirm it's deleted and non-expired rows remain.
 - [ ] 2.6 Run worker-service tests and lint clean; PR merged (`Closes` the ticket).
+
+## 3. Consolidate session issuance and remove verify_email's redundant query — independent of groups 1-2, may ship in any order
+
+- [ ] 3.1 Add a shared session-issuance helper in `services/users/app/api/auth_routes.py` (refresh token → `create_session` → access-token claim assembly, built from an already-loaded `user` object) and switch `login()` and `refresh_token()` to use it, preserving their existing claims/response shape exactly.
+- [ ] 3.2 Switch `verify_email()` to the same helper, passing the `user` returned by `mark_email_verified` — this removes its `_customer_role_claims(db, user.customer_id)` second DB query, since the helper reads `user.customer` directly like `login()` does.
+- [ ] 3.3 Add/update unit tests asserting `login`, `refresh_token`, and `verify_email` issue tokens with identical claim sets for equivalent users (role, customer_id, is_ngo/is_donor flags, email_verified).
+- [ ] 3.4 Run users-service tests and lint (flake8 --max-line-length=100) clean; PR merged (`Closes` the ticket).
+
+## 4. Revoke pre-existing sessions when verify-email is reused for email-change confirmation — depends on group 3 (shares the same handler)
+
+- [ ] 4.1 In `verify_email()`, before minting the new session, call `get_non_revoked_sessions_for_user(db, user.id)`; if it returns any sessions, revoke each via the existing `_revoke_session_everywhere` helper (same one `change_password()` uses) before issuing the new session.
+- [ ] 4.2 Add a unit test: a user with an active session confirms an email change via `/auth/verify-email`; assert the prior session is revoked (both in Postgres and via the Redis mark) and only the new one is valid.
+- [ ] 4.3 Add a unit test: a first-time (never-verified) account has no prior sessions, so verification proceeds without any revocation call.
+- [ ] 4.4 Run users-service tests and lint clean; PR merged (`Closes` the ticket).
+
+## 5. Frontend verification-flow polish — independent, may ship in any order
+
+- [ ] 5.1 `frontend-typescript/src/pages/VerifyEmail.tsx`: pass `state={{ email }}` on the expired-link "Resend confirmation email" link, matching the convention Register.tsx/Login.tsx already use for navigations to `/confirm-email`, so the one recovery path from an expired verification link carries the email forward.
+- [ ] 5.2 `frontend-typescript/src/pages/ConfirmEmail.tsx`: collapse the authenticated/unauthenticated JSX branches into one shared paragraph wrapper with only the differing action element (logout button vs. register-again link) varying.
+- [ ] 5.3 Run frontend lint/typecheck clean; PR merged (`Closes` the ticket).

--- a/services/ai/tests/test_email_verified_gate.py
+++ b/services/ai/tests/test_email_verified_gate.py
@@ -1,0 +1,40 @@
+"""session-security: an unverified token is rejected with 403 end-to-end,
+via a real TestClient/JWT (no `get_validated_user` override)."""
+
+from uuid import uuid4
+
+from fastapi.testclient import TestClient
+
+from main import app
+from shared.security.jwt_utils import create_access_token
+
+
+def _token(email_verified: bool) -> str:
+    return create_access_token(
+        {
+            "user_id": str(uuid4()),
+            "session_id": str(uuid4()),
+            "role": "superuser",
+            "customer_id": str(uuid4()),
+            "email_verified": email_verified,
+        }
+    )
+
+
+class TestAiSettingsEndpointRequiresVerifiedEmail:
+    def test_unverified_token_rejected_with_403(self):
+        client = TestClient(app)
+        resp = client.get(
+            "/api/v1/ai/settings",
+            headers={"Authorization": f"Bearer {_token(email_verified=False)}"},
+        )
+        assert resp.status_code == 403
+        assert resp.json()["detail"] == "email_not_verified"
+
+    def test_verified_token_is_not_blocked_by_the_verification_gate(self):
+        client = TestClient(app)
+        resp = client.get(
+            "/api/v1/ai/settings",
+            headers={"Authorization": f"Bearer {_token(email_verified=True)}"},
+        )
+        assert resp.status_code != 403

--- a/services/ai/tests/test_email_verified_gate.py
+++ b/services/ai/tests/test_email_verified_gate.py
@@ -3,9 +3,14 @@ via a real TestClient/JWT (no `get_validated_user` override)."""
 
 from uuid import uuid4
 
+import pytest
 from fastapi.testclient import TestClient
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
 from main import app
+from app.api.settings_routes import get_db
+from app.models.ai_provider import AIProvider
+from app.models.base import Base
 from shared.security.jwt_utils import create_access_token
 
 
@@ -21,6 +26,23 @@ def _token(email_verified: bool) -> str:
     )
 
 
+@pytest.fixture
+async def sessions_db():
+    # settings_routes.py declares its own module-local get_db (see
+    # project_user_routes_duplicate_get_db in memory for the sibling case) —
+    # this fixture exists only so
+    # test_verified_token_is_not_blocked_by_the_verification_gate doesn't
+    # need a real Postgres reachable at settings.ai_database_url, which isn't
+    # resolvable outside docker-compose.local.yml (or CI).
+    engine = create_async_engine("sqlite+aiosqlite://")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all, tables=[AIProvider.__table__])
+    maker = async_sessionmaker(engine, expire_on_commit=False)
+    async with maker() as session:
+        yield session
+    await engine.dispose()
+
+
 class TestAiSettingsEndpointRequiresVerifiedEmail:
     def test_unverified_token_rejected_with_403(self):
         client = TestClient(app)
@@ -31,10 +53,19 @@ class TestAiSettingsEndpointRequiresVerifiedEmail:
         assert resp.status_code == 403
         assert resp.json()["detail"] == "email_not_verified"
 
-    def test_verified_token_is_not_blocked_by_the_verification_gate(self):
-        client = TestClient(app)
-        resp = client.get(
-            "/api/v1/ai/settings",
-            headers={"Authorization": f"Bearer {_token(email_verified=True)}"},
-        )
+    @pytest.mark.anyio
+    async def test_verified_token_is_not_blocked_by_the_verification_gate(self, sessions_db):
+        # get_validated_user is deliberately left unmocked (see module
+        # docstring) so the gate itself runs for real; only get_db is
+        # overridden, so this stays a real end-to-end check of the
+        # verification gate without needing a live database.
+        app.dependency_overrides[get_db] = lambda: sessions_db
+        try:
+            client = TestClient(app)
+            resp = client.get(
+                "/api/v1/ai/settings",
+                headers={"Authorization": f"Bearer {_token(email_verified=True)}"},
+            )
+        finally:
+            del app.dependency_overrides[get_db]
         assert resp.status_code != 403

--- a/services/budget/tests/test_email_verified_gate.py
+++ b/services/budget/tests/test_email_verified_gate.py
@@ -3,9 +3,16 @@ via a real TestClient/JWT (no `get_validated_user` override)."""
 
 from uuid import uuid4
 
+import pytest
 from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
 
 from main import app
+from app.api.budget_routes import get_db
+from app.models.base import Base
+from app.models.budget import BudgetModel
 from shared.security.jwt_utils import create_access_token
 
 
@@ -21,6 +28,25 @@ def _token(email_verified: bool) -> str:
     )
 
 
+@pytest.fixture
+def sessions_db():
+    # budget_routes.py declares its own module-local get_db (see
+    # project_user_routes_duplicate_get_db in memory for the sibling case) —
+    # conftest.py's `db` fixture covers the right table but uses a plain
+    # in-memory engine with no StaticPool, which breaks here: TestClient
+    # runs the ASGI app's async route on a different thread than this
+    # fixture, and sqlite3 forbids cross-thread use of the same connection
+    # (see users-service's sessions_db fixture, the same fix for the same
+    # bug in that service's version of this test).
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine, tables=[BudgetModel.__table__])
+    return sessionmaker(bind=engine)()
+
+
 class TestBudgetsEndpointRequiresVerifiedEmail:
     def test_unverified_token_rejected_with_403(self):
         client = TestClient(app)
@@ -31,10 +57,18 @@ class TestBudgetsEndpointRequiresVerifiedEmail:
         assert resp.status_code == 403
         assert resp.json()["detail"] == "email_not_verified"
 
-    def test_verified_token_is_not_blocked_by_the_verification_gate(self):
-        client = TestClient(app)
-        resp = client.get(
-            "/api/v1/budgets/",
-            headers={"Authorization": f"Bearer {_token(email_verified=True)}"},
-        )
+    def test_verified_token_is_not_blocked_by_the_verification_gate(self, sessions_db):
+        # get_validated_user is deliberately left unmocked (see module
+        # docstring) so the gate itself runs for real; only get_db is
+        # overridden, so this stays a real end-to-end check of the
+        # verification gate without needing a live database.
+        app.dependency_overrides[get_db] = lambda: sessions_db
+        try:
+            client = TestClient(app)
+            resp = client.get(
+                "/api/v1/budgets/",
+                headers={"Authorization": f"Bearer {_token(email_verified=True)}"},
+            )
+        finally:
+            del app.dependency_overrides[get_db]
         assert resp.status_code != 403

--- a/services/budget/tests/test_email_verified_gate.py
+++ b/services/budget/tests/test_email_verified_gate.py
@@ -1,0 +1,40 @@
+"""session-security: an unverified token is rejected with 403 end-to-end,
+via a real TestClient/JWT (no `get_validated_user` override)."""
+
+from uuid import uuid4
+
+from fastapi.testclient import TestClient
+
+from main import app
+from shared.security.jwt_utils import create_access_token
+
+
+def _token(email_verified: bool) -> str:
+    return create_access_token(
+        {
+            "user_id": str(uuid4()),
+            "session_id": str(uuid4()),
+            "role": "user",
+            "customer_id": str(uuid4()),
+            "email_verified": email_verified,
+        }
+    )
+
+
+class TestBudgetsEndpointRequiresVerifiedEmail:
+    def test_unverified_token_rejected_with_403(self):
+        client = TestClient(app)
+        resp = client.get(
+            "/api/v1/budgets/",
+            headers={"Authorization": f"Bearer {_token(email_verified=False)}"},
+        )
+        assert resp.status_code == 403
+        assert resp.json()["detail"] == "email_not_verified"
+
+    def test_verified_token_is_not_blocked_by_the_verification_gate(self):
+        client = TestClient(app)
+        resp = client.get(
+            "/api/v1/budgets/",
+            headers={"Authorization": f"Bearer {_token(email_verified=True)}"},
+        )
+        assert resp.status_code != 403

--- a/services/users/app/api/ai_settings_routes.py
+++ b/services/users/app/api/ai_settings_routes.py
@@ -3,7 +3,7 @@ from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import JSONResponse
 
 from app.core.config import settings
-from app.utils.security import get_current_user
+from shared.security.dependencies import get_validated_user
 
 router = APIRouter(prefix="/users/me")
 
@@ -22,7 +22,7 @@ def _forward_error(response: httpx.Response) -> None:
 
 
 @router.get("/ai-settings")
-async def get_ai_settings(current_user: dict = Depends(get_current_user)):
+async def get_ai_settings(current_user: dict = Depends(get_validated_user)):
     async with httpx.AsyncClient() as client:
         response = await client.get(
             f"{settings.AI_SERVICE_URL}/ai/settings",
@@ -33,7 +33,7 @@ async def get_ai_settings(current_user: dict = Depends(get_current_user)):
 
 
 @router.put("/ai-settings")
-async def save_ai_settings(request: Request, current_user: dict = Depends(get_current_user)):
+async def save_ai_settings(request: Request, current_user: dict = Depends(get_validated_user)):
     body = await request.json()
     async with httpx.AsyncClient() as client:
         response = await client.put(
@@ -46,7 +46,7 @@ async def save_ai_settings(request: Request, current_user: dict = Depends(get_cu
 
 
 @router.delete("/ai-settings/{provider}/key")
-async def clear_ai_key(provider: str, current_user: dict = Depends(get_current_user)):
+async def clear_ai_key(provider: str, current_user: dict = Depends(get_validated_user)):
     async with httpx.AsyncClient() as client:
         response = await client.delete(
             f"{settings.AI_SERVICE_URL}/ai/settings/{provider}/key",

--- a/services/users/app/api/auth_routes.py
+++ b/services/users/app/api/auth_routes.py
@@ -6,11 +6,13 @@ from zoneinfo import ZoneInfo
 
 from app.schemas.auth_schema import (
     RegisterRequest,
+    RegisterResponse,
     LoginRequest,
     TokenResponse,
     ChangePasswordRequest,
     VerifyEmailRequest,
     VerifyEmailResponse,
+    ResendVerificationRequest,
     ResendVerificationResponse,
     ImpersonateRequest,
     ImpersonateResponse,
@@ -104,7 +106,7 @@ def _customer_role_claims(db: Session, customer_id) -> dict:
     return _role_flags(customer)
 
 
-@router.post("/register", response_model=TokenResponse)
+@router.post("/register", response_model=RegisterResponse)
 async def register_endpoint(
     req: RegisterRequest,
     request: Request = None,  # type: ignore[assignment]
@@ -145,25 +147,11 @@ async def register_endpoint(
         # can self-serve via /auth/resend-verification either way.
         logger.exception("verification_email_enqueue_failed", user_id=str(user.id))
 
-    refresh_token = create_refresh_token()
-    session = create_session(
-        session=db,
-        user_id=user.id,
-        refresh_token_hash=refresh_token,
+    # No session/token here — unauthenticated until verify-email succeeds.
+    return RegisterResponse(
+        message="Check your email to confirm your account.",
+        email=user.email,
     )
-
-    token = create_access_token(
-        {
-            "user_id": user.id,
-            "session_id": session.id,
-            "role": user.role,
-            "customer_id": user.customer_id,
-            **_customer_role_claims(db, user.customer_id),
-            **_email_verified_claim(user),
-        }
-    )
-
-    return TokenResponse(access_token=token, refresh_token=refresh_token, status=user.status)
 
 
 @router.post("/auth/login", response_model=TokenResponse)
@@ -192,6 +180,10 @@ def login(
         raise HTTPException(status_code=401, detail="Invalid credentials")
 
     clear_failed_attempts(req.email)
+
+    if not user.email_verified:
+        # Valid credentials, but no session until the account is verified.
+        raise HTTPException(status_code=403, detail="email_not_verified")
 
     refresh_token = create_refresh_token()
 
@@ -285,28 +277,60 @@ def verify_email(
         raise HTTPException(status_code=400, detail="Invalid or expired verification token")
 
     clear_failed_attempts(req.email, bucket="verify_email")
-    mark_email_verified(db, user)
-    return VerifyEmailResponse(email_verified=True)
+    user = mark_email_verified(db, user)
+
+    # This is the account's first session — verification is the login moment.
+    refresh_token = create_refresh_token()
+    session = create_session(
+        session=db,
+        user_id=user.id,
+        refresh_token_hash=refresh_token,
+    )
+    token = create_access_token(
+        {
+            "user_id": user.id,
+            "session_id": session.id,
+            "role": user.role,
+            "customer_id": user.customer_id,
+            **_customer_role_claims(db, user.customer_id),
+            **_email_verified_claim(user),
+        }
+    )
+
+    return VerifyEmailResponse(
+        email_verified=True,
+        access_token=token,
+        refresh_token=refresh_token,
+        status=user.status,
+    )
 
 
 @router.post("/auth/resend-verification", response_model=ResendVerificationResponse)
 def resend_verification(
-    current_user: dict = Depends(get_validated_user), db: Session = Depends(get_db)
+    req: ResendVerificationRequest,
+    request: Request = None,  # type: ignore[assignment]
+    db: Session = Depends(get_db),
 ):
-    user = get_user(db, current_user["user_id"])
-    if not user:
-        raise HTTPException(status_code=404, detail="User not found")
+    """Anonymous and enumeration-safe: same response regardless of account state."""
+    client_ip = request.client.host if request is not None and request.client else "unknown"
+    if is_locked_out(req.email, client_ip, bucket="resend_verification"):
+        raise HTTPException(
+            status_code=429,
+            detail="Too many resend attempts. Try again later.",
+        )
+    record_failed_attempt(req.email, client_ip, bucket="resend_verification")
 
-    if user.email_verified:
-        return ResendVerificationResponse(sent=False)
+    debug_token = None
+    user = get_user_by_email(db, req.email)
+    if user and not user.email_verified:
+        raw_token = set_email_verification_token(db, user)
+        try:
+            enqueue_verification_email(user.email, raw_token, user.first_name)
+        except Exception:
+            logger.exception("verification_email_enqueue_failed", user_id=str(user.id))
+        if settings.EXPOSE_VERIFICATION_TOKEN_FOR_TESTS:
+            debug_token = raw_token
 
-    raw_token = set_email_verification_token(db, user)
-    try:
-        enqueue_verification_email(user.email, raw_token, user.first_name)
-    except Exception:
-        logger.exception("verification_email_enqueue_failed", user_id=str(user.id))
-
-    debug_token = raw_token if settings.EXPOSE_VERIFICATION_TOKEN_FOR_TESTS else None
     return ResendVerificationResponse(sent=True, debug_token=debug_token)
 
 

--- a/services/users/app/api/customer_routes.py
+++ b/services/users/app/api/customer_routes.py
@@ -13,7 +13,6 @@ from app.services.admin_management_services import (
     get_company_service,
     update_company_service,
 )
-from app.utils.security import get_current_user
 from shared.security.dependencies import get_validated_user
 from uuid import UUID
 
@@ -25,7 +24,7 @@ def list_customers(
     is_ngo: bool | None = None,
     search: str | None = None,
     db: Session = Depends(get_db),
-    current_user: dict = Depends(get_current_user),
+    valid_user: dict = Depends(get_validated_user),
 ):
     return get_customers(session=db, is_ngo=is_ngo, search=search)
 
@@ -34,7 +33,7 @@ def list_customers(
 def create_customer_endpoint(
     customer: Customer,
     db: Session = Depends(get_db),
-    current_user: dict = Depends(get_current_user),
+    valid_user: dict = Depends(get_validated_user),
 ):
     db_customer = create_customer(
         session=db,

--- a/services/users/app/api/user_routes.py
+++ b/services/users/app/api/user_routes.py
@@ -16,7 +16,6 @@ from app.schemas.admin_management_schema import (
 from app.models.user import UserModel
 from app.models.customer import CustomerModel
 from app.db.session import SessionLocal
-from app.utils.security import get_current_user
 from app.crud.user_crud import (
     get_users_query,
     is_superuser,
@@ -124,11 +123,11 @@ async def update_user_endpoint(
     user_id: UUID,
     user_update: UserUpdate,
     db: Session = Depends(get_db),
-    current_user=Depends(get_current_user),
+    current_user: dict = Depends(get_validated_user),
 ):
     is_current_user_superuser = is_superuser(db, current_user["user_id"])
 
-    if current_user["user_id"] != user_id and not is_current_user_superuser:
+    if str(current_user["user_id"]) != str(user_id) and not is_current_user_superuser:
         raise HTTPException(status_code=403, detail="Not authorized to update this user")
 
     db_user = get_user(db, user_id)

--- a/services/users/app/schemas/auth_schema.py
+++ b/services/users/app/schemas/auth_schema.py
@@ -1,9 +1,10 @@
-from shared.schemas.auth_schema import RegisterRequest  # noqa: F401
+from shared.schemas.auth_schema import RegisterRequest, RegisterResponse  # noqa: F401
 from shared.schemas.auth_schema import LoginRequest, TokenResponse  # noqa: F401
 from shared.schemas.auth_schema import ChangePasswordRequest  # noqa: F401
 from shared.schemas.auth_schema import ImpersonateRequest, ImpersonateResponse  # noqa: F401
 from shared.schemas.auth_schema import (  # noqa: F401
     VerifyEmailRequest,
     VerifyEmailResponse,
+    ResendVerificationRequest,
     ResendVerificationResponse,
 )

--- a/services/users/maintenance/revoke_unverified_sessions.py
+++ b/services/users/maintenance/revoke_unverified_sessions.py
@@ -4,8 +4,8 @@ Run once, from the users service, after deploying this change:
     python -m maintenance.revoke_unverified_sessions
 """
 
-from app.crud.sessions_curd import revoke_all_sessions_for_user
 from app.db.session import SessionLocal
+from app.models.session import SessionModel
 from app.models.user import UserModel
 from app.utils.security import REFRESH_TOKEN_EXPIRE_DAYS
 from shared.security.session_revocation import mark_session_revoked
@@ -13,20 +13,26 @@ from shared.security.session_revocation import mark_session_revoked
 
 def revoke_unverified_users_sessions() -> int:
     db = SessionLocal()
-    revoked_count = 0
     try:
-        unverified_user_ids = [
-            user_id
-            for (user_id,) in db.query(UserModel.id)
-            .filter(UserModel.email_verified.is_(False))
+        session_ids = [
+            session_id
+            for (session_id,) in db.query(SessionModel.id)
+            .join(UserModel, UserModel.id == SessionModel.user_id)
+            .filter(UserModel.email_verified.is_(False), SessionModel.revoked.is_(False))
             .all()
         ]
-        for user_id in unverified_user_ids:
-            sessions = revoke_all_sessions_for_user(db, user_id)
-            for s in sessions:
-                mark_session_revoked(str(s.id), ttl_seconds=REFRESH_TOKEN_EXPIRE_DAYS * 24 * 3600)
-                revoked_count += 1
-        return revoked_count
+        if not session_ids:
+            return 0
+
+        db.query(SessionModel).filter(SessionModel.id.in_(session_ids)).update(
+            {"revoked": True}, synchronize_session=False
+        )
+        db.commit()
+
+        for session_id in session_ids:
+            mark_session_revoked(str(session_id), ttl_seconds=REFRESH_TOKEN_EXPIRE_DAYS * 24 * 3600)
+
+        return len(session_ids)
     finally:
         db.close()
 

--- a/services/users/maintenance/revoke_unverified_sessions.py
+++ b/services/users/maintenance/revoke_unverified_sessions.py
@@ -1,0 +1,36 @@
+"""One-time rollout: revoke every session belonging to an unverified user.
+
+Run once, from the users service, after deploying this change:
+    python -m maintenance.revoke_unverified_sessions
+"""
+
+from app.crud.sessions_curd import revoke_all_sessions_for_user
+from app.db.session import SessionLocal
+from app.models.user import UserModel
+from app.utils.security import REFRESH_TOKEN_EXPIRE_DAYS
+from shared.security.session_revocation import mark_session_revoked
+
+
+def revoke_unverified_users_sessions() -> int:
+    db = SessionLocal()
+    revoked_count = 0
+    try:
+        unverified_user_ids = [
+            user_id
+            for (user_id,) in db.query(UserModel.id)
+            .filter(UserModel.email_verified.is_(False))
+            .all()
+        ]
+        for user_id in unverified_user_ids:
+            sessions = revoke_all_sessions_for_user(db, user_id)
+            for s in sessions:
+                mark_session_revoked(str(s.id), ttl_seconds=REFRESH_TOKEN_EXPIRE_DAYS * 24 * 3600)
+                revoked_count += 1
+        return revoked_count
+    finally:
+        db.close()
+
+
+if __name__ == "__main__":
+    count = revoke_unverified_users_sessions()
+    print(f"Revoked {count} session(s) belonging to unverified users.")

--- a/services/users/tests/test_auth_gdpr_routes.py
+++ b/services/users/tests/test_auth_gdpr_routes.py
@@ -59,7 +59,7 @@ class TestLoginLockout:
         mock_record.assert_called_once()
 
     def test_successful_login_clears_failed_attempts(self):
-        user = UserModelFactory.build(customer_id=None)
+        user = UserModelFactory.build(customer_id=None, email_verified=True)
         user.customer = None
         with (
             patch("app.api.auth_routes.is_locked_out", return_value=False),
@@ -86,6 +86,41 @@ class TestLoginLockout:
             with pytest.raises(HTTPException) as exc_info:
                 login(LoginRequest(email=user.email, password="whatever"), db=MagicMock())
         assert exc_info.value.status_code == 401
+
+
+class TestLoginGatedOnVerification:
+    """Correct credentials alone no longer issue a session for an unverified account."""
+
+    def test_unverified_account_gets_no_session(self):
+        user = UserModelFactory.build(customer_id=None, email_verified=False)
+        user.customer = None
+        with (
+            patch("app.api.auth_routes.is_locked_out", return_value=False),
+            patch("app.api.auth_routes.get_user_by_email", return_value=user),
+            patch("app.api.auth_routes.verify_password", return_value=True),
+            patch("app.api.auth_routes.create_session") as mock_create_session,
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                login(LoginRequest(email=user.email, password="pw"), db=MagicMock())
+        assert exc_info.value.status_code == 403
+        assert exc_info.value.detail == "email_not_verified"
+        mock_create_session.assert_not_called()
+
+    def test_verified_account_logs_in_as_before(self):
+        user = UserModelFactory.build(customer_id=None, email_verified=True)
+        user.customer = None
+        with (
+            patch("app.api.auth_routes.is_locked_out", return_value=False),
+            patch("app.api.auth_routes.get_user_by_email", return_value=user),
+            patch("app.api.auth_routes.verify_password", return_value=True),
+            patch(
+                "app.api.auth_routes.create_session",
+                return_value=SimpleNamespace(id=str(uuid4())),
+            ),
+        ):
+            resp = login(LoginRequest(email=user.email, password="pw"), db=MagicMock())
+        assert resp.access_token
+        assert decode_access_token(resp.access_token)["email_verified"] is True
 
 
 class TestVerifyEmailLockout:
@@ -117,13 +152,19 @@ class TestVerifyEmailLockout:
 
     def test_successful_verification_clears_failed_attempts(self):
         user = UserModelFactory.build(
+            customer_id=None,
             email_verification_expires_at=datetime.now(timezone.utc).replace(tzinfo=None)
-            + timedelta(hours=1)
+            + timedelta(hours=1),
         )
         with (
             patch("app.api.auth_routes.is_locked_out", return_value=False),
             patch("app.api.auth_routes.get_user_by_verification_token", return_value=user),
-            patch("app.api.auth_routes.mark_email_verified"),
+            patch("app.api.auth_routes.mark_email_verified", return_value=user),
+            patch(
+                "app.api.auth_routes.create_session",
+                return_value=SimpleNamespace(id=str(uuid4())),
+            ),
+            patch("app.api.auth_routes.get_customer", MagicMock()),
             patch("app.api.auth_routes.clear_failed_attempts") as mock_clear,
         ):
             verify_email(VerifyEmailRequest(email=user.email, token="x"), db=MagicMock())
@@ -174,39 +215,52 @@ def _register(role_in_payload=None, **overrides):
 
 
 class TestRegisterCannotSetPrivilegedRole:
-    """Closes the pentest-confirmed chain: register as role=superuser, then
-    use the issued token to self-authorize /auth/impersonate."""
+    """Register as superuser, then check the role verify-email's session issues."""
 
-    def _register_and_issue_token(self, role_in_payload):
+    def _register_then_verify(self, role_in_payload):
         created_user = UserModelFactory.build(customer_id=None, role="user")
         with (
             patch(
                 "app.api.auth_routes.create_user", AsyncMock(return_value=created_user)
             ) as mock_create_user,
+            patch("app.api.auth_routes.set_email_verification_token", return_value="raw-token"),
+            patch("app.api.auth_routes.enqueue_verification_email"),
+        ):
+            asyncio.run(
+                register_endpoint(_register(role_in_payload=role_in_payload), db=object())
+            )
+
+        created_user.email_verification_expires_at = datetime.now(timezone.utc).replace(
+            tzinfo=None
+        ) + timedelta(hours=1)
+        with (
+            patch(
+                "app.api.auth_routes.get_user_by_verification_token", return_value=created_user
+            ),
+            patch("app.api.auth_routes.mark_email_verified", return_value=created_user),
             patch(
                 "app.api.auth_routes.create_session",
                 return_value=SimpleNamespace(id=str(uuid4())),
             ),
             patch("app.api.auth_routes.get_customer", MagicMock()),
-            patch("app.api.auth_routes.set_email_verification_token", return_value="raw-token"),
-            patch("app.api.auth_routes.enqueue_verification_email"),
         ):
-            resp = asyncio.run(
-                register_endpoint(_register(role_in_payload=role_in_payload), db=object())
+            verify_resp = verify_email(
+                VerifyEmailRequest(email=created_user.email, token="raw-token"), db=object()
             )
-        return resp, mock_create_user
+        return created_user, verify_resp, mock_create_user
 
     def test_superuser_in_payload_is_dropped_before_create_user(self):
-        _, mock_create_user = self._register_and_issue_token("superuser")
+        _, _, mock_create_user = self._register_then_verify("superuser")
         assert "role" not in mock_create_user.call_args.kwargs
 
-    def test_admin_in_payload_still_issues_a_user_role_token(self):
-        resp, _ = self._register_and_issue_token("admin")
-        assert decode_access_token(resp.access_token)["role"] == "user"
+    def test_admin_in_payload_still_persists_and_issues_a_user_role(self):
+        created_user, verify_resp, _ = self._register_then_verify("admin")
+        assert created_user.role == "user"
+        assert decode_access_token(verify_resp.access_token)["role"] == "user"
 
     def test_registered_role_user_cannot_self_authorize_impersonation(self):
-        resp, _ = self._register_and_issue_token("superuser")
-        claims = decode_access_token(resp.access_token)
+        _, verify_resp, _ = self._register_then_verify("superuser")
+        claims = decode_access_token(verify_resp.access_token)
         actor = {"user_id": claims["user_id"], "role": claims["role"]}
 
         with pytest.raises(HTTPException) as exc_info:

--- a/services/users/tests/test_auth_routes.py
+++ b/services/users/tests/test_auth_routes.py
@@ -26,6 +26,7 @@ from app.api.auth_routes import (
 from app.schemas.auth_schema import (
     LoginRequest,
     RegisterRequest,
+    ResendVerificationRequest,
     VerifyEmailRequest,
 )
 from app.utils.security import decode_access_token
@@ -54,28 +55,28 @@ class TestLoginRoleClaims:
         return resp
 
     def test_donor_customer(self):
-        user = UserModelFactory.build(customer_id=str(uuid4()))
+        user = UserModelFactory.build(customer_id=str(uuid4()), email_verified=True)
         user.customer = CustomerFactory.build(is_donor=True)
         claims = _claims(self._login(user))
         assert claims["is_donor"] is True
         assert claims["is_ngo"] is False
 
     def test_ngo_customer(self):
-        user = UserModelFactory.build(customer_id=str(uuid4()))
+        user = UserModelFactory.build(customer_id=str(uuid4()), email_verified=True)
         user.customer = CustomerFactory.build(is_ngo=True)
         claims = _claims(self._login(user))
         assert claims["is_ngo"] is True
         assert claims["is_donor"] is False
 
     def test_customer_both_ngo_and_donor(self):
-        user = UserModelFactory.build(customer_id=str(uuid4()))
+        user = UserModelFactory.build(customer_id=str(uuid4()), email_verified=True)
         user.customer = CustomerFactory.build(is_ngo=True, is_donor=True)
         claims = _claims(self._login(user))
         assert claims["is_ngo"] is True
         assert claims["is_donor"] is True
 
     def test_user_with_no_customer_id(self):
-        user = UserModelFactory.build(customer_id=None)
+        user = UserModelFactory.build(customer_id=None, email_verified=True)
         user.customer = None
         claims = _claims(self._login(user))
         assert claims["is_ngo"] is False
@@ -127,41 +128,33 @@ class TestRefreshRoleClaims:
         assert claims["is_donor"] is False
 
 
-class TestRegisterRoleClaims:
-    """register_endpoint has no already-loaded customer to reuse (a
-    just-inserted UserModel isn't eager-loaded), so this is the one call
-    site that still queries get_customer via _customer_role_claims."""
+class TestVerifyEmailRoleClaims:
+    """verify-email now issues the account's first session, not register."""
 
-    def _register(self, created_user, db, get_customer_mock):
+    def _verify(self, user, db, get_customer_mock):
+        user.email_verification_expires_at = datetime.now(timezone.utc).replace(
+            tzinfo=None
+        ) + timedelta(hours=1)
         with (
-            patch("app.api.auth_routes.create_user", AsyncMock(return_value=created_user)),
+            patch("app.api.auth_routes.get_user_by_verification_token", return_value=user),
+            patch("app.api.auth_routes.mark_email_verified", return_value=user),
             patch(
                 "app.api.auth_routes.create_session",
                 return_value=SimpleNamespace(id=str(uuid4())),
             ),
             patch("app.api.auth_routes.get_customer", get_customer_mock) as mock_get_customer,
-            patch("app.api.auth_routes.set_email_verification_token", return_value="raw-token"),
-            patch("app.api.auth_routes.enqueue_verification_email"),
         ):
-            resp = asyncio.run(
-                register_endpoint(
-                    RegisterRequest(
-                        email="new@example.com",
-                        password="Correct-Horse-1",
-                        customer_id=created_user.customer_id,
-                        consent_data_processing=True,
-                    ),
-                    db=db,
-                )
+            resp = verify_email(
+                VerifyEmailRequest(email=user.email, token="raw-token"), db=db
             )
         return resp, mock_get_customer
 
     def test_donor_customer(self):
         customer_id = str(uuid4())
-        created_user = UserModelFactory.build(customer_id=customer_id)
+        user = UserModelFactory.build(customer_id=customer_id)
         db = object()
-        resp, mock_get_customer = self._register(
-            created_user, db, MagicMock(return_value=CustomerFactory.build(is_donor=True))
+        resp, mock_get_customer = self._verify(
+            user, db, MagicMock(return_value=CustomerFactory.build(is_donor=True))
         )
         claims = _claims(resp)
         assert claims["is_donor"] is True
@@ -169,8 +162,8 @@ class TestRegisterRoleClaims:
         mock_get_customer.assert_called_once_with(db, customer_id)
 
     def test_user_with_no_customer_id(self):
-        created_user = UserModelFactory.build(customer_id=None)
-        resp, mock_get_customer = self._register(created_user, object(), MagicMock())
+        user = UserModelFactory.build(customer_id=None)
+        resp, mock_get_customer = self._verify(user, object(), MagicMock())
         claims = _claims(resp)
         assert claims["is_ngo"] is False
         assert claims["is_donor"] is False
@@ -181,9 +174,9 @@ class TestRegisterRoleClaims:
         customer, orphaned FK) — degrades to false/false, same as no
         customer_id at all."""
         customer_id = str(uuid4())
-        created_user = UserModelFactory.build(customer_id=customer_id)
-        resp, mock_get_customer = self._register(
-            created_user, object(), MagicMock(return_value=None)
+        user = UserModelFactory.build(customer_id=customer_id)
+        resp, mock_get_customer = self._verify(
+            user, object(), MagicMock(return_value=None)
         )
         claims = _claims(resp)
         assert claims["is_ngo"] is False
@@ -192,12 +185,12 @@ class TestRegisterRoleClaims:
 
     def test_customer_lookup_failure_still_issues_token(self):
         """A transient get_customer failure must not turn an
-        already-committed user+session into an unhandled 500 — see
+        already-committed verification+session into an unhandled 500 — see
         _customer_role_claims's docstring."""
         customer_id = str(uuid4())
-        created_user = UserModelFactory.build(customer_id=customer_id)
-        resp, _ = self._register(
-            created_user, object(), MagicMock(side_effect=RuntimeError("db blip"))
+        user = UserModelFactory.build(customer_id=customer_id)
+        resp, _ = self._verify(
+            user, object(), MagicMock(side_effect=RuntimeError("db blip"))
         )
         claims = _claims(resp)
         assert claims["is_ngo"] is False
@@ -205,33 +198,30 @@ class TestRegisterRoleClaims:
 
 
 class TestEmailVerifiedClaim:
-    """email_verified is merged into the JWT at register/login/refresh,
-    alongside is_ngo/is_donor — reflects the user row's current value, not
-    a hardcoded default."""
+    """email_verified is merged into the JWT at login/refresh/verify-email."""
 
-    def test_register_reflects_false(self):
-        created_user = UserModelFactory.build(customer_id=None, email_verified=False)
+    def test_verify_email_reflects_true(self):
+        user = UserModelFactory.build(
+            customer_id=None,
+            email_verified=False,
+            email_verification_expires_at=datetime.now(timezone.utc).replace(tzinfo=None)
+            + timedelta(hours=1),
+        )
         with (
-            patch("app.api.auth_routes.create_user", AsyncMock(return_value=created_user)),
+            patch("app.api.auth_routes.get_user_by_verification_token", return_value=user),
+            patch("app.api.auth_routes.mark_email_verified") as mock_mark,
             patch(
                 "app.api.auth_routes.create_session",
                 return_value=SimpleNamespace(id=str(uuid4())),
             ),
             patch("app.api.auth_routes.get_customer", MagicMock()),
-            patch("app.api.auth_routes.set_email_verification_token", return_value="raw-token"),
-            patch("app.api.auth_routes.enqueue_verification_email"),
         ):
-            resp = asyncio.run(
-                register_endpoint(
-                    RegisterRequest(
-                        email="new@example.com",
-                        password="Correct-Horse-1",
-                        consent_data_processing=True,
-                    ),
-                    db=object(),
-                )
+            user.email_verified = True
+            mock_mark.return_value = user
+            resp = verify_email(
+                VerifyEmailRequest(email=user.email, token="raw-token"), db=object()
             )
-        assert _claims(resp)["email_verified"] is False
+        assert _claims(resp)["email_verified"] is True
 
     def test_login_reflects_true(self):
         user = UserModelFactory.build(customer_id=None, email_verified=True)
@@ -268,16 +258,34 @@ class TestEmailVerifiedClaim:
         assert _claims(resp)["email_verified"] is True
 
 
+class TestRegistrationIssuesNoSession:
+    def test_response_carries_no_token_or_session_fields(self):
+        created_user = UserModelFactory.build(customer_id=None)
+        with (
+            patch("app.api.auth_routes.create_user", AsyncMock(return_value=created_user)),
+            patch("app.api.auth_routes.set_email_verification_token", return_value="raw-token"),
+            patch("app.api.auth_routes.enqueue_verification_email"),
+        ):
+            resp = asyncio.run(
+                register_endpoint(
+                    RegisterRequest(
+                        email="new@example.com",
+                        password="Correct-Horse-1",
+                        consent_data_processing=True,
+                    ),
+                    db=object(),
+                )
+            )
+        assert not hasattr(resp, "access_token")
+        assert not hasattr(resp, "refresh_token")
+        assert resp.email == created_user.email
+
+
 class TestRegisterEnqueuesVerificationEmail:
     def test_stores_token_and_enqueues_send(self):
         created_user = UserModelFactory.build(customer_id=None)
         with (
             patch("app.api.auth_routes.create_user", AsyncMock(return_value=created_user)),
-            patch(
-                "app.api.auth_routes.create_session",
-                return_value=SimpleNamespace(id=str(uuid4())),
-            ),
-            patch("app.api.auth_routes.get_customer", MagicMock()),
             patch(
                 "app.api.auth_routes.set_email_verification_token", return_value="raw-token"
             ) as mock_set_token,
@@ -304,11 +312,6 @@ class TestRegisterEnqueuesVerificationEmail:
         created_user = UserModelFactory.build(customer_id=None)
         with (
             patch("app.api.auth_routes.create_user", AsyncMock(return_value=created_user)),
-            patch(
-                "app.api.auth_routes.create_session",
-                return_value=SimpleNamespace(id=str(uuid4())),
-            ),
-            patch("app.api.auth_routes.get_customer", MagicMock()),
             patch("app.api.auth_routes.set_email_verification_token", return_value="raw-token"),
             patch(
                 "app.api.auth_routes.enqueue_verification_email",
@@ -325,27 +328,38 @@ class TestRegisterEnqueuesVerificationEmail:
                     db=object(),
                 )
             )
-        assert resp.access_token
+        assert resp.email == created_user.email
 
 
 class TestVerifyEmail:
-    def test_valid_unexpired_token_verifies_account(self):
+    def test_valid_unexpired_token_verifies_account_and_issues_a_session(self):
         user = UserModelFactory.build(
+            customer_id=None,
             email_verification_expires_at=datetime.now(timezone.utc).replace(tzinfo=None)
-            + timedelta(hours=1)
+            + timedelta(hours=1),
         )
         db = object()
         with (
             patch(
                 "app.api.auth_routes.get_user_by_verification_token", return_value=user
             ) as mock_lookup,
-            patch("app.api.auth_routes.mark_email_verified") as mock_mark,
+            patch("app.api.auth_routes.mark_email_verified", return_value=user) as mock_mark,
+            patch(
+                "app.api.auth_routes.create_session",
+                return_value=SimpleNamespace(id=str(uuid4())),
+            ) as mock_create_session,
+            patch("app.api.auth_routes.get_customer", MagicMock()),
         ):
             resp = verify_email(VerifyEmailRequest(email=user.email, token="raw-token"), db=db)
         assert resp.email_verified is True
+        assert resp.access_token
+        assert resp.refresh_token
         mock_lookup.assert_called_once_with(db, user.email, "raw-token")
         mock_mark.assert_called_once()
         assert mock_mark.call_args[0][1] is user
+        mock_create_session.assert_called_once_with(
+            session=db, user_id=user.id, refresh_token_hash=resp.refresh_token
+        )
 
     def test_expired_token_is_rejected(self):
         user = UserModelFactory.build(
@@ -374,31 +388,65 @@ class TestVerifyEmail:
 
 
 class TestResendVerification:
+    """Anonymous and enumeration-safe: every branch returns `sent=True`."""
+
     def test_unverified_account_gets_new_token_and_send(self):
         user = UserModelFactory.build(email_verified=False)
         with (
-            patch("app.api.auth_routes.get_user", return_value=user),
+            patch("app.api.auth_routes.is_locked_out", return_value=False),
+            patch("app.api.auth_routes.record_failed_attempt"),
+            patch("app.api.auth_routes.get_user_by_email", return_value=user),
             patch(
                 "app.api.auth_routes.set_email_verification_token", return_value="raw-token"
             ) as mock_set_token,
             patch("app.api.auth_routes.enqueue_verification_email") as mock_enqueue,
         ):
-            resp = resend_verification(current_user={"user_id": user.id}, db=object())
+            resp = resend_verification(ResendVerificationRequest(email=user.email), db=object())
         assert resp.sent is True
         mock_set_token.assert_called_once()
         mock_enqueue.assert_called_once_with(user.email, "raw-token", user.first_name)
 
-    def test_already_verified_account_is_a_noop(self):
+    def test_already_verified_account_returns_the_same_generic_response(self):
         user = UserModelFactory.build(email_verified=True)
         with (
-            patch("app.api.auth_routes.get_user", return_value=user),
+            patch("app.api.auth_routes.is_locked_out", return_value=False),
+            patch("app.api.auth_routes.record_failed_attempt"),
+            patch("app.api.auth_routes.get_user_by_email", return_value=user),
             patch("app.api.auth_routes.set_email_verification_token") as mock_set_token,
             patch("app.api.auth_routes.enqueue_verification_email") as mock_enqueue,
         ):
-            resp = resend_verification(current_user={"user_id": user.id}, db=object())
-        assert resp.sent is False
+            resp = resend_verification(ResendVerificationRequest(email=user.email), db=object())
+        assert resp.sent is True
         mock_set_token.assert_not_called()
         mock_enqueue.assert_not_called()
+
+    def test_nonexistent_email_returns_the_same_generic_response(self):
+        with (
+            patch("app.api.auth_routes.is_locked_out", return_value=False),
+            patch("app.api.auth_routes.record_failed_attempt"),
+            patch("app.api.auth_routes.get_user_by_email", return_value=None),
+            patch("app.api.auth_routes.set_email_verification_token") as mock_set_token,
+            patch("app.api.auth_routes.enqueue_verification_email") as mock_enqueue,
+        ):
+            resp = resend_verification(
+                ResendVerificationRequest(email="nobody@example.com"), db=object()
+            )
+        assert resp.sent is True
+        assert resp.debug_token is None
+        mock_set_token.assert_not_called()
+        mock_enqueue.assert_not_called()
+
+    def test_repeated_requests_past_the_threshold_are_rate_limited(self):
+        with (
+            patch("app.api.auth_routes.is_locked_out", return_value=True),
+            patch("app.api.auth_routes.get_user_by_email") as mock_get_user,
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                resend_verification(
+                    ResendVerificationRequest(email="a@b.com"), db=object()
+                )
+        assert exc_info.value.status_code == 429
+        mock_get_user.assert_not_called()
 
     def test_debug_token_included_when_flag_enabled(self):
         """EXPOSE_VERIFICATION_TOKEN_FOR_TESTS lets e2e drive the real
@@ -406,25 +454,29 @@ class TestResendVerification:
         services/users/.env.users.local, never in prod."""
         user = UserModelFactory.build(email_verified=False)
         with (
-            patch("app.api.auth_routes.get_user", return_value=user),
+            patch("app.api.auth_routes.is_locked_out", return_value=False),
+            patch("app.api.auth_routes.record_failed_attempt"),
+            patch("app.api.auth_routes.get_user_by_email", return_value=user),
             patch(
                 "app.api.auth_routes.set_email_verification_token", return_value="raw-token"
             ),
             patch("app.api.auth_routes.enqueue_verification_email"),
             patch("app.api.auth_routes.settings.EXPOSE_VERIFICATION_TOKEN_FOR_TESTS", True),
         ):
-            resp = resend_verification(current_user={"user_id": user.id}, db=object())
+            resp = resend_verification(ResendVerificationRequest(email=user.email), db=object())
         assert resp.debug_token == "raw-token"
 
     def test_debug_token_absent_when_flag_disabled(self):
         user = UserModelFactory.build(email_verified=False)
         with (
-            patch("app.api.auth_routes.get_user", return_value=user),
+            patch("app.api.auth_routes.is_locked_out", return_value=False),
+            patch("app.api.auth_routes.record_failed_attempt"),
+            patch("app.api.auth_routes.get_user_by_email", return_value=user),
             patch(
                 "app.api.auth_routes.set_email_verification_token", return_value="raw-token"
             ),
             patch("app.api.auth_routes.enqueue_verification_email"),
             patch("app.api.auth_routes.settings.EXPOSE_VERIFICATION_TOKEN_FOR_TESTS", False),
         ):
-            resp = resend_verification(current_user={"user_id": user.id}, db=object())
+            resp = resend_verification(ResendVerificationRequest(email=user.email), db=object())
         assert resp.debug_token is None

--- a/services/users/tests/test_customer_routes.py
+++ b/services/users/tests/test_customer_routes.py
@@ -17,8 +17,13 @@ class TestListCustomers:
         client = make_client(db=db)
         app = client.app
         from app.utils.security import get_current_user
+        from shared.security.dependencies import get_validated_user
 
+        # get_validated_user's real implementation still delegates to
+        # get_current_user for the actual decode, so both overrides need to
+        # come off to exercise the unauthenticated path.
         del app.dependency_overrides[get_current_user]
+        del app.dependency_overrides[get_validated_user]
 
         response = client.get("/api/customers/")
 
@@ -66,8 +71,13 @@ class TestCreateCustomer:
         client = make_client(db=db)
         app = client.app
         from app.utils.security import get_current_user
+        from shared.security.dependencies import get_validated_user
 
+        # get_validated_user's real implementation still delegates to
+        # get_current_user for the actual decode, so both overrides need to
+        # come off to exercise the unauthenticated path.
         del app.dependency_overrides[get_current_user]
+        del app.dependency_overrides[get_validated_user]
 
         response = client.post(
             "/api/customers/",

--- a/services/users/tests/test_email_verified_gate.py
+++ b/services/users/tests/test_email_verified_gate.py
@@ -1,0 +1,39 @@
+"""session-security: an unverified token is rejected with 403 end-to-end,
+via a real TestClient/JWT (no `get_validated_user` override)."""
+
+from uuid import uuid4
+
+from fastapi.testclient import TestClient
+
+from main import app
+from shared.security.jwt_utils import create_access_token
+
+
+def _token(email_verified: bool) -> str:
+    return create_access_token(
+        {
+            "user_id": str(uuid4()),
+            "session_id": str(uuid4()),
+            "role": "user",
+            "email_verified": email_verified,
+        }
+    )
+
+
+class TestSessionsEndpointRequiresVerifiedEmail:
+    def test_unverified_token_rejected_with_403(self):
+        client = TestClient(app)
+        resp = client.get(
+            "/api/auth/sessions",
+            headers={"Authorization": f"Bearer {_token(email_verified=False)}"},
+        )
+        assert resp.status_code == 403
+        assert resp.json()["detail"] == "email_not_verified"
+
+    def test_verified_token_is_not_blocked_by_the_verification_gate(self):
+        client = TestClient(app)
+        resp = client.get(
+            "/api/auth/sessions",
+            headers={"Authorization": f"Bearer {_token(email_verified=True)}"},
+        )
+        assert resp.status_code != 403

--- a/services/users/tests/test_email_verified_gate.py
+++ b/services/users/tests/test_email_verified_gate.py
@@ -3,9 +3,16 @@ via a real TestClient/JWT (no `get_validated_user` override)."""
 
 from uuid import uuid4
 
+import pytest
 from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
 
 from main import app
+from app.api.auth_routes import get_db
+from app.models.base import Base
+from app.models.session import SessionModel
 from shared.security.jwt_utils import create_access_token
 
 
@@ -20,6 +27,23 @@ def _token(email_verified: bool) -> str:
     )
 
 
+@pytest.fixture
+def sessions_db():
+    # auth_routes.py declares its own module-local get_db (see
+    # project_user_routes_duplicate_get_db in memory for the sibling case in
+    # user_routes.py) — this fixture exists only so
+    # test_verified_token_is_not_blocked_by_the_verification_gate doesn't
+    # need a real Postgres reachable at settings.users_database_url, which
+    # varies with $ENV and isn't resolvable outside docker-compose.local.yml.
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine, tables=[SessionModel.__table__])
+    return sessionmaker(bind=engine)()
+
+
 class TestSessionsEndpointRequiresVerifiedEmail:
     def test_unverified_token_rejected_with_403(self):
         client = TestClient(app)
@@ -30,10 +54,18 @@ class TestSessionsEndpointRequiresVerifiedEmail:
         assert resp.status_code == 403
         assert resp.json()["detail"] == "email_not_verified"
 
-    def test_verified_token_is_not_blocked_by_the_verification_gate(self):
-        client = TestClient(app)
-        resp = client.get(
-            "/api/auth/sessions",
-            headers={"Authorization": f"Bearer {_token(email_verified=True)}"},
-        )
+    def test_verified_token_is_not_blocked_by_the_verification_gate(self, sessions_db):
+        # get_current_user/get_validated_user are deliberately left
+        # unmocked (see module docstring) so the gate itself runs for real;
+        # only get_db is overridden, so this stays a real end-to-end check
+        # of the verification gate without needing a live database.
+        app.dependency_overrides[get_db] = lambda: sessions_db
+        try:
+            client = TestClient(app)
+            resp = client.get(
+                "/api/auth/sessions",
+                headers={"Authorization": f"Bearer {_token(email_verified=True)}"},
+            )
+        finally:
+            del app.dependency_overrides[get_db]
         assert resp.status_code != 403

--- a/shared/schemas/auth_schema.py
+++ b/shared/schemas/auth_schema.py
@@ -71,14 +71,10 @@ class VerifyEmailRequest(BaseModel):
     token: str
 
 
-class VerifyEmailResponse(BaseModel):
-    email_verified: bool
+class VerifyEmailResponse(TokenResponse):
     # Verification is now the first point identity is confirmed, so it
     # issues the account's first session — same shape as TokenResponse.
-    access_token: str
-    token_type: str = "bearer"
-    refresh_token: str
-    status: str
+    email_verified: bool
 
 
 class ResendVerificationRequest(BaseModel):

--- a/shared/schemas/auth_schema.py
+++ b/shared/schemas/auth_schema.py
@@ -49,6 +49,11 @@ class TokenResponse(BaseModel):
     status: str
 
 
+class RegisterResponse(BaseModel):
+    message: str
+    email: EmailStr
+
+
 class ImpersonateRequest(BaseModel):
     customer_id: UUID
 
@@ -68,6 +73,16 @@ class VerifyEmailRequest(BaseModel):
 
 class VerifyEmailResponse(BaseModel):
     email_verified: bool
+    # Verification is now the first point identity is confirmed, so it
+    # issues the account's first session — same shape as TokenResponse.
+    access_token: str
+    token_type: str = "bearer"
+    refresh_token: str
+    status: str
+
+
+class ResendVerificationRequest(BaseModel):
+    email: EmailStr
 
 
 class ResendVerificationResponse(BaseModel):

--- a/shared/security/dependencies.py
+++ b/shared/security/dependencies.py
@@ -73,6 +73,12 @@ def get_validated_user(
     """
     payload = dict(user["payload"])
     payload["token"] = user["token"]
+    # Defense-in-depth; 403 (not 401) so clients know to verify, not re-login.
+    if not payload.get("email_verified"):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="email_not_verified",
+        )
     set_span_attributes(user_id=payload.get("user_id"))
     if payload.get("is_impersonating"):
         log_privileged_access(payload, request)

--- a/shared/tests/test_dependencies.py
+++ b/shared/tests/test_dependencies.py
@@ -17,6 +17,7 @@ def _impersonation_token(user_id: str, customer_id: str, session_id: str) -> str
             "session_id": session_id,
             "role": "admin",
             "is_impersonating": True,
+            "email_verified": True,
         }
     )
 
@@ -28,8 +29,15 @@ def fake_redis(monkeypatch):
     return fake
 
 
-def _token_for(user_id: str, session_id: str) -> str:
-    return create_access_token({"user_id": user_id, "session_id": session_id, "role": "user"})
+def _token_for(user_id: str, session_id: str, email_verified: bool = True) -> str:
+    return create_access_token(
+        {
+            "user_id": user_id,
+            "session_id": session_id,
+            "role": "user",
+            "email_verified": email_verified,
+        }
+    )
 
 
 class TestGetCurrentUserRevocation:
@@ -68,6 +76,30 @@ class TestGetCurrentUserRevocation:
         # Session d is untouched.
         result = get_current_user(token=token_b)
         assert result["session_id"] == "session-d"
+
+
+class TestGetValidatedUserRequiresVerifiedEmail:
+    """Rejects an unverified token with 403, distinct from get_current_user's 401s."""
+
+    def test_unverified_token_rejected_with_403(self):
+        user_id = "99999999-9999-9999-9999-999999999999"
+        current_user = get_current_user(
+            token=_token_for(user_id, "session-i", email_verified=False)
+        )
+
+        with pytest.raises(HTTPException) as exc_info:
+            get_validated_user(user=current_user)
+        assert exc_info.value.status_code == 403
+        assert exc_info.value.detail == "email_not_verified"
+
+    def test_verified_token_behaves_as_before(self):
+        user_id = "10101010-1010-1010-1010-101010101010"
+        current_user = get_current_user(
+            token=_token_for(user_id, "session-j", email_verified=True)
+        )
+
+        payload = get_validated_user(user=current_user)
+        assert payload["user_id"] == user_id
 
 
 class TestGetValidatedUserSpanAttribute:

--- a/shared/tests/test_dependencies.py
+++ b/shared/tests/test_dependencies.py
@@ -94,9 +94,7 @@ class TestGetValidatedUserRequiresVerifiedEmail:
 
     def test_verified_token_behaves_as_before(self):
         user_id = "10101010-1010-1010-1010-101010101010"
-        current_user = get_current_user(
-            token=_token_for(user_id, "session-j", email_verified=True)
-        )
+        current_user = get_current_user(token=_token_for(user_id, "session-j", email_verified=True))
 
         payload = get_validated_user(user=current_user)
         assert payload["user_id"] == user_id


### PR DESCRIPTION
## Summary
- Registration no longer issues a session; verifying the email becomes the account's first login (previously unverified accounts could reach the app immediately after registering).
- Login now rejects unverified accounts with `403 email_not_verified` instead of issuing a session; resend-verification is anonymous, rate-limited, and enumeration-safe.
- `get_validated_user` (shared across users/budget/ai) now rejects any token whose `email_verified` claim isn't true, closing the loophole server-side even if a client bypasses the UI. Includes a one-time rollout script to revoke sessions already held by unverified users.

## Test plan
- [x] users, budget, ai, shared test suites pass; flake8 clean at `--max-line-length=100`
- [x] frontend test suite passes (254/254); `tsc --noEmit` clean
- [x] new integration tests confirm the 403 gate end-to-end on a representative endpoint in each of users/budget/ai
- [ ] manual verification of the two known-affected accounts, blocked on a separate Mailjet outage (tracked, not in scope here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)